### PR TITLE
Ready for version 0.10.3

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,61 +5,28 @@ orbs:
 
 
 executors:
-    gcc_14:
+    gcc_latest:
         docker:
             - image: gcc:14
-    gcc_13:
+    gcc_prev_latest:
         docker:
             - image: gcc:13
-    gcc_12:
-        docker:
-            - image: gcc:12
-    gcc_11:
-        docker:
-            - image: gcc:11
-    gcc_10:
-        docker:
-            - image: gcc:10
-    gcc_9:
-        docker:
-            - image: gcc:9
-    gcc_8:
+    gcc_earliest:
         docker:
             - image: gcc:8
-    clang18:
+    clang_latest:
         docker:
-            - image: silkeh/clang:18
-    clang17:
+            - image: silkeh/clang:20
+    clang_prev_latest:
         docker:
-            - image: silkeh/clang:17
-    clang16:
-        docker:
-            - image: silkeh/clang:16
-    clang15:
-        docker:
-            - image: silkeh/clang:15
-    clang14:
-        docker:
-            - image: silkeh/clang:14
-    clang13:
-        docker:
-            - image: silkeh/clang:13
-    clang12:
-        docker:
-            - image: silkeh/clang:12
-    clang11:
+            - image: silkeh/clang:19
+    clang_earliest:
         docker:
             - image: silkeh/clang:11
-    clang10:
-        docker:
-            - image: silkeh/clang:10
-    clang9:
-        docker:
-            - image: silkeh/clang:9  # no c++ 11, does not work
 
 jobs:
     test_legacy_grid2op:
-        executor: gcc_14
+        executor: gcc_latest
         resource_class: small
         steps:
             - checkout
@@ -220,8 +187,8 @@ jobs:
                       pip install grid2op==1.9.1
                       python -m unittest lightsim2grid/tests/test_compat_legacy_grid2op.py
 
-    compile_gcc13:
-        executor: gcc_13
+    compile_gcc_prev_latest:
+        executor: gcc_prev_latest
         resource_class: small
         steps:
             - checkout
@@ -239,83 +206,8 @@ jobs:
                       CC=gcc python setup.py build
                       python -m pip install -U .
 
-    compile_gcc12:
-        executor: gcc_12
-        resource_class: small
-        steps:
-            - checkout
-            - run: apt-get update && apt-get install python3-full python3-dev python3-pip python3-virtualenv git -y
-            - run: python3 -m virtualenv venv_test
-            - run:
-                  command: |
-                      source venv_test/bin/activate
-                      pip install --upgrade pip setuptools wheel
-                      pip install -U grid2op
-                      pip install -U pybind11
-                      git submodule init
-                      git submodule update
-                      make
-                      CC=gcc python setup.py build
-                      python -m pip install -U .
-    compile_gcc11:
-        executor: gcc_11
-        resource_class: small
-        steps:
-            - checkout
-            - run: apt-get update && apt-get install python3-pip python3-full -y
-            - run: python3 -m pip install virtualenv
-            - run: python3 -m virtualenv venv_test
-            - run:
-                  command: |
-                      source venv_test/bin/activate
-                      pip install --upgrade pip setuptools wheel
-                      pip install -U grid2op
-                      pip install -U pybind11
-                      git submodule init
-                      git submodule update
-                      make
-                      CC=gcc python setup.py build
-                      python -m pip install -U .
-    compile_gcc10:
-        executor: gcc_10
-        resource_class: small
-        steps:
-            - checkout
-            - run: apt-get update && apt-get install python3-pip python3-full -y
-            - run: python3 -m pip install virtualenv
-            - run: python3 -m virtualenv venv_test
-            - run:
-                  command: |
-                      source venv_test/bin/activate
-                      pip install --upgrade pip setuptools wheel
-                      pip install -U grid2op
-                      pip install -U pybind11
-                      git submodule init
-                      git submodule update
-                      make
-                      CC=gcc python setup.py build
-                      python -m pip install -U .
-    compile_gcc9:
-        executor: gcc_9
-        resource_class: small
-        steps:
-            - checkout
-            - run: apt-get update && apt-get install python3-pip python3-full -y
-            - run: python3 -m pip install virtualenv
-            - run: python3 -m virtualenv venv_test
-            - run:
-                  command: |
-                      source venv_test/bin/activate
-                      pip install --upgrade pip setuptools wheel
-                      pip install -U grid2op
-                      pip install -U pybind11
-                      git submodule init
-                      git submodule update
-                      make
-                      CC=gcc python setup.py build
-                      python -m pip install -U .
-    compile_gcc8:
-        executor: gcc_8
+    compile_gcc_earliest:
+        executor: gcc_earliest
         resource_class: small
         steps:
             - checkout
