### PR TITLE
Fix out-of-bounds memory access from Python bindings + RAII for linear-solver memory

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -115,6 +115,22 @@ TODO: integration test with pandapower (see `pandapower/contingency/contingency.
   built its working matrix from the grid model's own (never populated, hence empty) Ybus,
   causing out-of-bounds writes. It now uses the correctly indexed internal `Ybus_` and builds
   the required inputs on demand, so it works both before and after `compute()`.
+- [FIXED] several Python-exposed methods could read or write out of bounds (potential
+  segfault / memory corruption) when given an out-of-range or negative element id or a
+  mis-shaped array, because the id / array reached unchecked ``operator[]`` /
+  Eigen ``operator()`` / ``.col()`` (whose bounds asserts are compiled out in release
+  builds) with no prior validation. Out-of-range ids now raise ``IndexError`` and
+  mis-shaped arrays raise ``RuntimeError``, instead of corrupting memory. Affected:
+  ``deactivate_* / reactivate_* / change_bus_*`` (loads, gens, sgens, storages, shunts,
+  powerlines, trafos, dclines — the bounds check ran *after* the access),
+  ``update_slack_weights_by_id`` and ``set_gen_regulated_bus`` (out-of-bounds writes, the
+  latter also stored an unvalidated bus id), ``change_ratio_trafo`` /
+  ``change_shift_trafo`` / ``change_shift_trafo_deg`` (out-of-bounds writes),
+  ``get_status_droop_hvdc``, the grid2op fast-update path
+  (``update_gens_p`` / ``update_loads_p`` / ... when ``new_values`` is shorter than
+  ``has_changed``), ``set_*_pos_topo_vect`` / ``set_*_to_subid``, and
+  ``TimeSeriesCPP.compute_Vs`` (injection-matrix column / row counts are now validated
+  against the grid element counts).
 - [FIXED] pickling (or `save_binary`/`load_binary`) an `LSGrid` whose `_ls_to_orig`
   bus-mapping was set (which `init_from_pypowsybl` and `init_from_pandapower` both do)
   always raised ``"Impossible to set the converter ls_to_orig: the provided vector has
@@ -195,6 +211,12 @@ TODO: integration test with pandapower (see `pandapower/contingency/contingency.
   vs ``size_t``) and silenced ~188 intentionally-unused parameters on interface /
   default-virtual-method signatures (kept as ``/*name*/`` comments for documentation,
   matching the convention already used elsewhere in the codebase).
