### PR TITLE
Add power-grid-model to DISCLAIMER.md

### DIFF
--- a/DISCLAIMER.md
+++ b/DISCLAIMER.md
@@ -37,6 +37,8 @@ Open source options for powerflow analysis
 To get free of these limitations and be able to perform state of the art powerflow analysis, 
 while still using open source softwares, we kindly recommend you to have a look at:
 
+- [power-grid-model](https://github.com/PowerGridModel/power-grid-model) which is an "*open-source library for
+  steady-state distribution power system analysis, distributed for Python and C*"
 - [Matpower](https://matpower.org/) which is a "*free, open-source tools for electric power system simulation and 
   optimization*"
 - [Pandapower](https://www.pandapower.org/) that is "*An easy to use open source tool for power system modeling, 


### PR DESCRIPTION
LightSim2Grid, while a very useful calculation backend, has some known limitations as mentioned in the Disclaimer.md. Some alternatives are also mentioned there. However, those currently listed alternatives are either optimized for transmission grids (Dynaωo and PowSyBl; see also https://landscape.lfenergy.org/) and/or not part of LF Energy (Matpower, Pandapower, PowerModels, GridPack, Rustpower).

Because LightSim2Grid is now part of LF Energy, I think it would be a good idea to also promote particularly the alternatives included in LF Energy, such as [power-grid-model](https://github.com/PowerGridModel/power-grid-model). Hereby a proposal for its inclusion into the list of alternatives.