@@ -333,8 +225,8 @@ jobs:
                     make
                     CC=gcc python setup.py build
                     python -m pip install -U .
-    compile_and_test_gcc14:
-        executor: gcc_14
+    compile_and_test_gcc_latest:
+        executor: gcc_latest
         resource_class: medium
         steps:
             - checkout
@@ -380,46 +272,9 @@ jobs:
                     source venv_test/bin/activate
                     cd lightsim2grid/tests/
                     python -m unittest discover  -v
-    compile_clang9:  # no c++ 11, will not work
-        executor: clang9
-        resource_class: small
-        steps:
-            - checkout
-            - run: apt-get update && apt-get install python3-pip python3-full git -y
-            - run: python3 -m pip install virtualenv
-            - run: python3 -m virtualenv venv_test
-            - run:
-                command: |
-                    source venv_test/bin/activate
-                    pip install --upgrade pip setuptools wheel
-                    pip install -U pybind11
-                    git submodule init
-                    git submodule update
-                    make
-                    CC=clang python setup.py build
-                    CC=clang python -m pip install -U .
-    compile_clang10:
-        executor: clang10
-        resource_class: small
-        steps:
-            - checkout
-            - run: apt-get update && apt-get install python3-pip python3-full git -y
-            - run: 
-                command: |
-                    git submodule init
-                    git submodule update
-                    make
-            - run: python3 -m pip install virtualenv
-            - run: python3 -m virtualenv venv_test
-            - run:
-                command: |
-                    source venv_test/bin/activate
-                    pip install --upgrade pip setuptools wheel
-                    pip install -U pybind11
-                    CC=clang python setup.py build
-                    CC=clang python -m pip install .
-    compile_clang11:
-        executor: clang11
+
+    compile_clang_earliest:
+        executor: clang_earliest
         resource_class: small
         steps:
             - checkout
@@ -437,84 +292,9 @@ jobs:
                     make
                     CC=clang python setup.py build
                     CC=clang python -m pip install -U .