+- [IMPROVED] (cpp) the ``CKTSOLinearSolver`` and ``NICSLULinearSolver`` linear solvers now
+  hold their CSC index buffers (``ai_`` / ``ap_``) in ``std::unique_ptr<T[]>`` allocated with
+  ``std::make_unique`` instead of raw ``new[]`` / ``delete[]``. The lifetime is unchanged
+  (the buffers are still released on ``reset()`` and destruction), but ownership is now
+  RAII-managed, which also removes a latent leak if ``analyze()`` were called twice without
+  an intervening ``reset()``.
 - [ADDED] `lightsim2grid.network.bake_outer_loops`: rewrites a pypowsybl network's
   input setpoints to the converged PowSyBl OpenLoadFlow (OLF) outer-loop state (tap /
   shunt positions, reactive-limit PV->PQ switches, distributed-slack active power) so

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -211,12 +211,15 @@ TODO: integration test with pandapower (see `pandapower/contingency/contingency.
   vs ``size_t``) and silenced ~188 intentionally-unused parameters on interface /
   default-virtual-method signatures (kept as ``/*name*/`` comments for documentation,
   matching the convention already used elsewhere in the codebase).
-- [IMPROVED] (cpp) the ``CKTSOLinearSolver`` and ``NICSLULinearSolver`` linear solvers now
-  hold their CSC index buffers (``ai_`` / ``ap_``) in ``std::unique_ptr<T[]>`` allocated with
-  ``std::make_unique`` instead of raw ``new[]`` / ``delete[]``. The lifetime is unchanged
-  (the buffers are still released on ``reset()`` and destruction), but ownership is now
-  RAII-managed, which also removes a latent leak if ``analyze()`` were called twice without
-  an intervening ``reset()``.
+- [IMPROVED] (cpp) the built-in linear solvers now manage their solver memory with RAII
+  smart pointers instead of manual allocation. ``CKTSOLinearSolver`` and
+  ``NICSLULinearSolver`` hold their CSC index buffers (``ai_`` / ``ap_``) in
+  ``std::unique_ptr<T[]>`` allocated with ``std::make_unique`` (was raw ``new[]`` /
+  ``delete[]``); ``KLULinearSolver`` holds its ``klu_symbolic`` / ``klu_numeric`` handles in
+  ``std::unique_ptr`` with custom deleters that call ``klu_free_symbolic`` /
+  ``klu_free_numeric`` (was manual frees in the destructor and ``reset()``). Lifetimes are
+  unchanged, but ownership is now RAII-managed, which also removes a latent leak if
+  ``analyze()`` / ``factorize()`` were called twice without an intervening ``reset()``.
 - [ADDED] `lightsim2grid.network.bake_outer_loops`: rewrites a pypowsybl network's
   input setpoints to the converged PowSyBl OpenLoadFlow (OLF) outer-loop state (tap /
   shunt positions, reactive-limit PV->PQ switches, distributed-slack active power) so

--- a/lightsim2grid/tests/test_LSGrid_out_of_bounds.py
+++ b/lightsim2grid/tests/test_LSGrid_out_of_bounds.py
@@ -1,0 +1,248 @@
+# Copyright (c) 2020-2026, RTE (https://www.rte-france.com)
+# See AUTHORS.txt
+# This Source Code Form is subject to the terms of the Mozilla Public License, version 2.0.
+# If a copy of the Mozilla Public License, version 2.0 was not distributed with this file,
+# you can obtain one at http://mozilla.org/MPL/2.0/.
+# SPDX-License-Identifier: MPL-2.0
+# This file is part of LightSim2grid, LightSim2grid implements a c++ backend targeting the Grid2Op platform.
+
+"""
+Regression tests for the memory-safety fixes on the Python-exposed `LSGrid` /
+`TimeSeriesCPP` methods.
+
+Before the fix, passing an out-of-range or negative element id (or a mis-shaped
+array) to these methods reached unchecked C++ indexing (``operator[]`` / Eigen
+``operator()`` / ``.col()``, whose bounds asserts are compiled out in release
+builds) and could read or write out of bounds. They must now raise a clean Python
+exception instead:
+
+  * ``IndexError``   for out-of-range / negative element ids (``_check_in_range``
+    and the ``LSGrid``-level bus check throw ``std::out_of_range``);
+  * ``RuntimeError`` for array shape / length mismatches (``check_size``,
+    ``update_continuous_values`` and ``TimeSeries::compute_Vs`` throw
+    ``std::runtime_error``).
+"""
+
+import unittest
+import warnings
+import numpy as np
+
+import pandapower.networks as pn
+from lightsim2grid.network import init_from_pandapower
+
+try:
+    from lightsim2grid.lightsim2grid_cpp import TimeSeriesCPP
+    TimeSeriesCPP_AVAILABLE = True
+except ImportError:
+    TimeSeriesCPP_AVAILABLE = False
+
+
+# an id far above any element count, but still inside the C `int` range
+BIG = 10 ** 6
+
+
+class TestOutOfBoundsBindings(unittest.TestCase):
+    def setUp(self):
+        with warnings.catch_warnings():
+            warnings.filterwarnings("ignore")
+            net = pn.case14()
+            self.grid = init_from_pandapower(net)
+
+        # element counts as seen by the *gridmodel* (e.g. the pandapower ext_grid
+        # is modelled as an extra generator, so these differ from len(net.gen)).
+        self.n_gen = len(self.grid.get_generators())
+        self.n_sgen = len(self.grid.get_static_generators())
+        self.n_load = len(self.grid.get_loads())
+        self.n_shunt = len(self.grid.get_shunts())
+        self.n_storage = len(self.grid.get_storages())
+        self.n_line = len(self.grid.get_lines())
+        self.n_trafo = len(self.grid.get_trafos())
+        self.n_bus = self.grid.total_bus()
+
+    # ------------------------------------------------------------------
+    # helpers
+    # ------------------------------------------------------------------
+    def _assert_raises_each(self, exc, calls):
+        """`calls` is an iterable of (description, callable); each must raise `exc`."""
+        for descr, fun in calls:
+            with self.subTest(descr):
+                with self.assertRaises(exc):
+                    fun()
+
+    # ------------------------------------------------------------------
+    # out-of-bounds READS: deactivate / reactivate / change_bus family
+    # ------------------------------------------------------------------
+    def test_deactivate_reactivate_out_of_bounds(self):
+        # one-side elements (loads, gens, sgens, storages, shunts, svc) and
+        # two-side branches (powerlines, trafos). Empty containers (e.g. sgen /
+        # storage / svc in case14) still raise, so no special-casing is needed.
+        families = ["load", "gen", "sgen", "storage", "shunt", "svc",
+                    "powerline", "trafo"]
+        calls = []
+        for fam in families:
+            for bad in (-1, BIG):
+                calls.append((f"deactivate_{fam}({bad})",
+                              lambda fam=fam, bad=bad: getattr(self.grid, f"deactivate_{fam}")(bad)))
+                calls.append((f"reactivate_{fam}({bad})",
+                              lambda fam=fam, bad=bad: getattr(self.grid, f"reactivate_{fam}")(bad)))
+        self._assert_raises_each(IndexError, calls)
+
+    def test_change_bus_out_of_bounds(self):
+        valid_bus = 1  # any in-range gridmodel bus, to isolate the element-id check
+        calls = []
+        # one-side "change_bus_<fam>(el_id, new_bus)"
+        for fam in ["load", "gen", "sgen", "storage", "shunt", "svc"]:
+            for bad in (-1, BIG):
+                calls.append((f"change_bus_{fam}({bad})",
+                              lambda fam=fam, bad=bad: getattr(self.grid, f"change_bus_{fam}")(bad, valid_bus)))
+        # two-side "change_bus{1,2}_<fam>(el_id, new_bus)"
+        for fam in ["powerline", "trafo"]:
+            for side in (1, 2):
+                for bad in (-1, BIG):
+                    calls.append((f"change_bus{side}_{fam}({bad})",
+                                  lambda fam=fam, side=side, bad=bad:
+                                  getattr(self.grid, f"change_bus{side}_{fam}")(bad, valid_bus)))
+        self._assert_raises_each(IndexError, calls)
+
+    # ------------------------------------------------------------------
+    # out-of-bounds WRITES
+    # ------------------------------------------------------------------
+    def test_update_slack_weights_by_id_out_of_bounds(self):
+        calls = [
+            ("update_slack_weights_by_id([BIG])",
+             lambda: self.grid.update_slack_weights_by_id(np.array([BIG], dtype=np.int32))),
+            ("update_slack_weights_by_id([-1])",
+             lambda: self.grid.update_slack_weights_by_id(np.array([-1], dtype=np.int32))),
+        ]
+        self._assert_raises_each(IndexError, calls)
+
+    def test_set_gen_regulated_bus_out_of_bounds(self):
+        calls = [
+            # bad gen_id (valid bus)
+            ("set_gen_regulated_bus(-1, 0)", lambda: self.grid.set_gen_regulated_bus(-1, 0)),
+            ("set_gen_regulated_bus(BIG, 0)", lambda: self.grid.set_gen_regulated_bus(BIG, 0)),
+            # valid gen_id, bad bus_id
+            ("set_gen_regulated_bus(0, -1)", lambda: self.grid.set_gen_regulated_bus(0, -1)),
+            ("set_gen_regulated_bus(0, BIG)", lambda: self.grid.set_gen_regulated_bus(0, BIG)),
+        ]
+        self._assert_raises_each(IndexError, calls)
+
+    def test_change_ratio_shift_trafo_out_of_bounds(self):
+        calls = []
+        for name, arg in [("change_ratio_trafo", 1.0),
+                          ("change_shift_trafo", 0.1),
+                          ("change_shift_trafo_deg", 1.0)]:
+            for bad in (-1, BIG):
+                calls.append((f"{name}({bad})",
+                              lambda name=name, arg=arg, bad=bad: getattr(self.grid, name)(bad, arg)))
+        self._assert_raises_each(IndexError, calls)
+
+    # ------------------------------------------------------------------
+    # out-of-bounds READ (getter)
+    # ------------------------------------------------------------------
+    def test_get_status_droop_hvdc_out_of_bounds(self):
+        # case14 has no hvdc line; the empty-container bounds check still fires.
+        calls = [
+            ("get_status_droop_hvdc(-1)", lambda: self.grid.get_status_droop_hvdc(-1)),
+            ("get_status_droop_hvdc(BIG)", lambda: self.grid.get_status_droop_hvdc(BIG)),
+        ]
+        self._assert_raises_each(IndexError, calls)
+
+    # ------------------------------------------------------------------
+    # array length / shape mismatches
+    # ------------------------------------------------------------------
+    def test_update_continuous_values_length_mismatch(self):
+        # for each grid2op fast-update method, `new_values` must have the same
+        # length as `has_changed`; a shorter `new_values` used to over-read.
+        specs = [
+            ("update_gens_p", self.n_gen),
+            ("update_gens_v", self.n_gen),
+            ("update_sgens_p", self.n_sgen),
+            ("update_loads_p", self.n_load),
+            ("update_loads_q", self.n_load),
+            ("update_storages_p", self.n_storage),
+        ]
+        calls = []
+        for name, n in specs:
+            # has_changed longer than new_values by one -> mismatch (works for n == 0 too)
+            has_changed = np.zeros(n + 1, dtype=bool)
+            has_changed[-1] = True
+            new_values = np.zeros(n, dtype=np.float32)
+            calls.append((f"{name}(len mismatch)",
+                          lambda name=name, hc=has_changed, nv=new_values:
+                          getattr(self.grid, name)(hc, nv)))
+        self._assert_raises_each(RuntimeError, calls)
+
+    def test_set_pos_topo_vect_and_subid_size_mismatch(self):
+        specs = [
+            ("set_gen_pos_topo_vect", self.n_gen),
+            ("set_load_pos_topo_vect", self.n_load),
+            ("set_storage_pos_topo_vect", self.n_storage),
+            ("set_gen_to_subid", self.n_gen),
+            ("set_load_to_subid", self.n_load),
+            ("set_storage_to_subid", self.n_storage),
+            ("set_shunt_to_subid", self.n_shunt),
+        ]
+        calls = []
+        for name, n in specs:
+            wrong = np.zeros(n + 1, dtype=np.int32)  # one element too many
+            calls.append((f"{name}(size mismatch)",
+                          lambda name=name, arr=wrong: getattr(self.grid, name)(arr)))
+        self._assert_raises_each(RuntimeError, calls)
+
+    @unittest.skipUnless(TimeSeriesCPP_AVAILABLE, "TimeSeriesCPP not available")
+    def test_compute_Vs_shape_mismatch(self):
+        ts = TimeSeriesCPP(self.grid)
+        nb_steps = 3
+        Vinit = np.ones(self.n_bus, dtype=complex)
+
+        def mat(rows, cols):
+            return np.zeros((rows, cols), dtype=np.float64)
+
+        # correctly-shaped matrices (baseline used to build the mis-shaped variants)
+        gen_p = mat(nb_steps, self.n_gen)
+        sgen_p = mat(nb_steps, self.n_sgen)
+        load_p = mat(nb_steps, self.n_load)
+        load_q = mat(nb_steps, self.n_load)
+
+        calls = [
+            # wrong number of columns (fewer gens than the grid has)
+            ("gen_p wrong #cols",
+             lambda: ts.compute_Vs(mat(nb_steps, self.n_gen - 1), sgen_p, load_p, load_q, Vinit, 10, 1e-8)),
+            ("load_p wrong #cols",
+             lambda: ts.compute_Vs(gen_p, sgen_p, mat(nb_steps, self.n_load - 1), load_q, Vinit, 10, 1e-8)),
+            # mismatched number of rows (time steps) between matrices
+            ("load_q wrong #rows",
+             lambda: ts.compute_Vs(gen_p, sgen_p, load_p, mat(nb_steps - 1, self.n_load), Vinit, 10, 1e-8)),
+        ]
+        self._assert_raises_each(RuntimeError, calls)
+
+    # ------------------------------------------------------------------
+    # regression: the same methods still work for valid inputs
+    # ------------------------------------------------------------------
+    def test_valid_calls_still_work(self):
+        # these must NOT raise
+        self.grid.deactivate_load(0)
+        self.grid.reactivate_load(0)
+        self.grid.change_ratio_trafo(0, 1.0)
+        self.grid.change_shift_trafo(0, 0.0)
+        self.grid.set_gen_regulated_bus(0, 0)
+
+        has_changed = np.zeros(self.n_gen, dtype=bool)
+        new_values = np.zeros(self.n_gen, dtype=np.float32)
+        self.grid.update_gens_p(has_changed, new_values)
+
+        if TimeSeriesCPP_AVAILABLE:
+            ts = TimeSeriesCPP(self.grid)
+            nb_steps = 3
+            Vinit = np.ones(self.n_bus, dtype=complex)
+            res = ts.compute_Vs(np.zeros((nb_steps, self.n_gen), dtype=np.float64),
+                                 np.zeros((nb_steps, self.n_sgen), dtype=np.float64),
+                                 np.zeros((nb_steps, self.n_load), dtype=np.float64),
+                                 np.zeros((nb_steps, self.n_load), dtype=np.float64),
+                                 Vinit, 10, 1e-8)
+            self.assertIsNotNone(res)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/core/LSGrid.hpp
+++ b/src/core/LSGrid.hpp
@@ -1020,7 +1020,17 @@ class LS2G_API LSGrid final
          * voltage control). `bus_id` == the generator's own bus restores ordinary
          * local PV control.
          */
-        void set_gen_regulated_bus(int gen_id, int bus_id) {generators_.set_regulated_bus(gen_id, bus_id, algo_controler_); }
+        void set_gen_regulated_bus(int gen_id, int bus_id) {
+            // bus_id is stored verbatim and later dereferenced during solve, so reject
+            // an out-of-range bus here (gen_id is validated inside set_regulated_bus).
+            if(bus_id < 0 || bus_id >= static_cast<int>(total_bus())){
+                std::ostringstream exc_;
+                exc_ << "LSGrid::set_gen_regulated_bus: regulated bus id should be >= 0 and < ";
+                exc_ << total_bus() << " (number of buses on the grid), you provided " << bus_id << ".";
+                throw std::out_of_range(exc_.str());
+            }
+            generators_.set_regulated_bus(gen_id, bus_id, algo_controler_);
+        }
         /**
          * Change the bus on the dc line "side 1" dcline_id.
          * 
@@ -1904,6 +1914,14 @@ class LS2G_API LSGrid final
                                       Eigen::Ref<Eigen::Array<float, Eigen::Dynamic, Eigen::RowMajor> > & new_values,
                                       T fun)
         {
+            // new_values is indexed by has_changed's length below; a shorter new_values
+            // would over-read the buffer (Eigen operator[] is unchecked in release).
+            if(new_values.rows() != has_changed.rows()){
+                std::ostringstream exc_;
+                exc_ << "LSGrid::update_continuous_values: 'has_changed' (size " << has_changed.rows();
+                exc_ << ") and 'new_values' (size " << new_values.rows() << ") must have the same size.";
+                throw std::runtime_error(exc_.str());
+            }
             for(int el_id = 0; el_id < has_changed.rows(); ++el_id)
             {
                 if(has_changed(el_id))

--- a/src/core/batch_algorithm/TimeSeries.cpp
+++ b/src/core/batch_algorithm/TimeSeries.cpp
@@ -43,6 +43,33 @@ int TimeSeries::compute_Vs(Eigen::Ref<const RealMat> gen_p,
     const auto & s_generators = _grid_model.get_static_generators_as_data();
     const auto & loads = _grid_model.get_loads_as_data();
 
+    // Validate the shapes of the caller-supplied matrices before fill_SBus_* uses them.
+    // fill_SBus_* iterates el_id up to the grid's element count and reads
+    // temporal_data.col(el_id) (unchecked Eigen .col()), so a matrix with too few
+    // columns over-reads; and _Sbuses is sized with gen_p.rows(), so mismatched row
+    // counts turn the `Sbuses.col(...) += tmp` into an out-of-bounds read/write.
+    const auto check_mat = [nb_steps](Eigen::Ref<const RealMat> mat, Eigen::Index nb_expected_cols,
+                                      const std::string & name){
+        if(static_cast<size_t>(mat.rows()) != nb_steps){
+            std::ostringstream exc_;
+            exc_ << "TimeSeries::compute_Vs: '" << name << "' has " << mat.rows()
+                 << " rows (time steps) while 'gen_p' has " << nb_steps
+                 << ". All injection matrices must share the same number of rows.";
+            throw std::runtime_error(exc_.str());
+        }
+        if(mat.cols() != nb_expected_cols){
+            std::ostringstream exc_;
+            exc_ << "TimeSeries::compute_Vs: '" << name << "' has " << mat.cols()
+                 << " columns while the grid counts " << nb_expected_cols
+                 << " such elements. The number of columns must match the number of elements.";
+            throw std::runtime_error(exc_.str());
+        }
+    };
+    check_mat(gen_p, generators.nb(), "gen_p");
+    check_mat(sgen_p, s_generators.nb(), "sgen_p");
+    check_mat(load_p, loads.nb(), "load_p");
+    check_mat(load_q, loads.nb(), "load_q");
+
     // now build the Sbus
     _Sbuses = CplxMat::Zero(nb_steps, nb_buses_solver_);
 

--- a/src/core/element_container/GeneratorContainer.cpp
+++ b/src/core/element_container/GeneratorContainer.cpp
@@ -564,11 +564,16 @@ void GeneratorContainer::update_slack_weights_by_id(
     int nb_gen = nb();
     std::vector<bool> maybe_slack_bus(nb_gen, false);
 
+    // validate every caller-supplied id before it is used to index status_ /
+    // maybe_slack_bus / target_p_mw_ below (raw operator[] / Eigen operator() are
+    // unchecked, and a negative id would wrap to a huge size_t -> OOB write).
+    for(int gen_id : gen_slack_id) _check_in_range(gen_id, status_, "update_slack_weights_by_id");
+
     // find which generators can be slack
     real_type total_target_p = 0.;
     for(int gen_id : gen_slack_id)
     {
-        if(status_[gen_id]) 
+        if(status_[gen_id])
         {
             maybe_slack_bus[gen_id] = true;
             total_target_p += abs(target_p_mw_(gen_id));

--- a/src/core/element_container/GeneratorContainer.hpp
+++ b/src/core/element_container/GeneratorContainer.hpp
@@ -213,6 +213,10 @@ class LS2G_API GeneratorContainer final: public OneSideContainer_PQ, public Iter
             return regulated_bus_id_(gen_id) != bus_id_(gen_id).cast_int();
         }
         void set_regulated_bus(int gen_id, int bus_id, DualAlgoControl & solver_control){
+            // gen_id indexes regulated_bus_id_ with an unchecked Eigen operator() below
+            // (OOB write for an out-of-range / negative id). bus_id itself is validated
+            // by the caller (LSGrid::set_gen_regulated_bus) against the grid bus count.
+            _check_in_range(gen_id, regulated_bus_id_, "set_regulated_bus");
             if(regulated_bus_id_(gen_id) != bus_id){
                 regulated_bus_id_(gen_id) = bus_id;
                 solver_control.ac_algo_controler().tell_pv_changed();  // groups are rebuilt on topology init

--- a/src/core/element_container/HvdcLineContainer.hpp
+++ b/src/core/element_container/HvdcLineContainer.hpp
@@ -296,7 +296,12 @@ class LS2G_API HvdcLineContainer final : public TwoSidesContainer<ConverterStati
             for(int i = 0; i < nb_hvdc; ++i) if(is_droop_active(i)) return true;
             return false;
         }
-        int get_status_droop(int hvdc_id) const {return status_droop_(hvdc_id);}
+        int get_status_droop(int hvdc_id) const {
+            // hvdc_id indexes status_droop_ with an unchecked Eigen operator() (OOB read);
+            // the matching setter set_status_droop already guards the same way.
+            _check_in_range(hvdc_id, status_droop_, "get_status_droop");
+            return status_droop_(hvdc_id);
+        }
         std::vector<int> get_status_droop_vect() const {
             return std::vector<int>(status_droop_.begin(), status_droop_.end());
         }

--- a/src/core/element_container/OneSideContainer.hpp
+++ b/src/core/element_container/OneSideContainer.hpp
@@ -207,11 +207,16 @@ class OneSideContainer : public GenericContainer
         }
 
         virtual bool deactivate(int el_id, DualAlgoControl & solver_control) final {
+            // validate el_id *before* dispatching: `_deactivate` indexes status_[el_id]
+            // with an unchecked operator[] (a negative id would wrap to a huge size_t),
+            // and `_generic_deactivate` only checks afterwards.
+            _check_in_range(el_id, status_, "deactivate");
             bool res = this->_deactivate(el_id, solver_control);
             _generic_deactivate(el_id, status_);
             return res;
         }
         virtual bool reactivate(int el_id, DualAlgoControl & solver_control) final {
+            _check_in_range(el_id, status_, "reactivate");
             bool res = this->_reactivate(el_id, solver_control);
             _generic_reactivate(el_id, status_);
             return res;
@@ -228,6 +233,9 @@ class OneSideContainer : public GenericContainer
             GridModelBusId new_gridmodel_bus_id,
             DualAlgoControl & solver_control,
             const SubstationContainer & substation) final {
+                // validate load_id *before* dispatching: `_change_bus` reads bus_id_(load_id)
+                // with an unchecked Eigen operator(); `_generic_change_bus` only checks afterwards.
+                _check_in_range(load_id, bus_id_, "change_bus");
                 bool res = this->_change_bus(load_id, new_gridmodel_bus_id, solver_control, substation.nb_bus());
                 _generic_change_bus(load_id, new_gridmodel_bus_id, bus_id_, solver_control, substation.nb_bus());
                 return res;
@@ -253,11 +261,13 @@ class OneSideContainer : public GenericContainer
 
         void set_pos_topo_vect(Eigen::Ref<const IntVect> pos_topo_vect)
         {
+            check_size(pos_topo_vect, nb(), "pos_topo_vect");
             pos_topo_vect_.array() = pos_topo_vect;
         }
 
         void set_subid(Eigen::Ref<const IntVect> subid)
         {
+            check_size(subid, nb(), "subid");
             subid_.array() = subid;
         }
 

--- a/src/core/element_container/TrafoContainer.hpp
+++ b/src/core/element_container/TrafoContainer.hpp
@@ -177,6 +177,8 @@ class LS2G_API TrafoContainer final : public TwoSidesContainer_rxh_A<OneSideCont
             int el_id,
             real_type new_ratio,
             DualAlgoControl & solver_control){
+                // el_id indexes ratio_ with an unchecked Eigen operator() below (OOB write).
+                _check_in_range(el_id, ratio_, "change_ratio");
                 if(std::abs(ratio_(el_id) - new_ratio) >_tol_equal_float){
                     ratio_(el_id) = new_ratio;
                     // TODO speed: only some part needs to be recomputed
@@ -196,6 +198,8 @@ class LS2G_API TrafoContainer final : public TwoSidesContainer_rxh_A<OneSideCont
             int el_id,
             real_type new_shift_rad,
             DualAlgoControl & solver_control){
+                // el_id indexes shift_ with an unchecked Eigen operator() below (OOB write).
+                _check_in_range(el_id, shift_, "change_shift");
                 if(std::abs(shift_(el_id) - new_shift_rad) >_tol_equal_float){
                     shift_(el_id) = new_shift_rad;
                     // TODO speed: only some part needs to be recomputed

--- a/src/core/linear_solvers/CKTSOSolver.cpp
+++ b/src/core/linear_solvers/CKTSOSolver.cpp
@@ -20,15 +20,13 @@ const bool CKTSOLinearSolver::CAN_SOLVE_MAT = false;
 ErrorType CKTSOLinearSolver::reset(){
     // free everything
     if(solver_ != nullptr) solver_->DestroySolver();
-    if(ai_ != nullptr) delete [] ai_;
-    if(ap_ != nullptr) delete [] ap_;
+    ai_.reset();
+    ap_.reset();
 
     // should not be deleted, see https://github.com/Grid2Op/lightsim2grid/issues/52#issuecomment-1333565959
     // if(iparm_!= nullptr) delete iparm_;
     // if(oparm_!= nullptr) delete oparm_;
 
-    ai_ = nullptr;
-    ap_ = nullptr;
     iparm_ = nullptr;
     oparm_ = nullptr;
 
@@ -53,21 +51,21 @@ ErrorType CKTSOLinearSolver::analyze(const Eigen::SparseMatrix<real_type> & J){
     const auto n = J.cols();
     const unsigned int nnz = J.nonZeros();
 
-    ai_ = new int [nnz];
+    ai_ = std::make_unique<int[]>(nnz);
     const int * ref_ai = J.innerIndexPtr();
     for(unsigned int i = 0; i < nnz; ++i){
         ai_[i] = static_cast<int>(ref_ai[i]);
     }
 
-    ap_ = new int [n+1];
+    ap_ = std::make_unique<int[]>(n+1);
     const int * ref_ap = J.outerIndexPtr();
     for(int i = 0; i < n+1; ++i){
         ap_[i] = static_cast<int>(ref_ap[i]);
     }
     int ret = solver_->Analyze(false,  // complex or real
                                n,
-                               ap_,
-                               ai_,
+                               ap_.get(),
+                               ai_.get(),
                                J.valuePtr(),
                                nb_thread_);
     if (ret < 0){

--- a/src/core/linear_solvers/CKTSOSolver.hpp
+++ b/src/core/linear_solvers/CKTSOSolver.hpp
@@ -10,6 +10,8 @@
 #ifndef CKTSOSOLVER_H
 #define CKTSOSOLVER_H
 
+#include <memory>
+
 // eigen is necessary to easily pass data from numpy to c++ without any copy.
 // and to optimize the matrix operations
 #include "Utils.hpp"
@@ -52,13 +54,12 @@ class LS2G_API CKTSOLinearSolver final
         ~CKTSOLinearSolver() noexcept
         {
            if(solver_!= nullptr) solver_->DestroySolver();
-           if(ai_!= nullptr) delete [] ai_;
-           if(ap_!= nullptr) delete [] ap_;
-           
+           // ai_ / ap_ are std::unique_ptr and free themselves.
+
            // should not be deleted, see https://github.com/Grid2Op/lightsim2grid/issues/52#issuecomment-1333565959
            // if(iparm_!= nullptr) delete iparm_;
            // if(oparm_!= nullptr) delete oparm_;
-           
+
         }
         // CKTSOLinearSolver(CKTSOLinearSolver && other) noexcept: nb_thread_(ohter.nb_thread_){
         // TODO !
@@ -100,10 +101,12 @@ class LS2G_API CKTSOLinearSolver final
         // solver initialization
         ICktSo solver_;
         const unsigned int nb_thread_;
-        int * ai_;
-        int * ap_;
-        int * iparm_;
-        long long * oparm_;
+        // ai_ / ap_ own the CSC index buffers passed to CKTSO's Analyze; they must
+        // stay alive until reset() / destruction, which std::unique_ptr handles.
+        std::unique_ptr<int[]> ai_;
+        std::unique_ptr<int[]> ap_;
+        int * iparm_;   // owned by CKTSO, not freed here
+        long long * oparm_;  // owned by CKTSO, not freed here
 
 };
 

--- a/src/core/linear_solvers/KLUSolver.cpp
+++ b/src/core/linear_solvers/KLUSolver.cpp
@@ -15,32 +15,36 @@ namespace ls2g {
 const bool KLULinearSolver::CAN_SOLVE_MAT = false;
 
 ErrorType KLULinearSolver::reset(){
-    if(symbolic_ != nullptr) klu_free_symbolic(&symbolic_, &common_);
-    if(numeric_ != nullptr) klu_free_numeric(&numeric_, &common_);
+    // release both handles (their deleters use common_) before resetting common_
+    numeric_.reset();
+    symbolic_.reset();
     common_ = klu_common();
-    symbolic_ = nullptr;
-    numeric_ = nullptr;
     return ErrorType::NoError;
 }
 
 ErrorType KLULinearSolver::analyze(const Eigen::SparseMatrix<real_type>& J){
     // J is const here, but `klu_analyze` signature expects non-const arrays, so I const_cast
     const auto n = J.cols();
+    // free any previous factorization (using the current common_) before resetting it,
+    // so re-analyzing without a prior reset() no longer leaks the old handles
+    numeric_.reset();
+    symbolic_.reset();
     common_ = klu_common();
-    symbolic_ = klu_analyze(n,
-                            const_cast<Eigen::SparseMatrix<real_type>::StorageIndex *>(J.outerIndexPtr()),
-                            const_cast<Eigen::SparseMatrix<real_type>::StorageIndex *>(J.innerIndexPtr()),
-                            &common_);
+    symbolic_.reset(klu_analyze(n,
+                                const_cast<Eigen::SparseMatrix<real_type>::StorageIndex *>(J.outerIndexPtr()),
+                                const_cast<Eigen::SparseMatrix<real_type>::StorageIndex *>(J.innerIndexPtr()),
+                                &common_));
     if(common_.status != KLU_OK) return ErrorType::SolverAnalyze;
     return ErrorType::NoError;
 }
 
 ErrorType KLULinearSolver::factorize(const Eigen::SparseMatrix<real_type>& J){
     // J is const here, but `klu_factor` signature expects non-const arrays, so I const_cast
-    numeric_ = klu_factor(const_cast<Eigen::SparseMatrix<real_type>::StorageIndex *>(J.outerIndexPtr()),
-                          const_cast<Eigen::SparseMatrix<real_type>::StorageIndex *>(J.innerIndexPtr()),
-                          const_cast<real_type*>(J.valuePtr()),
-                          symbolic_, &common_);
+    // reset() frees any previous numeric factorization before storing the new one
+    numeric_.reset(klu_factor(const_cast<Eigen::SparseMatrix<real_type>::StorageIndex *>(J.outerIndexPtr()),
+                              const_cast<Eigen::SparseMatrix<real_type>::StorageIndex *>(J.innerIndexPtr()),
+                              const_cast<real_type*>(J.valuePtr()),
+                              symbolic_.get(), &common_));
     if(common_.status != KLU_OK) return ErrorType::SolverFactor;
     return ErrorType::NoError;
 }
@@ -51,7 +55,7 @@ ErrorType KLULinearSolver::refactorize(const Eigen::SparseMatrix<real_type>& J){
     int ok = klu_refactor(const_cast<Eigen::SparseMatrix<real_type>::StorageIndex *>(J.outerIndexPtr()),
                           const_cast<Eigen::SparseMatrix<real_type>::StorageIndex *>(J.innerIndexPtr()),
                           const_cast<real_type*>(J.valuePtr()),
-                          symbolic_, numeric_, &common_);
+                          symbolic_.get(), numeric_.get(), &common_);
     if(ok != 1){
         // std::cout << "\t KLU: refactor error" << std::endl;
         return ErrorType::SolverReFactor;
@@ -61,7 +65,7 @@ ErrorType KLULinearSolver::refactorize(const Eigen::SparseMatrix<real_type>& J){
 
 ErrorType KLULinearSolver::solve(RealVect & b){
     const int n = static_cast<int>(b.size());
-    int ok = klu_solve(symbolic_, numeric_, n, 1, &b(0), &common_);
+    int ok = klu_solve(symbolic_.get(), numeric_.get(), n, 1, &b(0), &common_);
     if(ok != 1){
         // std::cout << "\t KLU: klu_solve error" << std::endl;
         return ErrorType::SolverSolve;

--- a/src/core/linear_solvers/KLUSolver.hpp
+++ b/src/core/linear_solvers/KLUSolver.hpp
@@ -10,6 +10,7 @@
 #ifndef KLSOLVER_H
 #define KLSOLVER_H
 #include <iostream>
+#include <memory>
 
 // eigen is necessary to easily pass data from numpy to c++ without any copy.
 // and to optimize the matrix operations
@@ -39,29 +40,14 @@ Otherwise, unexpected behaviour might follow, including "segfault".
 class LS2G_API KLULinearSolver final
 {
     public:
-        KLULinearSolver() noexcept :symbolic_(nullptr),numeric_(nullptr),common_(){}
+        KLULinearSolver() noexcept :
+            common_(),
+            symbolic_(nullptr, SymbolicDeleter{&common_}),
+            numeric_(nullptr, NumericDeleter{&common_})
+            {}
 
-        ~KLULinearSolver() noexcept
-        {
-            // std::cout << "KLULinearSolver destructor 1" << std::endl;
-            if(symbolic_ != nullptr) klu_free_symbolic(&symbolic_, &common_);
-            // std::cout << "KLULinearSolver destructor 2" << std::endl;
-            if(numeric_ != nullptr) klu_free_numeric(&numeric_, &common_);
-            // std::cout << "KLULinearSolver destructor 3" << std::endl;
-        }
-
-        // KLULinearSolver(KLULinearSolver && other) noexcept {
-        //     TODO
-        //     if(symbolic_ != nullptr) klu_free_symbolic(&symbolic_, &common_);
-        //     symbolic_ = other.symbolic_;
-        //     other.symbolic_ = nullptr;
-            
-        //     if(numeric_ != nullptr) klu_free_numeric(&numeric_, &common_);
-        //     numeric_ = other.numeric_;
-        //     other.numeric_ = nullptr;
-
-        //     std::swap(common_, other.common_);
-        // }
+        // symbolic_ / numeric_ are unique_ptr with custom deleters and free themselves.
+        ~KLULinearSolver() noexcept = default;
 
         // public api
         ErrorType reset();
@@ -72,12 +58,37 @@ class LS2G_API KLULinearSolver final
 
         // can this linear solver solve problem where RHS is a matrix
         static const bool CAN_SOLVE_MAT;
-        
+
     private:
-        // solver initialization
-        klu_symbolic* symbolic_;
-        klu_numeric* numeric_;
+        // KLU frees its symbolic / numeric handles through a pair of functions that
+        // also need the `klu_common` control struct, so the deleters are stateful and
+        // hold a pointer to `common_`. `common_` is therefore declared *before* the two
+        // handles: members are destroyed in reverse declaration order, so the handles
+        // (and their deleters, which dereference `common_`) are released while `common_`
+        // is still alive.
+        struct SymbolicDeleter {
+            klu_common* common_ = nullptr;
+            void operator()(klu_symbolic* ptr) const noexcept {
+                if(ptr != nullptr){
+                    klu_symbolic* tmp = ptr;  // klu_free_symbolic takes a klu_symbolic**
+                    klu_free_symbolic(&tmp, common_);
+                }
+            }
+        };
+        struct NumericDeleter {
+            klu_common* common_ = nullptr;
+            void operator()(klu_numeric* ptr) const noexcept {
+                if(ptr != nullptr){
+                    klu_numeric* tmp = ptr;  // klu_free_numeric takes a klu_numeric**
+                    klu_free_numeric(&tmp, common_);
+                }
+            }
+        };
+
+        // solver initialization (declaration order matters, see note above)
         klu_common common_;
+        std::unique_ptr<klu_symbolic, SymbolicDeleter> symbolic_;
+        std::unique_ptr<klu_numeric, NumericDeleter> numeric_;
 
         // no copy allowed
         KLULinearSolver(const KLULinearSolver&) = delete;

--- a/src/core/linear_solvers/NICSLUSolver.cpp
+++ b/src/core/linear_solvers/NICSLUSolver.cpp
@@ -17,10 +17,8 @@ const bool NICSLULinearSolver::CAN_SOLVE_MAT = false;
 ErrorType NICSLULinearSolver::reset(){
     // free everything
     solver_.Free();
-    if(ai_ != nullptr) delete [] ai_;  // created in NICSLUSolver::initialize
-    if(ap_ != nullptr) delete [] ap_;  // created in NICSLUSolver::initialize
-    ai_ = nullptr;
-    ap_ = nullptr;
+    ai_.reset();  // created in NICSLUSolver::analyze
+    ap_.reset();  // created in NICSLUSolver::analyze
 
     solver_ = CNicsLU();
     int ret = solver_.Initialize();
@@ -43,21 +41,21 @@ ErrorType NICSLULinearSolver::analyze(const Eigen::SparseMatrix<real_type> & J){
     const auto n = J.cols();
     const unsigned int nnz = J.nonZeros();
 
-    ai_ = new unsigned int [nnz];  // deleted in destructor and NICSLUSolver::reset
+    ai_ = std::make_unique<unsigned int[]>(nnz);  // freed in destructor and NICSLUSolver::reset
     const int * ref_ai = J.innerIndexPtr();
     for(unsigned int i = 0; i < nnz; ++i){
         ai_[i] = static_cast<unsigned int>(ref_ai[i]);
     }
 
-    ap_ = new unsigned int [n+1];  // deleted in destructor and NICSLUSolver::reset
+    ap_ = std::make_unique<unsigned int[]>(n+1);  // freed in destructor and NICSLUSolver::reset
     const int * ref_ap = J.outerIndexPtr();
     for(int i = 0; i < n+1; ++i){
         ap_[i] = static_cast<unsigned int>(ref_ap[i]);
     }
     int ret = solver_.Analyze(n,
                               J.valuePtr(),
-                              ai_,
-                              ap_,
+                              ai_.get(),
+                              ap_.get(),
                               MATRIX_COLUMN_REAL);  // MATRIX_COLUMN_REAL, MATRIX_ROW_REAL
     if (ret < 0){
         // https://github.com/chenxm1986/nicslu/blob/master/nicslu202103/include/nicslu.h for error info

--- a/src/core/linear_solvers/NICSLUSolver.hpp
+++ b/src/core/linear_solvers/NICSLUSolver.hpp
@@ -10,6 +10,8 @@
 #ifndef NICSLUSOLVER_H
 #define NICSLUSOLVER_H
 
+#include <memory>
+
 // eigen is necessary to easily pass data from numpy to c++ without any copy.
 // and to optimize the matrix operations
 #include "Utils.hpp"
@@ -50,14 +52,7 @@ class LS2G_API NICSLULinearSolver final
         ~NICSLULinearSolver() noexcept
         {
            solver_.Free();
-           if(ai_!= nullptr){
-            delete [] ai_;
-            ai_= nullptr;
-           }
-           if(ap_!= nullptr){
-            delete [] ap_;
-            ap_ = nullptr;
-           }
+           // ai_ / ap_ are std::unique_ptr and free themselves.
         }
 
         // NICSLULinearSolver(NICSLULinearSolver && other) noexcept: nb_thread_(other.nb_thread_){
@@ -93,8 +88,10 @@ class LS2G_API NICSLULinearSolver final
         // solver initialization
         CNicsLU solver_;
         const unsigned int nb_thread_;
-        unsigned int * ai_;
-        unsigned int * ap_;
+        // ai_ / ap_ own the CSC index buffers passed to NICSLU's Analyze; they must
+        // stay alive until reset() / destruction, which std::unique_ptr handles.
+        std::unique_ptr<unsigned int[]> ai_;
+        std::unique_ptr<unsigned int[]> ap_;
 
 };
 


### PR DESCRIPTION
## Summary

Two related C++ memory-handling improvements on top of `n1_full_compute`:

1. **Fix out-of-bounds memory access reachable from the Python API.** Several Python-exposed methods passed an element id or array straight to unchecked C++ indexing (`std::vector::operator[]` / Eigen `operator()` / `.col()`, whose bounds asserts are compiled out under `NDEBUG`). A negative id wraps to a huge `size_t`; an out-of-range id reads or writes past the container. A plain call such as `grid.deactivate_load(-1)` or `grid.change_ratio_trafo(9999, 1.0)` could corrupt or leak process memory.
2. **RAII for the built-in linear solvers' memory** (the follow-up requested in review): replace manual `new[]`/`delete[]` and hand-written frees with `std::unique_ptr`.

All checks reuse the codebase's own validation idioms (`GenericContainer::_check_in_range` / `check_size` / `.at()`), the same guards the safe `change_p/q/v` and bus-id paths already use.

## Memory-safety fixes

Out-of-range ids now raise `IndexError` and mis-shaped arrays raise `RuntimeError`, instead of corrupting memory.

Out-of-bounds **writes** (highest severity):
- `update_slack_weights_by_id` — user id array indexed a `nb_gen`-sized vector unchecked.
- `set_gen_regulated_bus` — unchecked write on `gen_id`; `bus_id` was also stored without range validation.
- `change_ratio_trafo` / `change_shift_trafo` / `change_shift_trafo_deg` — unchecked write on `trafo_id`.
- `set_*_pos_topo_vect` / `set_*_to_subid` — numpy array assigned into a fixed-size Eigen view with no size check.

Out-of-bounds **reads**:
- `deactivate_* / reactivate_* / change_bus_*` (loads, gens, sgens, storages, shunts, powerlines, trafos, dclines) — the wrapper ran the unchecked `_method` hook *before* the `_generic_*` validator. Fixed once in the public `OneSideContainer` wrappers, which also covers the two-sided containers (they delegate to those `final` methods first). Mirrors the guard already present in `GeneratorContainer::_change_bus`.
- `get_status_droop_hvdc` — the setter was guarded, the getter was not.
- `update_gens_p` / `update_loads_p` / etc. — `new_values` was indexed by `has_changed`'s length; a shorter `new_values` over-read.
- `TimeSeriesCPP.compute_Vs` — the `gen_p/sgen_p/load_p/load_q` matrix column/row counts are now validated against the grid element counts before `fill_SBus_*` indexes user columns by grid element ids.

By contrast, `change_p/q/v`, `get_bus_*`, the `change_bus_*` bus-id validation, and the contingency-analysis id path were already correctly guarded and are unchanged.

## Linear-solver RAII refactor

- `CKTSOLinearSolver` and `NICSLULinearSolver`: the CSC index buffers `ai_`/`ap_` now use `std::unique_ptr<T[]>` via `std::make_unique` instead of `new[]`/`delete[]`.
- `KLULinearSolver`: the `klu_symbolic`/`klu_numeric` handles now use `std::unique_ptr` with stateful custom deleters calling `klu_free_symbolic`/`klu_free_numeric`. The deleters hold a pointer to `klu_common`, so `common_` is declared before the two handles to guarantee it outlives them at destruction (reverse-declaration-order teardown).

Lifetimes are unchanged (buffers/handles are still released on `reset()` and destruction), but ownership is RAII-managed and the manual frees are gone. This also removes a latent leak in all three: re-running `analyze()`/`factorize()` without an intervening `reset()` previously overwrote the raw pointer/handle without freeing the old one.

## Verification

- Built the extension and ran targeted tests on `case14`: 20 negative cases (negative and too-large ids across every fixed method) now raise `IndexError`; array-length/shape mismatches raise `RuntimeError`; none segfault. `compute_Vs` rejects wrong column counts and mismatched rows. No regression: AC powerflow still converges, `change_bus` still persists the change, all valid calls succeed.
- KLU solver (default build) on `case118`: converges and matches the SparseLU reference to ~2e-15 after 50 topology-change cycles (repeated `analyze`/`factorize`/`reset`).
- CKTSO/NICSLU are compiled only when those proprietary vendor libraries are present (not in CI here), so their exact `unique_ptr<T[]>` pattern was compiled standalone and run clean under AddressSanitizer.

Changes are documented in `CHANGELOG.rst` (`[0.14.0]`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017ptbLEZy5KUt4u8qkiRjmR

---
_Generated by [Claude Code](https://claude.ai/code/session_017ptbLEZy5KUt4u8qkiRjmR)_