### PR TITLE
Add memory-hardening CI: ASan+UBSan and debug-assertions jobs (+ bugs they found)

### DIFF
--- a/.github/workflows/sanitizers.yml
+++ b/.github/workflows/sanitizers.yml
@@ -1,0 +1,99 @@
+# Memory-hardening CI: builds the C++ core + bindings with instrumentation
+# that the release wheels do not carry, and runs the test modules most likely
+# to surface memory issues (out-of-bounds, use-after-free, UB, silenced
+# assertions). Complements the functional suites on CircleCI, which run
+# against plain optimized builds.
+
+name: Sanitizers
+
+on:
+  push:
+    branches:
+      - '*'
+    tags:
+      - 'v*.*.*'
+
+jobs:
+  asan_ubsan:
+    # AddressSanitizer + UndefinedBehaviorSanitizer over the untrusted-input
+    # path (binary serialization) and the heaviest C++ compute paths (solver
+    # control, time series, contingency analysis).
+    name: ASan + UBSan tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: true
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install python dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -r requirements_compile_ci.txt
+          python -m pip install grid2op scipy pandapower
+
+      - name: Build lightsim2grid with ASan + UBSan
+        # __SANITIZE=1 is picked up by src/core/CMakeLists.txt and
+        # src/bindings/python/CMakeLists.txt: -fsanitize=address,undefined
+        # on both lightsim2grid_core and lightsim2grid_cpp
+        run: __SANITIZE=1 python -m pip install -v . --no-build-isolation
+
+      - name: Run tests under ASan + UBSan
+        # The sanitized code lives in a python extension, so the ASan runtime
+        # must be the first thing loaded into the (uninstrumented) python
+        # process: hence LD_PRELOAD. Leak detection stays off: CPython's
+        # allocator keeps interned objects alive by design and would drown
+        # real reports in noise.
+        env:
+          ASAN_OPTIONS: detect_leaks=0
+          UBSAN_OPTIONS: print_stacktrace=1:halt_on_error=1
+        run: |
+          export LD_PRELOAD=$(gcc -print-file-name=libasan.so)
+          cd lightsim2grid/tests
+          python -W ignore -m unittest -v \
+            test_binary_serialization \
+            test_solver_control \
+            test_TimeSerie \
+            test_time_series_dc \
+            test_SecurityAnlysis \
+            test_DCSecurityAnlysis \
+            test_SecurityAnlysis_cpp \
+            test_ContingencyAnalysis_limit_violations \
+            test_ContingencyAnalysis_split
+
+  debug_asserts:
+    # Release wheels are compiled with NDEBUG, which silences every Eigen
+    # bounds assertion: logically-wrong-but-in-bounds indexing is invisible
+    # to ASan. This build re-enables them (plus the ABI-safe libstdc++
+    # container checks) and runs the solver-heavy modules.
+    name: Eigen/libstdc++ assertions tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: true
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install python dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -r requirements_compile_ci.txt
+          python -m pip install grid2op scipy pandapower
+
+      - name: Build lightsim2grid with assertions re-enabled
+        # __DEBUG_ASSERTS=1 -> -UNDEBUG -D_GLIBCXX_ASSERTIONS on both targets
+        run: __DEBUG_ASSERTS=1 python -m pip install -v . --no-build-isolation
+
+      - name: Run solver tests with assertions active
+        run: |
+          cd lightsim2grid/tests
+          python -W ignore -m unittest -v \
+            test_ACPF \
+            test_DCPF \
+            test_solver_control

--- a/.github/workflows/sanitizers.yml
+++ b/.github/workflows/sanitizers.yml
@@ -9,7 +9,9 @@ name: Sanitizers
 on:
   push:
     branches:
-      - '*'
+      # '**' and not '*': a single '*' does not match '/' in GitHub Actions
+      # globs, so topic branches like 'foo/bar' would silently never run
+      - '**'
     tags:
       - 'v*.*.*'
 

--- a/.github/workflows/sanitizers.yml
+++ b/.github/workflows/sanitizers.yml
@@ -44,14 +44,17 @@ jobs:
       - name: Run tests under ASan + UBSan
         # The sanitized code lives in a python extension, so the ASan runtime
         # must be the first thing loaded into the (uninstrumented) python
-        # process: hence LD_PRELOAD. Leak detection stays off: CPython's
-        # allocator keeps interned objects alive by design and would drown
-        # real reports in noise.
+        # process: hence LD_PRELOAD. libstdc++ must be preloaded along with
+        # it: python itself does not link it, and without it ASan's
+        # __cxa_throw interceptor cannot resolve the real function and every
+        # C++ exception aborts the process. Leak detection stays off:
+        # CPython's allocator keeps interned objects alive by design and
+        # would drown real reports in noise.
         env:
           ASAN_OPTIONS: detect_leaks=0
           UBSAN_OPTIONS: print_stacktrace=1:halt_on_error=1
         run: |