-    compile_clang12:
-        executor: clang12
-        resource_class: small
-        steps:
-            - checkout
-            - run: apt-get update && apt-get install python3-pip python3-full git -y
-            - run: python3 -m pip install virtualenv
-            - run: python3 -m virtualenv venv_test
-            - run:
-                command: |
-                    source venv_test/bin/activate
-                    pip install --upgrade pip setuptools wheel
-                    pip install -U grid2op
-                    pip install -U pybind11
-                    git submodule init
-                    git submodule update
-                    make
-                    CC=clang python setup.py build
-                    CC=clang python -m pip install -U .
-    compile_clang13:
-        executor: clang13
-        resource_class: small
-        steps:
-            - checkout
-            - run: apt-get update && apt-get install python3-pip python3-full git -y
-            - run: python3 -m pip install virtualenv
-            - run: python3 -m virtualenv venv_test
-            - run:
-                command: |
-                    source venv_test/bin/activate
-                    pip install --upgrade pip setuptools wheel
-                    pip install -U grid2op
-                    pip install -U pybind11
-                    git submodule init
-                    git submodule update
-                    make
-                    CC=clang python setup.py build
-                    CC=clang python -m pip install -U . 
-    compile_clang14:
-        executor: clang14
-        resource_class: small
-        steps:
-            - checkout
-            - run: apt-get update && apt-get install python3-pip python3-full git -y
-            - run: python3 -m pip install virtualenv
-            - run: python3 -m virtualenv venv_test
-            - run:
-                command: |
-                    source venv_test/bin/activate
-                    pip install --upgrade pip setuptools wheel
-                    pip install -U grid2op
-                    pip install -U pybind11
-                    git submodule init
-                    git submodule update
-                    make
-                    CC=clang python setup.py build
-                    CC=clang python -m pip install -U .
-    compile_clang15:
-        executor: clang15
-        resource_class: small
-        steps:
-            - checkout
-            - run: apt-get update && apt-get install python3-pip python3-full git -y
-            - run: python3 -m pip install virtualenv
-            - run: python3 -m virtualenv venv_test
-            - run:
-                command: |
-                    source venv_test/bin/activate
-                    pip install --upgrade pip setuptools wheel
-                    pip install -U grid2op
-                    pip install -U pybind11
-                    git submodule init
-                    git submodule update
-                    make
-                    CC=clang python setup.py build
-                    CC=clang python -m pip install -U .
-    compile_clang16:
-        executor: clang16
+
+    compile_clang_prev_latest:
+        executor: clang_prev_latest
         resource_class: small
         steps:
             - checkout
@@ -531,26 +311,9 @@ jobs:
                     make
                     CC=clang python setup.py build
                     CC=clang python -m pip install -U .
-    compile_clang17:
-        executor: clang16
-        resource_class: small
-        steps:
-            - checkout
-            - run: apt-get update && apt-get install python3-full python3-dev python3-pip python3-virtualenv git -y
-            - run: python3 -m virtualenv venv_test
-            - run:
-                command: |
-                    source venv_test/bin/activate
-                    pip install --upgrade pip setuptools wheel
-                    pip install -U grid2op
-                    pip install -U pybind11
-                    git submodule init
-                    git submodule update
-                    make
-                    CC=clang python setup.py build
-                    CC=clang python -m pip install -U .
-    compile_and_test_clang18:
-        executor: clang18
+
+    compile_and_test_clang_latest:
+        executor: clang_latest
         resource_class: medium
         steps:
             - checkout
@@ -641,19 +404,11 @@ workflows:
     version: 2.1
     compile:
         jobs:
-          - compile_gcc8  # re add
-        #   - compile_gcc10
-        #   - compile_gcc11
-        #   - compile_gcc12
-          - compile_gcc13 # re add
-          # - compile_clang10  # does not work I don't know why, too lazy to check
-          - compile_clang11  # re add
-        #   - compile_clang13
-        #   - compile_clang14
-        #   - compile_clang15
-        #   - compile_clang16
-          - compile_clang17  # re add
+          - compile_gcc_earliest
+          - compile_gcc_prev_latest
+          - compile_clang_earliest
+          - compile_clang_prev_latest
           - test_legacy_grid2op
-          - compile_and_test_windows # re add
-          - compile_and_test_clang18 # re add
-          - compile_and_test_gcc14 # re add
+          - compile_and_test_windows
+          - compile_and_test_clang_latest
+          - compile_and_test_gcc_latest

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -34,6 +34,9 @@ TODO: integration test with pandapower (see `pandapower/contingency/contingency.
 - [FIXED] remove deprecated use of numpy<2 function in LightSimBackend
 - [FIXED] the "copy.deepcopy" of a lightsim2grid backend does not crash anymore 
   (see issues #36 and #97)
+- [FIXED] an issue that could lead to a "segfault" if the "runpf" method of
+  `LightSimBackend` was called first with is_dc=True and then with is_dc=False
+- [IMPROVED] compat with grid2op 1.11.0
 
 [0.10.2] 2025-03-07
 ----------------------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -37,6 +37,7 @@ TODO: integration test with pandapower (see `pandapower/contingency/contingency.
 - [FIXED] an issue that could lead to a "segfault" if the "runpf" method of
   `LightSimBackend` was called first with is_dc=True and then with is_dc=False
 - [IMPROVED] compat with grid2op 1.11.0
+- [IMPROVED] now test proper compilation on clang 20 (was limited to clang 18 before)
 
 [0.10.2] 2025-03-07
 ----------------------

--- a/lightsim2grid/tests/test_issue_101.py
+++ b/lightsim2grid/tests/test_issue_101.py
@@ -29,10 +29,14 @@ class Issue101Tester(unittest.TestCase):
         with warnings.catch_warnings():
             warnings.filterwarnings("ignore")
             self.env = grid2op.make("educ_case14_storage", 
-                                     test=True,
-                                     allow_detachment=True,
-                                     backend=LightSimBackend(),
-                                     action_class=CompleteAction)
+                                    test=True,
+                                    allow_detachment=True,
+                                    backend=LightSimBackend(),
+                                    action_class=CompleteAction)
+        params = self.env.parameters
+        params.ENV_DOES_REDISPATCHING = False
+        self.env.change_parameters(params)
+        self.env.change_forecast_parameters(params)
         self.env.reset(seed=0, options={"time serie id": 0})
         obs = self.env.reset()
         return super().setUp()
@@ -49,7 +53,7 @@ class Issue101Tester(unittest.TestCase):
                 "set_bus": {"generators_id": [(gen_id, -1)]}
             }
         ))
-        assert not done
+        assert not done, info["exception"]
         assert obs.gen_detached[gen_id]
         assert np.abs(obs.gen_p[gen_id]) <= tol
         assert np.abs(obs.gen_v[gen_id]) <= tol
@@ -58,7 +62,7 @@ class Issue101Tester(unittest.TestCase):
         assert abs(obs.gen_p_detached[gen_id] - 79.8) <= tol
         
         obs1, _, done, info = self.env.step(self.env.action_space({}))
-        assert not done
+        assert not done, info["exception"]
         assert obs1.gen_detached[gen_id]
         assert np.abs(obs1.gen_p[gen_id]) <= tol
         assert np.abs(obs1.gen_v[gen_id]) <= tol
@@ -67,7 +71,7 @@ class Issue101Tester(unittest.TestCase):
         assert abs(obs1.gen_p_detached[gen_id] - 80.5) <= tol
         
         obs2, _, done, info = self.env.step(self.env.action_space({}))
-        assert not done
+        assert not done, info["exception"]
         assert obs2.gen_detached[gen_id]
         assert np.abs(obs2.gen_p[gen_id]) <= tol
         assert np.abs(obs2.gen_v[gen_id]) <= tol
@@ -83,7 +87,7 @@ class Issue101Tester(unittest.TestCase):
                 "set_bus": {"loads_id": [(load_id, -1)]}
             }
         ))
-        assert not done
+        assert not done, info["exception"]
         assert obs.load_detached[load_id]
         assert np.abs(obs.load_p[load_id]) <= tol
         assert np.abs(obs.load_q[load_id]) <= tol
@@ -91,7 +95,7 @@ class Issue101Tester(unittest.TestCase):
         assert abs(obs.load_p_detached[load_id] - 21.9) <= tol
         
         obs1, _, done, info = self.env.step(self.env.action_space({}))
-        assert not done
+        assert not done, info["exception"]
         assert obs1.load_detached[load_id]
         assert np.abs(obs1.load_p[load_id]) <= tol
         assert np.abs(obs1.load_q[load_id]) <= tol
@@ -99,7 +103,7 @@ class Issue101Tester(unittest.TestCase):
         assert abs(obs1.load_p_detached[load_id] - 21.7) <= tol
         
         obs2, _, done, info = self.env.step(self.env.action_space({}))