-          export LD_PRELOAD=$(gcc -print-file-name=libasan.so)
+          export LD_PRELOAD="$(gcc -print-file-name=libasan.so) $(gcc -print-file-name=libstdc++.so.6)"
           cd lightsim2grid/tests
           python -W ignore -m unittest -v \
             test_binary_serialization \

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -393,6 +393,16 @@ TODO: integration test with pandapower (see `pandapower/contingency/contingency.
     `ConverterStationInfo.ConverterType` -- the last three are now exposed to
     python) are pinned by a test (`TestSerializedEnumValues`) that fails with
     a "bump BINARY_FORMAT_VERSION" message if they are renumbered.
+- [ADDED] memory-hardening CI (`.github/workflows/sanitizers.yml`): an
+  **ASan + UBSan** job (build with `__SANITIZE=1`, runs the binary
+  serialization, solver control, time series and contingency analysis test
+  modules under AddressSanitizer + UndefinedBehaviorSanitizer) and a
+  **debug-assertions** job (build with `__DEBUG_ASSERTS=1`:
+  `-UNDEBUG -D_GLIBCXX_ASSERTIONS`, re-enabling the Eigen bounds assertions
+  that Release builds silence, runs the solver-heavy modules). Also a new
+  corruption-sweep test (`TestCorruptionSweep`) that corrupts a valid binary
+  file at every byte offset and checks `load_binary` never does anything
+  worse than raising a clean `RuntimeError`.
 - [FIXED] `LSGrid.save_binary`/`load_binary` (and pickle, which shares the same
   `LSGrid::get_state()`/`set_state()`/`StateRes` contract) silently dropped the
   per-solver `AlgoConfig` (scaling/refactor policy, line-search tolerances, etc. --

--- a/lightsim2grid/tests/test_binary_serialization.py
+++ b/lightsim2grid/tests/test_binary_serialization.py
@@ -413,6 +413,78 @@ class TestBinarySerialization(unittest.TestCase):
                 type(grid).load_binary(garbage_path)
 
 
+class TestCorruptionSweep(unittest.TestCase):
+    """Deterministic mini-fuzzer for load_binary: corrupt a valid file at
+    EVERY byte offset and check the loader never does anything worse than
+    raising a clean RuntimeError.
+
+    Loading a corrupted file has exactly two acceptable outcomes: success
+    (the corruption hit payload data and produced a different but structurally
+    valid grid) or RuntimeError (the corruption was detected). A segfault, a
+    MemoryError (a corrupted count being trusted before any bounds check) or
+    any other exception type is a bug in the reader. This test is most potent
+    in the ASan+UBSan CI job (.github/workflows/sanitizers.yml), where any
+    out-of-bounds read also becomes a hard failure even if it would not have
+    crashed a regular build.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        with warnings.catch_warnings():
+            warnings.filterwarnings("ignore")
+            env = grid2op.make("l2rpn_case14_sandbox", test=True, backend=LightSimBackend())
+        cls.grid_cls = type(env.backend._grid)
+        cls.tmpdir = tempfile.TemporaryDirectory()
+        path = os.path.join(cls.tmpdir.name, "sweep_reference.lsb")
+        env.backend._grid.save_binary(path)
+        with open(path, "rb") as f:
+            cls.data = f.read()
+        env.close()
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.tmpdir.cleanup()
+
+    def _check_load(self, corrupted, description):
+        bad_path = os.path.join(self.tmpdir.name, "sweep_corrupted.lsb")
+        with open(bad_path, "wb") as f:
+            f.write(corrupted)
+        try:
+            self.grid_cls.load_binary(bad_path)
+        except RuntimeError:
+            pass  # corruption detected and rejected cleanly: fine
+        except BaseException as exc:
+            self.fail(f"{description}: load_binary raised {type(exc).__name__} "
+                      f"instead of RuntimeError: {exc}")
+
+    def test_single_byte_flips(self):
+        """Invert one byte at every offset of the file."""
+        for offset in range(len(self.data)):
+            corrupted = bytearray(self.data)
+            corrupted[offset] ^= 0xFF
+            self._check_load(bytes(corrupted), f"byte flip at offset {offset}")
+
+    def test_uint64_stamps(self):
+        """Stamp 8 bytes of 0xFF at every offset: turns any count/length
+        field it lands on into a huge value, the worst case for the
+        bounds-checked allocations."""
+        for offset in range(len(self.data) - 7):
+            corrupted = bytearray(self.data)
+            corrupted[offset:offset + 8] = b"\xff" * 8
+            self._check_load(bytes(corrupted), f"0xFF uint64 stamp at offset {offset}")
+
+    def test_truncations(self):
+        """Cut the file at every length: must always raise RuntimeError
+        (a strictly shorter file can never be a complete state)."""
+        for length in range(len(self.data)):
+            bad_path = os.path.join(self.tmpdir.name, "sweep_truncated.lsb")
+            with open(bad_path, "wb") as f:
+                f.write(self.data[:length])
+            with self.assertRaises(RuntimeError,
+                                   msg=f"no error for a file truncated at {length} bytes"):
+                self.grid_cls.load_binary(bad_path)
+
+
 class TestSerializedEnumValues(unittest.TestCase):
     """The integer values of these C++ enums are written verbatim into the
     binary files (and into pickles), so they are part of the serialized

--- a/src/bindings/python/CMakeLists.txt
+++ b/src/bindings/python/CMakeLists.txt
@@ -55,6 +55,23 @@ target_include_directories(lightsim2grid_cpp PRIVATE
 
 target_link_libraries(lightsim2grid_cpp PRIVATE lightsim2grid_core)
 
+# CI hardening builds (see .github/workflows/sanitizers.yml). The env vars are
+# read again here (rather than relying on the USE_SANITIZERS/USE_DEBUG_ASSERTS
+# options defined in src/core/CMakeLists.txt) so the flags also apply when
+# lightsim2grid_core is imported pre-built and src/core is never processed.
+if(NOT MSVC)
+    set(ENV_SANITIZE "$ENV{__SANITIZE}")
+    if(ENV_SANITIZE STREQUAL "1" OR ENV_SANITIZE STREQUAL "True")
+        target_compile_options(lightsim2grid_cpp PRIVATE
+            -fsanitize=address,undefined -fno-omit-frame-pointer -g -O1)
+        target_link_options(lightsim2grid_cpp PRIVATE -fsanitize=address,undefined)
+    endif()
+    set(ENV_DEBUG_ASSERTS "$ENV{__DEBUG_ASSERTS}")
+    if(ENV_DEBUG_ASSERTS STREQUAL "1" OR ENV_DEBUG_ASSERTS STREQUAL "True")
+        target_compile_options(lightsim2grid_cpp PRIVATE -UNDEBUG -D_GLIBCXX_ASSERTIONS)
+    endif()
+endif()
+
 if(APPLE)
     set(_LS2G_RPATH "@loader_path")
 elseif(NOT WIN32)

--- a/src/core/BinaryArchive.cpp
+++ b/src/core/BinaryArchive.cpp
@@ -8,7 +8,7 @@
 
 #include "BinaryArchive.hpp"
 
-#include <cstdio>   // std::remove, std::rename
+#include <cstdio>   // std::remove, std::rename, std::snprintf
 #include <cstring>
 #include <sstream>
 #include <stdexcept>
@@ -42,6 +42,29 @@ std::string supported_formats_str()
         oss << f;
         first = false;
     }
+    return oss.str();
+}
+
+// Strings read from a (possibly corrupted) file must be escaped before being
+// embedded in an exception message: pybind11 converts what() to a python str
+// as UTF-8, and raw garbage bytes would turn the intended RuntimeError into a
+// UnicodeDecodeError (found by the corruption-sweep test). Also truncated,
+// so a corrupted length cannot produce a message megabytes long.
+std::string printable(const std::string & s)
+{
+    const std::size_t max_len = 64;
+    std::ostringstream oss;
+    for (std::size_t i = 0; i < s.size() && i < max_len; ++i) {
+        const unsigned char c = static_cast<unsigned char>(s[i]);
+        if (c >= 0x20 && c < 0x7f) {
+            oss << static_cast<char>(c);
+        } else {
+            char buf[8];
+            std::snprintf(buf, sizeof(buf), "\\x%02x", c);
+            oss << buf;
+        }
+    }
+    if (s.size() > max_len) oss << "... (" << s.size() << " chars)";
     return oss.str();
 }
 
@@ -206,7 +229,7 @@ void BinaryArchive::check_header(const std::string & type_tag,
     if (!is_format_supported(file_format)) {
         std::ostringstream oss;
         oss << "BinaryArchive: incompatible file '" << path_ << "': it was written by lightsim2grid version "
-            << file_major << "." << file_medium << "." << file_minor
+            << printable(file_major) << "." << printable(file_medium) << "." << printable(file_minor)
             << " using binary format " << file_format
             << ", but the currently installed lightsim2grid (version "
             << v_major << "." << v_medium << "." << v_minor
@@ -219,7 +242,7 @@ void BinaryArchive::check_header(const std::string & type_tag,
     if (file_tag != type_tag) {
         std::ostringstream oss;
         oss << "BinaryArchive: wrong object type in file '" << path_ << "': it contains a '"
-            << file_tag << "', not a '" << type_tag << "'.";
+            << printable(file_tag) << "', not a '" << type_tag << "'.";
         throw std::runtime_error(oss.str());
     }
 }

--- a/src/core/BinaryArchive.hpp
+++ b/src/core/BinaryArchive.hpp
@@ -232,11 +232,28 @@ struct is_raw_vector_elem : std::integral_constant<bool,
 template<typename T, typename Enable = void>
 struct ValueArchiver;  // intentionally incomplete: every real field type below has a specialization
 
-// arithmetic scalars (real_type, int, bool, ...)
+// arithmetic scalars (real_type, int, ...)
 template<typename T>
 struct ValueArchiver<T, typename std::enable_if<std::is_arithmetic<T>::value>::type> {
     static void write(BinaryArchive & ar, const T & v) { ar.write_scalar(v); }
     static void read(BinaryArchive & ar, T & v) { ar.read_scalar(v); }
+};
+
+// bool: one byte on disk (same size as before), but normalized to 0/1 on
+// read. Reading a corrupted byte straight into a bool object would create
+// a bool holding eg 255, and merely loading such a value later is undefined
+// behavior (found by UBSan under the corruption-sweep test).
+template<>
+struct ValueArchiver<bool> {
+    static void write(BinaryArchive & ar, const bool & v) {
+        const std::uint8_t b = v ? 1 : 0;
+        ar.write_scalar(b);
+    }
+    static void read(BinaryArchive & ar, bool & v) {
+        std::uint8_t b = 0;
+        ar.read_scalar(b);
+        v = (b != 0);
+    }
 };
 
 // cplx_type (std::complex<real_type>), standard-guaranteed layout

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -254,6 +254,24 @@ else()
     option(USE_O3_OPTIM "Enable O3 optimization" ON)
 endif()
 
+# CI hardening builds (see .github/workflows/sanitizers.yml), not meant for
+# distributed wheels. __SANITIZE=1 compiles with ASan+UBSan; __DEBUG_ASSERTS=1
+# re-enables the assertions Release builds silence with NDEBUG (Eigen bounds
+# checks) plus the ABI-safe libstdc++ hardening checks.
+set(ENV_SANITIZE "$ENV{__SANITIZE}")
+if(ENV_SANITIZE STREQUAL "1" OR ENV_SANITIZE STREQUAL "True")
+    option(USE_SANITIZERS "Compile with AddressSanitizer + UBSan" ON)
+else()
+    option(USE_SANITIZERS "Compile with AddressSanitizer + UBSan" OFF)
+endif()
+
+set(ENV_DEBUG_ASSERTS "$ENV{__DEBUG_ASSERTS}")
+if(ENV_DEBUG_ASSERTS STREQUAL "1" OR ENV_DEBUG_ASSERTS STREQUAL "True")
+    option(USE_DEBUG_ASSERTS "Re-enable NDEBUG-silenced assertions (Eigen bounds checks, _GLIBCXX_ASSERTIONS)" ON)
+else()
+    option(USE_DEBUG_ASSERTS "Re-enable NDEBUG-silenced assertions (Eigen bounds checks, _GLIBCXX_ASSERTIONS)" OFF)
+endif()
+
 
 # =============================================================================
 # Core library sources
@@ -361,6 +379,18 @@ if(NOT MSVC)
     endif()
     if(USE_MARCH_NATIVE)
         target_compile_options(lightsim2grid_core PRIVATE -march=native)
+    endif()
+    if(USE_SANITIZERS)
+        # placed after the -O3 block on purpose: the later -O1 wins, keeping
+        # ASan stack traces / line info usable
+        target_compile_options(lightsim2grid_core PRIVATE
+            -fsanitize=address,undefined -fno-omit-frame-pointer -g -O1)
+        target_link_options(lightsim2grid_core PRIVATE -fsanitize=address,undefined)
+    endif()
+    if(USE_DEBUG_ASSERTS)
+        # -UNDEBUG comes after CMAKE_CXX_FLAGS_RELEASE's -DNDEBUG on the
+        # command line, so Eigen's bounds assertions come back to life
+        target_compile_options(lightsim2grid_core PRIVATE -UNDEBUG -D_GLIBCXX_ASSERTIONS)
     endif()
 else()
     if(USE_O3_OPTIM)

--- a/src/core/SubstationContainer.cpp
+++ b/src/core/SubstationContainer.cpp
@@ -47,15 +47,15 @@ void SubstationContainer::set_state(SubstationContainer::StateRes & my_state)
     // TODO dev switches
 
     // assign data
-    sub_vn_kv_ = RealVect::Map(&sub_vn_kv[0], sub_vn_kv.size());
+    sub_vn_kv_ = RealVect::Map(sub_vn_kv.data(), sub_vn_kv.size());
     bus_status_ = bus_status;
-    bus_vn_kv_ = RealVect::Map(&bus_vn_kv[0], bus_vn_kv.size());
+    bus_vn_kv_ = RealVect::Map(bus_vn_kv.data(), bus_vn_kv.size());
     sub_names_ = std::get<5>(my_state);
 
     std::vector<real_type> & bus_vmin_kv = std::get<6>(my_state);
     std::vector<real_type> & bus_vmax_kv = std::get<7>(my_state);
-    bus_vmin_kv_ = bus_vmin_kv.empty() ? RealVect() : RealVect::Map(&bus_vmin_kv[0], bus_vmin_kv.size());
-    bus_vmax_kv_ = bus_vmax_kv.empty() ? RealVect() : RealVect::Map(&bus_vmax_kv[0], bus_vmax_kv.size());
+    bus_vmin_kv_ = bus_vmin_kv.empty() ? RealVect() : RealVect::Map(bus_vmin_kv.data(), bus_vmin_kv.size());
+    bus_vmax_kv_ = bus_vmax_kv.empty() ? RealVect() : RealVect::Map(bus_vmax_kv.data(), bus_vmax_kv.size());
 }
 
 void SubstationContainer::save_binary(const std::string & path, bool atomic) const {

--- a/src/core/element_container/ConverterStationContainer.cpp
+++ b/src/core/element_container/ConverterStationContainer.cpp
@@ -110,13 +110,13 @@ void ConverterStationContainer::set_state(ConverterStationContainer::StateRes & 
     check_size(max_q, size, "max_q");
     check_size(power_factor, size, "power_factor");
 
-    type_ = IntVect::Map(&type[0], type.size());
-    loss_factor_ = RealVect::Map(&loss_factor[0], loss_factor.size());
+    type_ = IntVect::Map(type.data(), type.size());
+    loss_factor_ = RealVect::Map(loss_factor.data(), loss_factor.size());
     voltage_regulator_on_ = voltage_regulator_on;
-    target_vm_pu_ = RealVect::Map(&vm_pu[0], vm_pu.size());
-    min_q_ = RealVect::Map(&min_q[0], min_q.size());
-    max_q_ = RealVect::Map(&max_q[0], max_q.size());
-    power_factor_ = RealVect::Map(&power_factor[0], power_factor.size());
+    target_vm_pu_ = RealVect::Map(vm_pu.data(), vm_pu.size());
+    min_q_ = RealVect::Map(min_q.data(), min_q.size());
+    max_q_ = RealVect::Map(max_q.data(), max_q.size());
+    power_factor_ = RealVect::Map(power_factor.data(), power_factor.size());
     reset_results();
 }
 

--- a/src/core/element_container/GeneratorContainer.cpp
+++ b/src/core/element_container/GeneratorContainer.cpp
@@ -117,12 +117,12 @@ void GeneratorContainer::set_state(GeneratorContainer::StateRes & my_state)
 
     // assign data
     voltage_regulator_on_ = voltage_regulator_on;
-    target_vm_pu_ = RealVect::Map(&vm_pu[0], vm_pu.size());
-    min_q_ = RealVect::Map(&min_q[0], min_q.size());
-    max_q_ = RealVect::Map(&max_q[0], max_q.size());
+    target_vm_pu_ = RealVect::Map(vm_pu.data(), vm_pu.size());
+    min_q_ = RealVect::Map(min_q.data(), min_q.size());
+    max_q_ = RealVect::Map(max_q.data(), max_q.size());
     gen_slackbus_ = slack_bus;
     gen_slack_weight_ = slack_weight;
-    regulated_bus_id_ = Eigen::VectorXi::Map(&regulated_bus[0], regulated_bus.size());
+    regulated_bus_id_ = Eigen::VectorXi::Map(regulated_bus.data(), regulated_bus.size());
     reset_results();
 }
 
@@ -548,7 +548,7 @@ void GeneratorContainer::update_slack_weights(
     {
         if(could_be_slack(gen_id)) gen_slack_id.push_back(gen_id);
     }
-    Eigen::Ref<const IntVect> gen_slack_id_ref = IntVect::Map(&gen_slack_id[0], gen_slack_id.size());
+    Eigen::Ref<const IntVect> gen_slack_id_ref = IntVect::Map(gen_slack_id.data(), gen_slack_id.size());
     update_slack_weights_by_id(
         gen_slack_id_ref,
         solver_control);

--- a/src/core/element_container/HvdcLineContainer.cpp
+++ b/src/core/element_container/HvdcLineContainer.cpp
@@ -216,18 +216,18 @@ void HvdcLineContainer::set_state(HvdcLineContainer::StateRes & my_state)
     check_size(pmax_2to1_mw, size, "pmax_2to1_mw");
     check_size(status_droop, size, "status_droop");
 
-    loss_percent_ = RealVect::Map(&loss_percent[0], loss_percent.size());
-    loss_mw_ = RealVect::Map(&loss_mw[0], loss_mw.size());
-    converters_mode_ = IntVect::Map(&converters_mode[0], converters_mode.size());
-    p_setpoint_mw_ = RealVect::Map(&p_setpoint_mw[0], p_setpoint_mw.size());
-    r_ohm_ = RealVect::Map(&r_ohm[0], r_ohm.size());
-    nominal_v_kv_ = RealVect::Map(&nominal_v_kv[0], nominal_v_kv.size());
+    loss_percent_ = RealVect::Map(loss_percent.data(), loss_percent.size());
+    loss_mw_ = RealVect::Map(loss_mw.data(), loss_mw.size());
+    converters_mode_ = IntVect::Map(converters_mode.data(), converters_mode.size());
+    p_setpoint_mw_ = RealVect::Map(p_setpoint_mw.data(), p_setpoint_mw.size());
+    r_ohm_ = RealVect::Map(r_ohm.data(), r_ohm.size());
+    nominal_v_kv_ = RealVect::Map(nominal_v_kv.data(), nominal_v_kv.size());
     droop_enabled_ = droop_enabled;
-    p0_mw_ = RealVect::Map(&p0_mw[0], p0_mw.size());
-    k_mw_per_rad_ = RealVect::Map(&k_mw_per_rad[0], k_mw_per_rad.size());
-    pmax_1to2_mw_ = RealVect::Map(&pmax_1to2_mw[0], pmax_1to2_mw.size());
-    pmax_2to1_mw_ = RealVect::Map(&pmax_2to1_mw[0], pmax_2to1_mw.size());
-    status_droop_ = IntVect::Map(&status_droop[0], status_droop.size());
+    p0_mw_ = RealVect::Map(p0_mw.data(), p0_mw.size());
+    k_mw_per_rad_ = RealVect::Map(k_mw_per_rad.data(), k_mw_per_rad.size());
+    pmax_1to2_mw_ = RealVect::Map(pmax_1to2_mw.data(), pmax_1to2_mw.size());
+    pmax_2to1_mw_ = RealVect::Map(pmax_2to1_mw.data(), pmax_2to1_mw.size());
+    status_droop_ = IntVect::Map(status_droop.data(), status_droop.size());
     reset_results();
 }
 

--- a/src/core/element_container/OneSideContainer.hpp
+++ b/src/core/element_container/OneSideContainer.hpp
@@ -381,13 +381,13 @@ class OneSideContainer : public GenericContainer
             {
                 const std::vector<int> & subid = std::get<4>(my_state);
                 check_size(subid, size, "subid");
-                subid_ = IntVect::Map(&subid[0], subid.size());
+                subid_ = IntVect::Map(subid.data(), subid.size());
             }
             if(has_topo_vect_info)
             {
                 const std::vector<int> & topo_vect = std::get<6>(my_state);
                 check_size(topo_vect, size, "topo_vect");
-                pos_topo_vect_ = IntVect::Map(&topo_vect[0], topo_vect.size());
+                pos_topo_vect_ = IntVect::Map(topo_vect.data(), topo_vect.size());
             }
 
             // input data

--- a/src/core/element_container/OneSideContainer_PQ.hpp
+++ b/src/core/element_container/OneSideContainer_PQ.hpp
@@ -150,8 +150,8 @@ class OneSideContainer_PQ : public OneSideContainer
             check_size(q_mvar, size, "q_mvar");
 
             // input data
-            target_p_mw_ = RealVect::Map(&p_mw[0], p_mw.size());
-            target_q_mvar_ = RealVect::Map(&q_mvar[0], q_mvar.size());
+            target_p_mw_ = RealVect::Map(p_mw.data(), p_mw.size());
+            target_q_mvar_ = RealVect::Map(q_mvar.data(), q_mvar.size());
 
             // initialize properly the right "results" vectors (ie res_XXX RealVect)
             this->reset_results();

--- a/src/core/element_container/SGenContainer.cpp
+++ b/src/core/element_container/SGenContainer.cpp
@@ -61,10 +61,10 @@ void SGenContainer::set_state(SGenContainer::StateRes & my_state )
     GenericContainer::check_size(q_min, size, "q_min");
     GenericContainer::check_size(q_max, size, "q_max");
 
-    p_min_mw_ = RealVect::Map(&p_min[0], size);
-    p_max_mw_ = RealVect::Map(&p_max[0], size);
-    q_min_mvar_ = RealVect::Map(&q_min[0], size);
-    q_max_mvar_ = RealVect::Map(&q_max[0], size);
+    p_min_mw_ = RealVect::Map(p_min.data(), size);
+    p_max_mw_ = RealVect::Map(p_max.data(), size);
+    q_min_mvar_ = RealVect::Map(q_min.data(), size);
+    q_max_mvar_ = RealVect::Map(q_max.data(), size);
     reset_results();
 }
 

--- a/src/core/element_container/SvcContainer.cpp
+++ b/src/core/element_container/SvcContainer.cpp
@@ -76,12 +76,12 @@ void SvcContainer::set_state(SvcContainer::StateRes & my_state)
     check_size(bmax, size, "b_max");
     check_size(regulated_bus, size, "regulated_bus");
 
-    regulation_mode_ = IntVect::Map(&mode[0], mode.size());
-    target_vm_pu_ = RealVect::Map(&vm_pu[0], vm_pu.size());
-    slope_pu_ = RealVect::Map(&slope[0], slope.size());
-    b_min_ = RealVect::Map(&bmin[0], bmin.size());
-    b_max_ = RealVect::Map(&bmax[0], bmax.size());
-    regulated_bus_id_ = Eigen::VectorXi::Map(&regulated_bus[0], regulated_bus.size());
+    regulation_mode_ = IntVect::Map(mode.data(), mode.size());
+    target_vm_pu_ = RealVect::Map(vm_pu.data(), vm_pu.size());
+    slope_pu_ = RealVect::Map(slope.data(), slope.size());
+    b_min_ = RealVect::Map(bmin.data(), bmin.size());
+    b_max_ = RealVect::Map(bmax.data(), bmax.size());
+    regulated_bus_id_ = Eigen::VectorXi::Map(regulated_bus.data(), regulated_bus.size());
     reset_results();
 }
 

--- a/src/core/element_container/TrafoContainer.cpp
+++ b/src/core/element_container/TrafoContainer.cpp
@@ -116,8 +116,8 @@ void TrafoContainer::set_state(TrafoContainer::StateRes & my_state)
     GenericContainer::check_size(is_tap_side1, size, "is_tap_side1");
     GenericContainer::check_size(shift, size, "shift");
 
-    ratio_  = RealVect::Map(&ratio[0], size);
-    shift_  = RealVect::Map(&shift[0], size);
+    ratio_  = RealVect::Map(ratio.data(), size);
+    shift_  = RealVect::Map(shift.data(), size);
     is_tap_side1_ = is_tap_side1;
     ignore_tap_side_for_shift_ = std::get<4>(my_state);
 
@@ -126,8 +126,8 @@ void TrafoContainer::set_state(TrafoContainer::StateRes & my_state)
     std::vector<real_type> & base_x = std::get<7>(my_state);
     GenericContainer::check_size(base_r, size, "base_r");
     GenericContainer::check_size(base_x, size, "base_x");
-    base_r_ = RealVect::Map(&base_r[0], size);
-    base_x_ = RealVect::Map(&base_x[0], size);
+    base_r_ = RealVect::Map(base_r.data(), size);
+    base_x_ = RealVect::Map(base_x.data(), size);
     rx_corr_alpha_ = std::get<8>(my_state);
     rx_corr_pct_ = std::get<9>(my_state);
 

--- a/src/core/element_container/TwoSidesContainer_rxh_A.hpp
+++ b/src/core/element_container/TwoSidesContainer_rxh_A.hpp
@@ -848,22 +848,22 @@ class TwoSidesContainer_rxh_A: public TwoSidesContainer<OneSideType>
             check_size(branch_h1, size, "branch h (=g+j.b), side 1");
             check_size(branch_h2, size, "branch h (=g+j.b), side 2");
 
-            r_ = RealVect::Map(&branch_r[0], size);
-            x_ = RealVect::Map(&branch_x[0], size);
-            h_side_1_ = CplxVect::Map(&branch_h1[0], size);
-            h_side_2_ = CplxVect::Map(&branch_h2[0], size);
+            r_ = RealVect::Map(branch_r.data(), size);
+            x_ = RealVect::Map(branch_x.data(), size);
+            h_side_1_ = CplxVect::Map(branch_h1.data(), size);
+            h_side_2_ = CplxVect::Map(branch_h2.data(), size);
 
             const std::vector<real_type> & limit_a1_ka = std::get<5>(my_state);
             const std::vector<real_type> & limit_a2_ka = std::get<6>(my_state);
             if(limit_a1_ka.size() > 0){
                 check_size(limit_a1_ka, size, "limit_a1_ka");
-                limit_a1_ka_ = RealVect::Map(&limit_a1_ka[0], size);
+                limit_a1_ka_ = RealVect::Map(limit_a1_ka.data(), size);
             } else {
                 limit_a1_ka_ = RealVect();
             }
             if(limit_a2_ka.size() > 0){
                 check_size(limit_a2_ka, size, "limit_a2_ka");
-                limit_a2_ka_ = RealVect::Map(&limit_a2_ka[0], size);
+                limit_a2_ka_ = RealVect::Map(limit_a2_ka.data(), size);
             } else {
                 limit_a2_ka_ = RealVect();
             }


### PR DESCRIPTION
## What this PR does

Adds CI that can spot memory issues (out-of-bounds, undefined behaviour, allocator misuse) that the functional suites on CircleCI cannot see — plus fixes for the real bugs this tooling found on its very first run.

**Note:** was originally stacked on #144 (the corruption-sweep test relies on the bounds-checked binary reader introduced there); now that #144 is merged, the branch has been rebased onto `n1_full_compute` and the diff is only the CI work + UB fixes. First run of the new workflow was green: [Sanitizers run #1](https://github.com/Grid2op/lightsim2grid/actions/runs/29168080768) (ASan+UBSan: 13 min, debug-asserts: 7 min).

### New workflow `.github/workflows/sanitizers.yml` (GitHub Actions, on every push)

- **ASan + UBSan job**: builds with `__SANITIZE=1` (new CMake option, same env-var pattern as `__O3_OPTIM`: `-fsanitize=address,undefined -fno-omit-frame-pointer -g -O1` on `lightsim2grid_core` and `lightsim2grid_cpp`), then runs the binary serialization, solver control, time series and contingency/security analysis test modules (302 tests) under the sanitizers. Two runtime subtleties are handled and documented in the workflow: `LD_PRELOAD` must include **libstdc++ along with libasan** (python does not link libstdc++, and without it ASan's `__cxa_throw` interceptor aborts on the first C++ exception), and `ASAN_OPTIONS=detect_leaks=0` (CPython's allocator makes leak reports pure noise).
- **Debug-assertions job**: builds with `__DEBUG_ASSERTS=1` → `-UNDEBUG -D_GLIBCXX_ASSERTIONS`, re-enabling the **Eigen bounds assertions** that Release builds silence with `NDEBUG` (verified: Eigen's assert strings are present in this build, absent in a normal one), plus the ABI-safe libstdc++ container checks. Runs the solver-heavy modules (`test_ACPF`, `test_DCPF`, `test_solver_control`) — this catches logically-wrong-but-in-bounds Eigen indexing that ASan cannot see.
- Trigger uses `branches: '**'` — a single `'*'` does not match `/` in Actions globs, so topic branches like `foo/bar` would silently never run (this also affects `main.yml`, left untouched here).

### New corruption-sweep test (deterministic mini-fuzzer)

`TestCorruptionSweep` in `test_binary_serialization.py`: takes a valid saved grid and corrupts it at **every byte offset** (single-byte flips, 8-byte `0xFF` stamps, truncation at every length — ~14k loads, a few seconds). Each load must either succeed or raise a clean `RuntimeError`; a segfault, `MemoryError` or any other exception type fails the test. It also runs in the existing CircleCI full suite, and is most potent inside the ASan job.

### Bugs found by this tooling and fixed here

- **50 sites** of `Eigen::Map(&vec[0], vec.size())` across the element containers: undefined behaviour whenever the vector is empty (flagged by UBSan in `SubstationContainer::set_state`; also reachable through pickle). Fixed to `vec.data()`.
- `BinaryArchive` deserialized `bool` as a raw byte: a corrupted byte yields a `bool` holding 255, and merely loading such a value is UB (7 sites flagged). Bools are now normalized through `uint8_t` (same 1-byte on-disk size, no format change).
- Corrupted header strings flowed un-escaped into exception messages, so pybind11 raised `UnicodeDecodeError` instead of the intended `RuntimeError`. Messages now escape non-printable bytes and are length-capped.

## Testing

- Local run of the exact ASan job commands: 302 tests OK under ASan+UBSan, no reports (7 min 18 s).
- Local debug-asserts build: 229 solver tests OK; differential `strings` check proves the Eigen assertions are compiled in.
- After the rebase onto the merged #144: 29/29 binary-serialization tests pass locally.
- `CHANGELOG.rst` updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XjPTtnmQ7Yrf6jcEyfhqSN