-        assert not done
+        assert not done, info["exception"]
         assert obs2.load_detached[load_id]
         assert np.abs(obs2.load_p[load_id]) <= tol
         assert np.abs(obs2.load_q[load_id]) <= tol
@@ -115,18 +119,18 @@ class Issue101Tester(unittest.TestCase):
                 "set_storage": [(0, 1.)]
             }
         ))
-        assert not done
+        assert not done, info["exception"]
         assert obs.storage_detached[sto_id]
         assert np.abs(obs.storage_power[sto_id]) <= tol, f"{obs.storage_power[sto_id]} vs 0."
         assert abs(obs.storage_p_detached[sto_id] - 1.) <= tol, f"{obs.storage_p_detached[sto_id]} vs 1."
         
         obs1, _, done, info = self.env.step(self.env.action_space({}))
-        assert not done
+        assert not done, info["exception"]
         assert obs1.storage_detached[sto_id]
         assert abs(obs1.storage_power[sto_id]) <= tol, f"{obs1.storage_power[sto_id]} vs 0."
         
         obs2, _, done, info = self.env.step(self.env.action_space({}))
-        assert not done
+        assert not done, info["exception"]
         assert obs2.storage_detached[sto_id]
         assert abs(obs2.storage_power[sto_id]) <= tol, f"{obs2.storage_power[sto_id]} vs 0."
         

--- a/src/GridModel.cpp
+++ b/src/GridModel.cpp
@@ -377,6 +377,12 @@ CplxVect GridModel::ac_pf(const CplxVect & Vinit,
     // pre process the data to define a proper jacobian matrix, the proper voltage vector etc.
     bool is_ac = true;
     // std::cout << "before pre process" << std::endl;
+    // std::cout << "acSbus_.size()" << acSbus_.size() << std::endl;
+    // std::cout << "Ybus_ac_.size()" << Ybus_ac_.size() << std::endl;
+    // std::cout << "id_me_to_ac_solver_.size()" << id_me_to_ac_solver_.size() << std::endl;
+    // std::cout << "id_ac_solver_to_me_.size()" << id_ac_solver_to_me_.size() << std::endl;
+    // std::cout << "slack_bus_id_ac_me_.size()" << slack_bus_id_ac_me_.size() << std::endl;
+    // std::cout << "slack_bus_id_ac_solver_.size()" << slack_bus_id_ac_solver_.size() << std::endl;
     CplxVect V = pre_process_solver(Vinit, 
                                     acSbus_,
                                     Ybus_ac_,
@@ -386,6 +392,7 @@ CplxVect GridModel::ac_pf(const CplxVect & Vinit,
                                     slack_bus_id_ac_solver_,
                                     is_ac,
                                     solver_control_);
+    // std::cout << "after pre process" << std::endl;
 
     // start the solver
     if(solver_control_.need_reset_solver() || 
@@ -399,6 +406,7 @@ CplxVect GridModel::ac_pf(const CplxVect & Vinit,
     conv = _solver.compute_pf(Ybus_ac_, V, acSbus_, slack_bus_id_ac_solver_, slack_weights_, bus_pv_, bus_pq_, max_iter, tol / sn_mva_);
 
     // store results (in ac mode) 
+    // std::cout << "\tbefore process_results" << std::endl;
     process_results(conv, res, Vinit, true, id_me_to_ac_solver_);
 
     timer_last_ac_pf_ = timer.duration();


### PR DESCRIPTION
WIth changelog

- [FIXED] remove deprecated use of numpy<2 function in LightSimBackend
- [FIXED] the "copy.deepcopy" of a lightsim2grid backend does not crash anymore 
  (see issues #36 and #97)
- [FIXED] an issue that could lead to a "segfault" if the "runpf" method of
  `LightSimBackend` was called first with is_dc=True and then with is_dc=False
- [IMPROVED] compat with grid2op 1.11.0
- [IMPROVED] now test proper compilation on clang 20 (was limited to clang 18 before)