### PR TITLE
Dedicated C++ unit tests (Catch2 + valgrind) for BinaryArchive and LSGrid, plus C++-library docs

### DIFF
--- a/.github/workflows/cpp_unit_tests.yml
+++ b/.github/workflows/cpp_unit_tests.yml
@@ -1,0 +1,50 @@
+# C++ unit tests: builds the Catch2 suite under src/tests/ (the archive layer
+# compiled straight into a small test binary -- no python, no pip, no solver
+# deps) and runs it twice: once through ctest, once under valgrind. Being a
+# plain binary makes valgrind practical here (--error-exitcode=1 turns any
+# memory error into a CI failure), which it is not over the python test suite
+# (10-50x slowdown plus CPython suppressions). Complements the Sanitizers
+# workflow, which exercises the full python extension.
+
+name: C++ unit tests
+
+on:
+  push:
+    branches:
+      # '**' and not '*': a single '*' does not match '/' in GitHub Actions
+      # globs, so topic branches like 'foo/bar' would silently never run
+      - '**'
+    tags:
+      - 'v*.*.*'
+
+jobs:
+  cpp_unit_tests:
+    name: Catch2 + valgrind
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # eigen (transitive include of the core headers) and Catch2
+          submodules: true
+
+      - name: Install valgrind
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y valgrind
+
+      - name: Configure
+        # standalone test project: no python, pybind11 or KLU involved.
+        # Debug keeps assert() live and gives valgrind full line info.
+        run: cmake -S src/tests -B build_tests -DCMAKE_BUILD_TYPE=Debug
+
+      - name: Build
+        run: cmake --build build_tests -j$(nproc)
+
+      - name: Run tests
+        run: ctest --test-dir build_tests --output-on-failure
+
+      - name: Run tests under valgrind
+        run: |
+          cd build_tests
+          valgrind --error-exitcode=1 --leak-check=full --track-origins=yes \
+            ./lightsim2grid_unit_tests

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ __pycache__/
 # Distribution / packaging
 .Python
 build/
+build_tests/
 develop-eggs/
 dist/
 downloads/

--- a/.gitmodules
+++ b/.gitmodules
@@ -6,3 +6,7 @@
 	path = eigen
 	url = https://gitlab.com/libeigen/eigen.git
 	ignore = dirty
+[submodule "Catch2"]
+	path = Catch2
+	url = https://github.com/catchorg/Catch2.git
+	ignore = dirty

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -443,7 +443,14 @@ TODO: integration test with pandapower (see `pandapower/contingency/contingency.
   (converged => per-bus V, diverged => empty vector), physically-checked
   results (power balance, analytic DC angles), copy / `get_state` /
   `save_binary` round trips, setpoint changes, load deactivation and the
-  documented error paths. The test target now links `lightsim2grid_core`.
+  documented error paths. Also covers every other element type and control
+  scenario: shunts, storage units, SVCs (all three regulation modes), HVDC
+  (VSC-VSC with and without angle droop, voltage-regulating VSC, LCC power
+  factor, LCC+droop rejection), transformers (tap ratio and phase shifter,
+  incl. the `change_ratio_trafo` / `change_shift_trafo` setters), distributed
+  slack, remote generator voltage control and the rejection of an unfeasible
+  local+remote controller pair on one bus. The test target now links
+  `lightsim2grid_core`.
 - [ADDED] documentation for using `lightsim2grid_core` as a standalone C++
   library (`docs/cpp_library.rst`): building/installing it from source
   (`cmake -S src/core`), consuming the copy shipped inside the python wheel

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -437,6 +437,25 @@ TODO: integration test with pandapower (see `pandapower/contingency/contingency.
   (`.github/workflows/cpp_unit_tests.yml`) -- practical only because the
   suite is a small plain binary. This is also the first framework for C++
   unit tests of the core (eg future solver-level tests).
+- [ADDED] C++ unit tests for the `LSGrid` main API (`src/tests/test_lsgrid.cpp`):
+  a 3-bus grid built programmatically through the `init_*` methods and solved
+  with the default Eigen SparseLU algorithms -- AC/DC powerflow contract
+  (converged => per-bus V, diverged => empty vector), physically-checked
+  results (power balance, analytic DC angles), copy / `get_state` /
+  `save_binary` round trips, setpoint changes, load deactivation and the
+  documented error paths. The test target now links `lightsim2grid_core`.
+- [ADDED] documentation for using `lightsim2grid_core` as a standalone C++
+  library (`docs/cpp_library.rst`): building/installing it from source
+  (`cmake -S src/core`), consuming the copy shipped inside the python wheel
+  (`lightsim2grid.get_cmake_dir()`), linking with CMake via
+  `find_package(lightsim2grid_core CONFIG)` / `lightsim2grid::core`, a
+  complete build-a-grid-and-solve example, and how to run the C++ unit tests.
+- [FIXED] `TrafoContainer` left two bool members (`ignore_tap_side_for_shift_`,
+  `shift_dependent_rx_`) uninitialized when `init_trafo` was never called (any
+  grid built without trafos): copying or serializing such a grid read
+  indeterminate bools (undefined behavior, garbage written into binary files /
+  pickles). Found by valgrind over the new C++ LSGrid tests; both members now
+  have default initializers.
 - [FIXED] `LSGrid.save_binary`/`load_binary` (and pickle, which shares the same
   `LSGrid::get_state()`/`set_state()`/`StateRes` contract) silently dropped the
   per-solver `AlgoConfig` (scaling/refactor policy, line-search tolerances, etc. --

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -427,6 +427,16 @@ TODO: integration test with pandapower (see `pandapower/contingency/contingency.
   corruption-sweep test (`TestCorruptionSweep`) that corrupts a valid binary
   file at every byte offset and checks `load_binary` never does anything
   worse than raising a clean `RuntimeError`.
+- [ADDED] a dedicated C++ unit test suite (Catch2, new git submodule, under
+  `src/tests/`) exercising the binary serialization layer (`BinaryArchive`)
+  without python or a real grid: synthetic `StateRes` round trips covering
+  every serialized field shape, every bounds-check / header-mismatch path,
+  the atomic temp-file commit/rollback, and a C++ port of the corruption
+  sweep. Built standalone (`cmake -S src/tests`) or via `BUILD_TESTING=ON`,
+  and run in CI both through ctest and under `valgrind --error-exitcode=1`
+  (`.github/workflows/cpp_unit_tests.yml`) -- practical only because the
+  suite is a small plain binary. This is also the first framework for C++
+  unit tests of the core (eg future solver-level tests).
 - [FIXED] `LSGrid.save_binary`/`load_binary` (and pickle, which shares the same
   `LSGrid::get_state()`/`set_state()`/`StateRes` contract) silently dropped the
   per-solver `AlgoConfig` (scaling/refactor policy, line-search tolerances, etc. --

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -71,6 +71,15 @@ endif()
 # pybind11 extension.
 add_subdirectory("src/bindings/python")
 
+# --- C++ unit tests (Catch2) ---
+# OFF by default so pip / wheel builds are unaffected. The tests can also be
+# configured standalone, without python or pybind11: cmake -S src/tests
+option(BUILD_TESTING "Build the C++ unit tests (src/tests, Catch2)" OFF)
+if(BUILD_TESTING)
+    enable_testing()
+    add_subdirectory("src/tests")
+endif()
+
 # --- Python-only compile definitions (applied after targets exist) ---
 
 # Read The Docs — only affects binding stubs

--- a/docs/cpp_library.rst
+++ b/docs/cpp_library.rst
@@ -23,8 +23,8 @@ Everything is in the ``ls2g`` namespace, headers at the root of
 - ``ls2g::LSGrid`` (``LSGrid.hpp``): the grid model itself -- built
   programmatically through the ``init_*`` methods (buses, powerlines, trafos,
   loads, generators, ...), solved with ``ac_pf`` / ``dc_pf``, inspected with
-  the ``get_*_res`` methods. This is the C++ class exposed to python as
-  ``GridModel``.
+  the ``get_*_res`` methods. This is the C++ class exposed to python under
+  the same name, ``LSGrid``.
 - the element containers (``element_container/*.hpp``), time series and
   contingency analysis (``batch_algorithm/``), the powerflow algorithms
   (``powerflow_algorithm/``) and linear solvers (``linear_solvers/``).
@@ -42,7 +42,7 @@ need your own copy.
 Option 1: use the copy shipped with the python wheel
 -----------------------------------------------------
 
-Every ``pip install lightsim2grid`` (>= 0.14) already contains everything a
+Every ``pip install lightsim2grid`` (>= 1.0) already contains everything a
 C++ consumer needs, inside the installed package directory:
 
 - ``liblightsim2grid_core.so`` (or ``.dylib`` / ``.dll``) next to the python

--- a/docs/cpp_library.rst
+++ b/docs/cpp_library.rst
@@ -1,0 +1,251 @@
+.. _cpp_library:
+
+Using lightsim2grid as a C++ library
+=====================================
+
+Since the split between the C++ core and the python bindings, everything that
+computes in lightsim2grid lives in a standalone shared library called
+``lightsim2grid_core``, with **no dependency on python, pybind11 or grid2op**.
+The python package (``lightsim2grid_cpp``) is only a thin pybind11 wrapper
+around it.
+
+This page documents how to build that library, install it, and link your own
+C++ code against it. If your goal is to plug a custom powerflow algorithm into
+the *python* package, see :ref:`solver_plugin` instead -- this page is about
+consuming the C++ API directly.
+
+What the library contains
+--------------------------
+
+Everything is in the ``ls2g`` namespace, headers at the root of
+``src/core/``. The main entry points:
+
+- ``ls2g::LSGrid`` (``LSGrid.hpp``): the grid model itself -- built
+  programmatically through the ``init_*`` methods (buses, powerlines, trafos,
+  loads, generators, ...), solved with ``ac_pf`` / ``dc_pf``, inspected with
+  the ``get_*_res`` methods. This is the C++ class exposed to python as
+  ``GridModel``.
+- the element containers (``element_container/*.hpp``), time series and
+  contingency analysis (``batch_algorithm/``), the powerflow algorithms
+  (``powerflow_algorithm/``) and linear solvers (``linear_solvers/``).
+- ``AlgorithmRegistry.hpp``: the registry used to add custom powerflow
+  algorithms (see :ref:`solver_plugin`).
+- ``BinaryArchive.hpp``: the fast binary serialization used by
+  ``save_binary`` / ``load_binary`` (see :ref:`binary-serialization`).
+
+The public API is C++14 (the library itself compiles with the newest standard
+your compiler supports, see below). Eigen is part of the public interface
+(vector arguments are ``Eigen::VectorXd`` / ``Eigen::VectorXi`` and friends);
+the matching Eigen headers are shipped alongside the library so you do not
+need your own copy.
+
+Option 1: use the copy shipped with the python wheel
+-----------------------------------------------------
+
+Every ``pip install lightsim2grid`` (>= 0.14) already contains everything a
+C++ consumer needs, inside the installed package directory:
+
+- ``liblightsim2grid_core.so`` (or ``.dylib`` / ``.dll``) next to the python
+  extension;
+- the headers (including the bundled ``Eigen/``) under
+  ``lightsim2grid/include/``;
+- a CMake package config under
+  ``lightsim2grid/share/cmake/lightsim2grid_core/``.
+
+Two python helpers return those paths, so build scripts do not need to
+hard-code anything:
+
+.. code-block:: python
+
+    import lightsim2grid
+    lightsim2grid.get_include()    # .../site-packages/lightsim2grid/include
+    lightsim2grid.get_cmake_dir()  # .../site-packages/lightsim2grid/share/cmake/lightsim2grid_core
+
+Option 2: build and install the core from source
+-------------------------------------------------
+
+``src/core`` is a self-contained CMake project (python is never required):
+
+.. code-block:: bash
+
+    git clone https://github.com/Grid2op/lightsim2grid.git
+    cd lightsim2grid
+    git submodule update --init eigen        # required (header-only)
+    git submodule update --init SuiteSparse  # optional, for the KLU solver
+
+    cmake -S src/core -B build_core -DCMAKE_BUILD_TYPE=Release
+    cmake --build build_core -j
+    cmake --install build_core --prefix /where/you/want/it
+
+The install lays out a standard prefix: ``lib/liblightsim2grid_core.so``,
+``include/lightsim2grid/*.hpp`` (with Eigen bundled next to them) and
+``lib/cmake/lightsim2grid_core/`` (the package config).
+
+About KLU: the build looks for the KLU sparse linear solver four ways (system
+CMake config e.g. ``libsuitesparse-dev``, legacy system libraries, pre-built
+static libraries inside the ``SuiteSparse`` submodule, and finally building it
+from the submodule -- this last strategy needs CMake >= 3.22). **If none
+succeeds the build does not fail**: the library simply falls back to the
+always-available Eigen ``SparseLU`` algorithms (which are also the
+``LSGrid`` defaults), and only the ``*_KLU`` entries of ``AlgorithmType``
+disappear. When KLU is found, ``KLU_SOLVER_AVAILABLE`` is defined on the
+target (and propagated to consumers) and the KLU code is baked into the
+shared library.
+
+A few environment variables tune the compilation, following the same
+convention as the python build: ``__O3_OPTIM`` (``-O3``, on by default),
+``__COMPILE_MARCHNATIVE`` (``-march=native``), ``__SANITIZE``
+(ASan + UBSan) and ``__DEBUG_ASSERTS`` (``-UNDEBUG -D_GLIBCXX_ASSERTIONS``,
+re-enabling the Eigen bounds assertions).
+
+Linking against it with CMake
+------------------------------
+
+The package config exports a single imported target,
+``lightsim2grid::core`` (with ``ls2g::core`` as a convenience alias). A
+minimal consumer:
+
+.. code-block:: cmake
+
+    cmake_minimum_required(VERSION 3.16)
+    project(my_grid_tool LANGUAGES CXX)
+    set(CMAKE_CXX_STANDARD 14)
+
+    find_package(lightsim2grid_core CONFIG REQUIRED)
+
+    add_executable(my_grid_tool main.cpp)
+    target_link_libraries(my_grid_tool PRIVATE lightsim2grid::core)
+
+The imported target carries the include directories (lightsim2grid headers
+*and* the bundled Eigen), the ``Threads`` dependency, and the
+``KLU_SOLVER_AVAILABLE`` definition when the library was built with KLU --
+nothing else to configure.
+
+Point CMake at the config with either of:
+
+.. code-block:: bash
+
+    # a source install (option 2): the prefix you installed into
+    cmake -S . -B build -DCMAKE_PREFIX_PATH=/where/you/want/it
+
+    # the python wheel (option 1): the exact config directory
+    cmake -S . -B build \
+        -Dlightsim2grid_core_DIR=$(python -c "import lightsim2grid; print(lightsim2grid.get_cmake_dir())")
+
+Alternatively, a super-project that vendors the lightsim2grid sources can
+skip ``find_package`` entirely and pull the target in directly (this is what
+the python bindings and the C++ unit tests do):
+
+.. code-block:: cmake
+
+    if(NOT TARGET lightsim2grid_core)
+        add_subdirectory(path/to/lightsim2grid/src/core lightsim2grid_core_build)
+    endif()
+    target_link_libraries(my_grid_tool PRIVATE lightsim2grid_core)
+
+One MSVC-specific note: the headers decorate the API with ``LS2G_API``
+(dllimport when consuming, dllexport when building). This is automatic as
+long as you *link* the library. Only if you compile core ``.cpp`` files
+directly into your own target must you add the ``LS2G_BUILDING_CORE``
+compile definition.
+
+Minimal example
+----------------
+
+Build a 3-bus grid (slack generator, two lines, one load) and solve an AC
+powerflow -- no input file, no python:
+
+.. code-block:: c++
+
+    #include <iostream>
+    #include "LSGrid.hpp"
+
+    int main()
+    {
+        ls2g::LSGrid grid;
+        grid.set_sn_mva(100.);
+
+        // three 138 kV buses (one busbar per substation)
+        ls2g::RealVect bus_vn_kv(3);
+        bus_vn_kv << 138., 138., 138.;
+        grid.init_bus(3, 1, bus_vn_kv, 0, 0);
+
+        // two lines 0-1 and 1-2, r/x/h given in pu on the sn_mva base
+        ls2g::RealVect r(2), x(2);
+        r << 0.01, 0.01;
+        x << 0.10, 0.10;
+        ls2g::CplxVect h = ls2g::CplxVect::Zero(2);
+        Eigen::VectorXi from_id(2), to_id(2);
+        from_id << 0, 1;
+        to_id << 1, 2;
+        grid.init_powerlines(r, x, h, from_id, to_id);
+
+        // a 50 MW / 10 MVar load at bus 2
+        ls2g::RealVect load_p(1), load_q(1);
+        load_p << 50.;
+        load_q << 10.;
+        Eigen::VectorXi load_bus(1);
+        load_bus << 2;
+        grid.init_loads(load_p, load_q, load_bus);
+
+        // a generator at bus 0 (1.02 pu), registered as the slack
+        ls2g::RealVect gen_p(1), gen_v(1), min_q(1), max_q(1);
+        gen_p << 0.;
+        gen_v << 1.02;
+        min_q << -1000.;
+        max_q << 1000.;
+        Eigen::VectorXi gen_bus(1);
+        gen_bus << 0;
+        grid.init_generators(gen_p, gen_v, min_q, max_q, gen_bus);
+        grid.add_gen_slackbus(0, 1.);
+
+        // Newton-Raphson with Eigen SparseLU (the default, KLU not needed)
+        const ls2g::CplxVect Vinit =
+            ls2g::CplxVect::Constant(grid.total_bus(), ls2g::cplx_type(1., 0.));
+        const ls2g::CplxVect V = grid.ac_pf(Vinit, 20, 1e-8);
+
+        if (V.size() == 0) {  // diverged: the result vector is empty
+            std::cerr << "powerflow diverged" << std::endl;
+            return 1;
+        }
+        for (Eigen::Index bus = 0; bus < V.size(); ++bus) {
+            std::cout << "bus " << bus << ": " << std::abs(V(bus)) << " pu, "
+                      << std::arg(V(bus)) << " rad" << std::endl;
+        }
+        const auto gen_res = grid.get_gen_res();  // (p_mw, q_mvar, v_kv)
+        std::cout << "slack injects " << std::get<0>(gen_res)(0) << " MW" << std::endl;
+        return 0;
+    }
+
+Conventions worth knowing (they mirror the python API, which shares this
+code): ``init_powerlines`` takes r/x/h **in pu** on the ``sn_mva`` base;
+loads are in MW / MVar; generator voltage setpoints in pu; ``ac_pf`` /
+``dc_pf`` take a per-bus complex initial voltage of size ``total_bus()`` and
+return the per-bus complex voltage, or an **empty vector when the powerflow
+diverged** (details via ``grid.get_algo().converged()`` /
+``get_error()`` / ``get_nb_iter()``). Errors (bad element ids, wrong
+``Vinit`` size, invalid slack) are reported as ``std::runtime_error`` /
+``std::out_of_range`` exceptions.
+
+The C++ unit tests
+-------------------
+
+The library has its own test suite (Catch2, under ``src/tests/``) covering
+the binary serialization layer and the ``LSGrid`` API above -- the
+``test_lsgrid.cpp`` file doubles as a working example of building and
+solving a grid from C++. It builds standalone in seconds, without python:
+
+.. code-block:: bash
+
+    git submodule update --init eigen Catch2   # SuiteSparse optional
+    cmake -S src/tests -B build_tests -DCMAKE_BUILD_TYPE=Debug
+    cmake --build build_tests -j
+    ctest --test-dir build_tests --output-on-failure
+
+    # the whole suite is a small plain binary: valgrind is practical
+    valgrind --error-exitcode=1 --leak-check=full build_tests/lightsim2grid_unit_tests
+
+The same suite can be enabled from the top-level (python) build with
+``-DBUILD_TESTING=ON`` (off by default: wheels never build it), and runs in
+CI on every push -- once through ctest and once under valgrind
+(``.github/workflows/cpp_unit_tests.yml``).

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -61,6 +61,7 @@ This is a work in progress at the moment
    algorithm_names
    time_series
    security_analysis
+   cpp_library
    solver_plugin
    binary_serialization
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -97,6 +97,11 @@ exclude = [
     "old",
     "wheelhouse",
 
+    # C++ unit tests and the Catch2 submodule they build against — never
+    # compiled by a pip / wheel build (BUILD_TESTING defaults OFF)
+    "Catch2",
+    "src/tests",
+
     # SuiteSparse submodule — only KLU and its direct dependencies are used
     # (SuiteSparse_config, AMD, BTF, COLAMD, CXSparse, KLU are kept).
     "SuiteSparse/CAMD",

--- a/src/core/element_container/TrafoContainer.hpp
+++ b/src/core/element_container/TrafoContainer.hpp
@@ -282,8 +282,13 @@ class LS2G_API TrafoContainer final : public TwoSidesContainer_rxh_A<OneSideCont
          * 
          * This is the default behaviour in pandapower, where the phase shifter
          * is always assigned to side 1.
+         *
+         * Default-initialized: a container whose init_trafo() is never called
+         * (grid without trafos) is still copied and serialized, and an
+         * indeterminate bool there is undefined behavior (found by valgrind
+         * over the C++ unit tests).
          */
-        bool ignore_tap_side_for_shift_;
+        bool ignore_tap_side_for_shift_ = false;
         
         // physical properties
         std::vector<bool> is_tap_side1_;  // whether the tap is hav side or not
@@ -296,7 +301,8 @@ class LS2G_API TrafoContainer final : public TwoSidesContainer_rxh_A<OneSideCont
         // lightsim2grid has no "tap" concept: the per-step r/x correction is stored
         // as a function of the phase-shift `alpha` and looked up by the current
         // `shift_`. Disabled (flag false, empty tables) for pandapower.
-        bool shift_dependent_rx_;
+        // Default-initialized for the same reason as ignore_tap_side_for_shift_.
+        bool shift_dependent_rx_ = false;
         RealVect base_r_;  // neutral (uncorrected) r, per trafo
         RealVect base_x_;  // neutral (uncorrected) x, per trafo
         std::vector<std::vector<real_type> > rx_corr_alpha_;  // per trafo: alpha (rad), ascending

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -1,0 +1,55 @@
+# ---- Standalone guard -------------------------------------------------------
+# Mirrors src/core/CMakeLists.txt: when included via add_subdirectory() from
+# the root CMakeLists (BUILD_TESTING=ON), the project() call is skipped. When
+# invoked as a standalone "cmake -S src/tests", the full project is set up so
+# the C++ unit tests build without python, pybind11 or the pip machinery --
+# this is how the cpp_unit_tests CI workflow builds them.
+if(NOT PROJECT_NAME)
+    cmake_minimum_required(VERSION 3.16...4.99)
+    project(lightsim2grid_tests LANGUAGES CXX)
+
+    if("cxx_std_23" IN_LIST CMAKE_CXX_COMPILE_FEATURES)
+        set(CMAKE_CXX_STANDARD 23)
+    elseif("cxx_std_17" IN_LIST CMAKE_CXX_COMPILE_FEATURES)
+        set(CMAKE_CXX_STANDARD 17)
+    elseif("cxx_std_14" IN_LIST CMAKE_CXX_COMPILE_FEATURES)
+        set(CMAKE_CXX_STANDARD 14)
+    else()
+        message(FATAL_ERROR "lightsim2grid requires at least C++14")
+    endif()
+    set(CMAKE_CXX_STANDARD_REQUIRED ON)
+    set(CMAKE_CXX_EXTENSIONS OFF)
+
+    # Eigen is two levels up (repo root / eigen/)
+    include_directories("${CMAKE_CURRENT_SOURCE_DIR}/../../eigen")
+
+    enable_testing()
+endif()
+
+# Catch2 (repo root / Catch2/ submodule). The guard keeps a future second
+# consumer (or a parent that already provides Catch2) from adding it twice.
+if(NOT TARGET Catch2::Catch2WithMain)
+    add_subdirectory("${CMAKE_CURRENT_SOURCE_DIR}/../../Catch2" "${CMAKE_CURRENT_BINARY_DIR}/catch2")
+endif()
+
+# The archive layer under test is deliberately compiled into the test binary
+# instead of linking lightsim2grid_core: BinaryArchive.cpp is self-contained
+# (see its header), so the tests need neither KLU/SuiteSparse detection nor a
+# shared-library build, and compile in seconds. When solver-level unit tests
+# arrive, link lightsim2grid_core here instead of growing this source list.
+add_executable(lightsim2grid_unit_tests
+    "${CMAKE_CURRENT_SOURCE_DIR}/../core/BinaryArchive.cpp"
+    test_binary_archive.cpp
+    test_binary_archive_stateres.cpp
+    test_binary_archive_corruption.cpp
+)
+target_include_directories(lightsim2grid_unit_tests PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/../core")
+# LS2G_API must resolve to dllexport (not dllimport) on MSVC, since the core
+# translation unit is built into this binary rather than imported from a DLL
+target_compile_definitions(lightsim2grid_unit_tests PRIVATE LS2G_BUILDING_CORE)
+target_link_libraries(lightsim2grid_unit_tests PRIVATE Catch2::Catch2WithMain)
+
+# one ctest entry per TEST_CASE
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/../../Catch2/extras")
+include(Catch)
+catch_discover_tests(lightsim2grid_unit_tests)

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -10,7 +10,12 @@ if(NOT PROJECT_NAME)
     # package version file from PROJECT_VERSION
     project(lightsim2grid_tests VERSION 0.0.0 LANGUAGES CXX)
 
-    if("cxx_std_23" IN_LIST CMAKE_CXX_COMPILE_FEATURES)
+    # cxx_std_26 only appears in CMAKE_CXX_COMPILE_FEATURES when both CMake
+    # (>= 3.30) and the compiler know C++26, so the check is safe with the
+    # 3.16 minimum above: elsewhere it is simply never selected.
+    if("cxx_std_26" IN_LIST CMAKE_CXX_COMPILE_FEATURES)
+        set(CMAKE_CXX_STANDARD 26)
+    elseif("cxx_std_23" IN_LIST CMAKE_CXX_COMPILE_FEATURES)
         set(CMAKE_CXX_STANDARD 23)
     elseif("cxx_std_17" IN_LIST CMAKE_CXX_COMPILE_FEATURES)
         set(CMAKE_CXX_STANDARD 17)

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -6,7 +6,9 @@
 # this is how the cpp_unit_tests CI workflow builds them.
 if(NOT PROJECT_NAME)
     cmake_minimum_required(VERSION 3.16...4.99)
-    project(lightsim2grid_tests LANGUAGES CXX)
+    # the VERSION is required: src/core (added below) generates its CMake
+    # package version file from PROJECT_VERSION
+    project(lightsim2grid_tests VERSION 0.0.0 LANGUAGES CXX)
 
     if("cxx_std_23" IN_LIST CMAKE_CXX_COMPILE_FEATURES)
         set(CMAKE_CXX_STANDARD 23)
@@ -32,22 +34,23 @@ if(NOT TARGET Catch2::Catch2WithMain)
     add_subdirectory("${CMAKE_CURRENT_SOURCE_DIR}/../../Catch2" "${CMAKE_CURRENT_BINARY_DIR}/catch2")
 endif()
 
-# The archive layer under test is deliberately compiled into the test binary
-# instead of linking lightsim2grid_core: BinaryArchive.cpp is self-contained
-# (see its header), so the tests need neither KLU/SuiteSparse detection nor a
-# shared-library build, and compile in seconds. When solver-level unit tests
-# arrive, link lightsim2grid_core here instead of growing this source list.
+# The full core library: needed since the tests exercise LSGrid (powerflow,
+# solvers). Same guard as src/bindings/python/CMakeLists.txt: when added from
+# the root CMakeLists the bindings have already created the target; standalone
+# it is built from src/core (KLU detection included -- the core degrades
+# gracefully to Eigen SparseLU when KLU is not found, and the LSGrid tests
+# only rely on the always-available SparseLU algorithms).
+if(NOT TARGET lightsim2grid_core)
+    add_subdirectory("${CMAKE_CURRENT_SOURCE_DIR}/../core" "${CMAKE_CURRENT_BINARY_DIR}/core")
+endif()
+
 add_executable(lightsim2grid_unit_tests
-    "${CMAKE_CURRENT_SOURCE_DIR}/../core/BinaryArchive.cpp"
     test_binary_archive.cpp
     test_binary_archive_stateres.cpp
     test_binary_archive_corruption.cpp
+    test_lsgrid.cpp
 )
-target_include_directories(lightsim2grid_unit_tests PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/../core")
-# LS2G_API must resolve to dllexport (not dllimport) on MSVC, since the core
-# translation unit is built into this binary rather than imported from a DLL
-target_compile_definitions(lightsim2grid_unit_tests PRIVATE LS2G_BUILDING_CORE)
-target_link_libraries(lightsim2grid_unit_tests PRIVATE Catch2::Catch2WithMain)
+target_link_libraries(lightsim2grid_unit_tests PRIVATE lightsim2grid_core Catch2::Catch2WithMain)
 
 # one ctest entry per TEST_CASE
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/../../Catch2/extras")

--- a/src/tests/test_binary_archive.cpp
+++ b/src/tests/test_binary_archive.cpp
@@ -1,0 +1,381 @@
+// Copyright (c) 2026, RTE (https://www.rte-france.com)
+// See AUTHORS.txt
+// This Source Code Form is subject to the terms of the Mozilla Public License, version 2.0.
+// If a copy of the Mozilla Public License, version 2.0 was not distributed with this file,
+// you can obtain one at http://mozilla.org/MPL/2.0/.
+// SPDX-License-Identifier: MPL-2.0
+// This file is part of LightSim2grid, LightSim2grid implements a c++ backend targeting the Grid2Op platform.
+
+// Low-level BinaryArchive API: primitive round-trips, header / magic / format
+// / tag validation, every require_count path, truncation and trailing-byte
+// detection, and the atomic temp-file commit / rollback lifecycle.
+
+#include <cstdint>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_exception.hpp>
+#include <catch2/matchers/catch_matchers_string.hpp>
+
+#include "BinaryArchive.hpp"
+#include "test_helpers.hpp"
+
+using ls2g::BinaryArchive;
+using ls2g_test::TempFile;
+using Catch::Matchers::ContainsSubstring;
+using Catch::Matchers::MessageMatches;
+
+namespace {
+
+// most tests start from a freshly written file
+void with_written(const std::string & path, void (*writer)(BinaryArchive &))
+{
+    BinaryArchive ar(path, BinaryArchive::Mode::Write);
+    writer(ar);
+    ar.commit();
+}
+
+}  // anonymous namespace
+
+TEST_CASE("scalars round-trip", "[BinaryArchive]")
+{
+    TempFile file;
+    with_written(file.str(), [](BinaryArchive & ar) {
+        ar.write_scalar(std::int32_t(-123));
+        ar.write_scalar(std::uint64_t(1) << 60);
+        ar.write_scalar(2.75);
+        ar.write_scalar(ls2g::cplx_type(1., -1.));
+    });
+
+    BinaryArchive ar(file.str(), BinaryArchive::Mode::Read);
+    std::int32_t i = 0;
+    std::uint64_t u = 0;
+    double d = 0.;
+    ls2g::cplx_type c;
+    ar.read_scalar(i);
+    ar.read_scalar(u);
+    ar.read_scalar(d);
+    ar.read_scalar(c);
+    CHECK(i == -123);
+    CHECK(u == (std::uint64_t(1) << 60));
+    CHECK(d == 2.75);
+    CHECK(c == ls2g::cplx_type(1., -1.));
+    CHECK_NOTHROW(ar.check_fully_consumed());
+}
+
+TEST_CASE("strings round-trip, including empty and embedded NUL", "[BinaryArchive]")
+{
+    TempFile file;
+    const std::string with_nul("a\0b", 3);
+    {
+        BinaryArchive ar(file.str(), BinaryArchive::Mode::Write);
+        ar.write_string("");
+        ar.write_string("plain");
+        ar.write_string(with_nul);
+        ar.commit();
+    }
+    BinaryArchive ar(file.str(), BinaryArchive::Mode::Read);
+    std::string a, b, c;
+    ar.read_string(a);
+    ar.read_string(b);
+    ar.read_string(c);
+    CHECK(a == "");
+    CHECK(b == "plain");
+    CHECK(c == with_nul);
+    CHECK_NOTHROW(ar.check_fully_consumed());
+}
+
+TEST_CASE("bool / string / raw vectors round-trip, including empty", "[BinaryArchive]")
+{
+    TempFile file;
+    const std::vector<bool> bools{true, false, true};
+    const std::vector<std::string> strings{"", "x", "yz"};
+    const std::vector<double> doubles{-1., 0., 1.5};
+    const std::vector<int> ints{7, -8};
+    const std::vector<ls2g::cplx_type> cplxs{ls2g::cplx_type(0., 2.)};
+    {
+        BinaryArchive ar(file.str(), BinaryArchive::Mode::Write);
+        ar.write_bool_vector(bools);
+        ar.write_bool_vector({});
+        ar.write_string_vector(strings);
+        ar.write_string_vector({});
+        ar.write_vector_raw(doubles);
+        ar.write_vector_raw(std::vector<double>{});
+        ar.write_vector_raw(ints);
+        ar.write_vector_raw(cplxs);
+        ar.commit();
+    }
+    BinaryArchive ar(file.str(), BinaryArchive::Mode::Read);
+    std::vector<bool> rb, rb_empty;
+    std::vector<std::string> rs, rs_empty;
+    std::vector<double> rd, rd_empty;
+    std::vector<int> ri;
+    std::vector<ls2g::cplx_type> rc;
+    ar.read_bool_vector(rb);
+    ar.read_bool_vector(rb_empty);
+    ar.read_string_vector(rs);
+    ar.read_string_vector(rs_empty);
+    ar.read_vector_raw(rd);
+    ar.read_vector_raw(rd_empty);
+    ar.read_vector_raw(ri);
+    ar.read_vector_raw(rc);
+    CHECK(rb == bools);
+    CHECK(rb_empty.empty());
+    CHECK(rs == strings);
+    CHECK(rs_empty.empty());
+    CHECK(rd == doubles);
+    CHECK(rd_empty.empty());
+    CHECK(ri == ints);
+    CHECK(rc == cplxs);
+    CHECK_NOTHROW(ar.check_fully_consumed());
+}
+
+TEST_CASE("header round-trips; writer version strings are not compared", "[BinaryArchive]")
+{
+    TempFile file;
+    {
+        BinaryArchive ar(file.str(), BinaryArchive::Mode::Write);
+        ar.write_header("SomeTag", "0", "14", "0");
+        ar.commit();
+    }
+    {
+        BinaryArchive ar(file.str(), BinaryArchive::Mode::Read);
+        CHECK_NOTHROW(ar.check_header("SomeTag", "0", "14", "0"));
+        CHECK_NOTHROW(ar.check_fully_consumed());
+    }
+    // a build with a different version but the same binary format reads the file
+    BinaryArchive ar(file.str(), BinaryArchive::Mode::Read);
+    CHECK_NOTHROW(ar.check_header("SomeTag", "99", "0", "1"));
+}
+
+TEST_CASE("garbage magic number is rejected", "[BinaryArchive]")
+{
+    TempFile file;
+    ls2g_test::write_file(file.str(), {'G', 'A', 'R', 'B', 'A', 'G', 'E', '!'});
+    BinaryArchive ar(file.str(), BinaryArchive::Mode::Read);
+    REQUIRE_THROWS_MATCHES(
+        ar.check_magic(), std::runtime_error,
+        MessageMatches(ContainsSubstring("magic number mismatch")));
+}
+
+TEST_CASE("unsupported binary format version is rejected with a precise message", "[BinaryArchive]")
+{
+    TempFile file;
+    {
+        // hand-crafted header claiming format 999: magic is valid, so the
+        // header must still parse and the error must cite both versions
+        BinaryArchive ar(file.str(), BinaryArchive::Mode::Write);
+        ar.write_magic();
+        ar.write_scalar(std::uint32_t(999));
+        ar.write_string("SomeTag");
+        ar.write_string("12");
+        ar.write_string("34");
+        ar.write_string("56");
+        ar.commit();
+    }
+    BinaryArchive ar(file.str(), BinaryArchive::Mode::Read);
+    REQUIRE_THROWS_MATCHES(
+        ar.check_header("SomeTag", "0", "14", "0"), std::runtime_error,
+        MessageMatches(ContainsSubstring("binary format 999") &&
+                       ContainsSubstring("12.34.56") &&
+                       ContainsSubstring("only supports binary format(s)")));
+}
+
+TEST_CASE("wrong type tag is rejected", "[BinaryArchive]")
+{
+    TempFile file;
+    with_written(file.str(), [](BinaryArchive & ar) {
+        ar.write_header("LoadContainer", "0", "14", "0");
+    });
+    BinaryArchive ar(file.str(), BinaryArchive::Mode::Read);
+    REQUIRE_THROWS_MATCHES(
+        ar.check_header("StorageContainer", "0", "14", "0"), std::runtime_error,
+        MessageMatches(ContainsSubstring("wrong object type") &&
+                       ContainsSubstring("'LoadContainer'") &&
+                       ContainsSubstring("'StorageContainer'")));
+}
+
+TEST_CASE("corrupt strings are escaped and truncated in error messages", "[BinaryArchive]")
+{
+    SECTION("non-printable bytes become \\x escapes") {
+        TempFile file;
+        with_written(file.str(), [](BinaryArchive & ar) {
+            ar.write_header(std::string("bad\x01tag\xff", 8), "0", "14", "0");
+        });
+        BinaryArchive ar(file.str(), BinaryArchive::Mode::Read);
+        REQUIRE_THROWS_MATCHES(
+            ar.check_header("SomeTag", "0", "14", "0"), std::runtime_error,
+            MessageMatches(ContainsSubstring("\\x01") && ContainsSubstring("\\xff")));
+    }
+    SECTION("over-long strings are truncated with a length note") {
+        TempFile file;
+        const std::string long_tag(200, 'A');
+        {
+            BinaryArchive ar(file.str(), BinaryArchive::Mode::Write);
+            ar.write_header(long_tag, "0", "14", "0");
+            ar.commit();
+        }
+        BinaryArchive ar(file.str(), BinaryArchive::Mode::Read);
+        REQUIRE_THROWS_MATCHES(
+            ar.check_header("SomeTag", "0", "14", "0"), std::runtime_error,
+            MessageMatches(ContainsSubstring("... (200 chars)") &&
+                           !ContainsSubstring(long_tag)));
+    }
+}
+
+TEST_CASE("require_count", "[BinaryArchive]")
+{
+    TempFile file;
+    // 16 bytes of payload, nothing consumed yet
+    ls2g_test::write_file(file.str(), std::vector<char>(16, '\0'));
+    BinaryArchive ar(file.str(), BinaryArchive::Mode::Read);
+
+    SECTION("counts that fit do not throw") {
+        CHECK_NOTHROW(ar.require_count(16, 1));
+        CHECK_NOTHROW(ar.require_count(2, 8));
+        CHECK_NOTHROW(ar.require_count(0, 8));
+    }
+    SECTION("one element too many throws before any allocation") {
+        REQUIRE_THROWS_MATCHES(
+            ar.require_count(17, 1), std::runtime_error,
+            MessageMatches(ContainsSubstring("truncated or corrupted")));
+        REQUIRE_THROWS_AS(ar.require_count(3, 8), std::runtime_error);
+    }
+    SECTION("huge counts cannot overflow back into acceptance") {
+        // 2^61 * 8 == 2^64 wraps to 0 with a multiplication-based check
+        REQUIRE_THROWS_AS(ar.require_count(std::uint64_t(1) << 61, 8), std::runtime_error);
+        REQUIRE_THROWS_AS(ar.require_count(~std::uint64_t(0), 8), std::runtime_error);
+    }
+    SECTION("elem_size 0 never throws") {
+        CHECK_NOTHROW(ar.require_count(~std::uint64_t(0), 0));
+    }
+    SECTION("the check is relative to the current read position") {
+        std::uint64_t dummy = 0;
+        ar.read_scalar(dummy);  // consume 8 of the 16 bytes
+        CHECK_NOTHROW(ar.require_count(8, 1));
+        REQUIRE_THROWS_AS(ar.require_count(9, 1), std::runtime_error);
+    }
+}
+
+TEST_CASE("trailing bytes are treated as corruption", "[BinaryArchive]")
+{
+    TempFile file;
+    with_written(file.str(), [](BinaryArchive & ar) {
+        ar.write_scalar(std::int32_t(1));
+        ar.write_scalar(std::uint8_t(0));  // the trailing byte
+    });
+    BinaryArchive ar(file.str(), BinaryArchive::Mode::Read);
+    std::int32_t v = 0;
+    ar.read_scalar(v);
+    REQUIRE_THROWS_MATCHES(
+        ar.check_fully_consumed(), std::runtime_error,
+        MessageMatches(ContainsSubstring("1 unexpected byte(s)")));
+}
+
+TEST_CASE("reading past the end of a truncated file throws", "[BinaryArchive]")
+{
+    TempFile file;
+    ls2g_test::write_file(file.str(), {'\x01', '\x02', '\x03', '\x04'});
+    BinaryArchive ar(file.str(), BinaryArchive::Mode::Read);
+    double d = 0.;  // needs 8 bytes, only 4 available
+    REQUIRE_THROWS_MATCHES(
+        ar.read_scalar(d), std::runtime_error,
+        MessageMatches(ContainsSubstring("unexpected end of file")));
+}
+
+TEST_CASE("constructor failures name the file", "[BinaryArchive]")
+{
+    SECTION("reading a nonexistent file") {
+        REQUIRE_THROWS_MATCHES(
+            BinaryArchive("no_such_file.lsb", BinaryArchive::Mode::Read),
+            std::runtime_error,
+            MessageMatches(ContainsSubstring("cannot open file for reading") &&
+                           ContainsSubstring("no_such_file.lsb")));
+    }
+    SECTION("atomic write into a nonexistent directory names the temp file") {
+        REQUIRE_THROWS_MATCHES(
+            BinaryArchive("no_such_dir_ls2g/x.lsb", BinaryArchive::Mode::Write),
+            std::runtime_error,
+            MessageMatches(ContainsSubstring("cannot open file for writing") &&
+                           ContainsSubstring(".lsb_tmp")));
+    }
+    SECTION("non-atomic write into a nonexistent directory") {
+        REQUIRE_THROWS_MATCHES(
+            BinaryArchive("no_such_dir_ls2g/x.lsb", BinaryArchive::Mode::Write, false),
+            std::runtime_error,
+            MessageMatches(ContainsSubstring("cannot open file for writing")));
+    }
+}
+
+TEST_CASE("commit() on a read-mode archive throws", "[BinaryArchive]")
+{
+    TempFile file;
+    ls2g_test::write_file(file.str(), {'\0'});
+    BinaryArchive ar(file.str(), BinaryArchive::Mode::Read);
+    REQUIRE_THROWS_MATCHES(
+        ar.commit(), std::runtime_error,
+        MessageMatches(ContainsSubstring("read-mode")));
+}
+
+TEST_CASE("atomic write lifecycle", "[BinaryArchive]")
+{
+    TempFile file;
+    const std::string tmp = file.str() + ".lsb_tmp";
+
+    SECTION("data goes to the temp file, the destination only appears on commit") {
+        BinaryArchive ar(file.str(), BinaryArchive::Mode::Write);
+        ar.write_scalar(std::int32_t(1));
+        CHECK(ls2g_test::file_exists(tmp));
+        CHECK_FALSE(ls2g_test::file_exists(file.str()));
+        ar.commit();
+        CHECK_FALSE(ls2g_test::file_exists(tmp));
+        CHECK(ls2g_test::file_exists(file.str()));
+    }
+
+    SECTION("an interrupted write leaves a previously good file untouched") {
+        // a good file first
+        with_written(file.str(), [](BinaryArchive & ar) {
+            ar.write_scalar(std::int32_t(42));
+        });
+        const std::vector<char> before = ls2g_test::read_file(file.str());
+        {
+            // then a write abandoned before commit() (as after an exception
+            // during serialization): rollback in the destructor
+            BinaryArchive ar(file.str(), BinaryArchive::Mode::Write);
+            ar.write_scalar(std::int32_t(-1));
+            ar.write_scalar(std::int32_t(-2));
+        }
+        CHECK_FALSE(ls2g_test::file_exists(tmp));
+        CHECK(ls2g_test::read_file(file.str()) == before);
+    }
+}
+
+TEST_CASE("non-atomic write goes straight to the destination", "[BinaryArchive]")
+{
+    TempFile file;
+    const std::string tmp = file.str() + ".lsb_tmp";
+
+    SECTION("no temp file is involved") {
+        BinaryArchive ar(file.str(), BinaryArchive::Mode::Write, false);
+        ar.write_scalar(std::int32_t(1));
+        CHECK_FALSE(ls2g_test::file_exists(tmp));
+        CHECK(ls2g_test::file_exists(file.str()));
+        ar.commit();
+        CHECK(ls2g_test::file_exists(file.str()));
+    }
+
+    SECTION("an abandoned partial file remains and is rejected as truncated at load time") {
+        {
+            // declares a 5-element block whose data is never written
+            BinaryArchive ar(file.str(), BinaryArchive::Mode::Write, false);
+            ar.write_scalar(std::uint64_t(5));
+            // no commit(): simulates an interrupted save
+        }
+        CHECK(ls2g_test::file_exists(file.str()));
+        BinaryArchive ar(file.str(), BinaryArchive::Mode::Read);
+        std::vector<double> v;
+        REQUIRE_THROWS_AS(ar.read_vector_raw(v), std::runtime_error);
+    }
+}

--- a/src/tests/test_binary_archive_corruption.cpp
+++ b/src/tests/test_binary_archive_corruption.cpp
@@ -1,0 +1,90 @@
+// Copyright (c) 2026, RTE (https://www.rte-france.com)
+// See AUTHORS.txt
+// This Source Code Form is subject to the terms of the Mozilla Public License, version 2.0.
+// If a copy of the Mozilla Public License, version 2.0 was not distributed with this file,
+// you can obtain one at http://mozilla.org/MPL/2.0/.
+// SPDX-License-Identifier: MPL-2.0
+// This file is part of LightSim2grid, LightSim2grid implements a c++ backend targeting the Grid2Op platform.
+
+// Deterministic corruption sweep: the C++ twin of the python sweep in
+// lightsim2grid/tests/test_binary_serialization.py, but running on the
+// archive layer alone -- so it is cheap enough to run at every byte offset,
+// and any memory error it provokes becomes a hard failure under the valgrind
+// / ASan CI jobs. The contract under test: loading arbitrarily corrupted
+// bytes either succeeds (the corruption kept all counts consistent) or
+// throws std::runtime_error -- never anything else, never a crash or an
+// attempted huge allocation.
+
+#include <cstring>   // std::memset
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+#include <catch2/catch_test_macros.hpp>
+
+#include "BinaryArchive.hpp"
+#include "test_helpers.hpp"
+
+using ls2g_test::FakeContainer;
+
+namespace {
+
+// writes the corrupted bytes and attempts a load; anything other than a
+// clean success or a std::runtime_error fails the test at this offset
+void check_load(const std::string & path, const std::vector<char> & bytes, std::size_t offset)
+{
+    ls2g_test::write_file(path, bytes);
+    INFO("corruption at byte offset " << offset << " of " << bytes.size());
+    try {
+        (void) ls2g::load_binary_generic<FakeContainer>(path, "0", "14", "0");
+    } catch (const std::runtime_error &) {
+        // the expected rejection path
+    }
+    // any other exception type (std::bad_alloc, std::length_error, ...)
+    // propagates out of the loop and fails the surrounding TEST_CASE
+    SUCCEED();
+}
+
+std::vector<char> reference_bytes(const std::string & path)
+{
+    ls2g::save_binary_generic(ls2g_test::make_reference_container(), path, "0", "14", "0");
+    return ls2g_test::read_file(path);
+}
+
+}  // anonymous namespace
+
+TEST_CASE("every single-byte flip loads cleanly or throws runtime_error", "[corruption]")
+{
+    ls2g_test::TempFile file;
+    const std::vector<char> ref = reference_bytes(file.str());
+    REQUIRE(ref.size() > 0);
+    for (std::size_t i = 0; i < ref.size(); ++i) {
+        std::vector<char> corrupted = ref;
+        corrupted[i] = static_cast<char>(corrupted[i] ^ 0xFF);
+        check_load(file.str(), corrupted, i);
+    }
+}
+
+TEST_CASE("every 8-byte 0xFF stamp loads cleanly or throws runtime_error", "[corruption]")
+{
+    // stamps a maximal uint64 over every alignment, the worst case for any
+    // count / length field it happens to cover
+    ls2g_test::TempFile file;
+    const std::vector<char> ref = reference_bytes(file.str());
+    REQUIRE(ref.size() >= 8);
+    for (std::size_t i = 0; i + 8 <= ref.size(); ++i) {
+        std::vector<char> corrupted = ref;
+        std::memset(&corrupted[i], 0xFF, 8);
+        check_load(file.str(), corrupted, i);
+    }
+}
+
+TEST_CASE("every truncation loads cleanly or throws runtime_error", "[corruption]")
+{
+    ls2g_test::TempFile file;
+    const std::vector<char> ref = reference_bytes(file.str());
+    for (std::size_t len = 0; len < ref.size(); ++len) {
+        const std::vector<char> truncated(ref.begin(), ref.begin() + len);
+        check_load(file.str(), truncated, len);
+    }
+}

--- a/src/tests/test_binary_archive_stateres.cpp
+++ b/src/tests/test_binary_archive_stateres.cpp
@@ -1,0 +1,159 @@
+// Copyright (c) 2026, RTE (https://www.rte-france.com)
+// See AUTHORS.txt
+// This Source Code Form is subject to the terms of the Mozilla Public License, version 2.0.
+// If a copy of the Mozilla Public License, version 2.0 was not distributed with this file,
+// you can obtain one at http://mozilla.org/MPL/2.0/.
+// SPDX-License-Identifier: MPL-2.0
+// This file is part of LightSim2grid, LightSim2grid implements a c++ backend targeting the Grid2Op platform.
+
+// ValueArchiver dispatch + the generic save_binary_generic / load_binary_generic
+// entry points, over synthetic StateRes types (test_helpers.hpp) covering every
+// field shape the real containers use -- no grid, no Eigen data, no python.
+
+#include <cstdint>
+#include <stdexcept>
+#include <string>
+#include <tuple>
+#include <vector>
+
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_exception.hpp>
+#include <catch2/matchers/catch_matchers_string.hpp>
+
+#include "BinaryArchive.hpp"
+#include "test_helpers.hpp"
+
+using ls2g_test::FakeContainer;
+using ls2g_test::TempFile;
+using Catch::Matchers::ContainsSubstring;
+using Catch::Matchers::MessageMatches;
+
+namespace {
+
+// number of bytes the header occupies for a given tag, with the "0"/"14"/"0"
+// version strings every test here writes: magic (4) + format (uint32) + four
+// length-prefixed strings (uint32 length each)
+std::size_t header_size(const std::string & tag)
+{
+    return 4 + 4 + (4 + tag.size()) + (4 + 1) + (4 + 2) + (4 + 1);
+}
+
+template<typename T>
+void save(const T & obj, const std::string & path, bool atomic = true)
+{
+    ls2g::save_binary_generic(obj, path, "0", "14", "0", atomic);
+}
+
+template<typename T>
+T load(const std::string & path)
+{
+    return ls2g::load_binary_generic<T>(path, "0", "14", "0");
+}
+
+}  // anonymous namespace
+
+TEST_CASE("full StateRes round-trip covering every ValueArchiver specialization", "[StateRes]")
+{
+    const FakeContainer ref = ls2g_test::make_reference_container();
+    TempFile file;
+    save(ref, file.str());
+    const FakeContainer loaded = load<FakeContainer>(file.str());
+    // std::tuple operator== compares field by field, recursing into the
+    // nested tuple and the nested vectors
+    CHECK(loaded.get_state() == ref.get_state());
+}
+
+TEST_CASE("an all-default (empty) StateRes round-trips", "[StateRes]")
+{
+    const FakeContainer ref{};  // zero scalars, empty strings and vectors
+    TempFile file;
+    save(ref, file.str());
+    CHECK(load<FakeContainer>(file.str()).get_state() == ref.get_state());
+}
+
+TEST_CASE("non-atomic save round-trips too", "[StateRes]")
+{
+    const FakeContainer ref = ls2g_test::make_reference_container();
+    TempFile file;
+    save(ref, file.str(), false);
+    CHECK_FALSE(ls2g_test::file_exists(file.str() + ".lsb_tmp"));
+    CHECK(load<FakeContainer>(file.str()).get_state() == ref.get_state());
+}
+
+TEST_CASE("a corrupted on-disk bool byte is normalized, not undefined behavior", "[StateRes]")
+{
+    // reading a byte holding eg 255 straight into a bool object would be UB
+    // when that bool is later loaded; ValueArchiver<bool> normalizes instead
+    const FakeContainer ref = ls2g_test::make_reference_container();
+    TempFile file;
+    save(ref, file.str());
+
+    // the bool is the third StateRes field: after the int and the real_type
+    std::vector<char> bytes = ls2g_test::read_file(file.str());
+    const std::size_t bool_offset =
+        header_size(FakeContainer::binary_type_tag()) + sizeof(int) + sizeof(ls2g::real_type);
+    REQUIRE(bytes.at(bool_offset) == 1);  // written by the reference container as true
+    bytes.at(bool_offset) = static_cast<char>(0xFF);
+    ls2g_test::write_file(file.str(), bytes);
+
+    const FakeContainer loaded = load<FakeContainer>(file.str());
+    CHECK(std::get<2>(loaded.get_state()) == true);
+
+    bytes.at(bool_offset) = 0;
+    ls2g_test::write_file(file.str(), bytes);
+    CHECK(std::get<2>(load<FakeContainer>(file.str()).get_state()) == false);
+}
+
+TEST_CASE("identical StateRes layouts are told apart by the type tag", "[StateRes]")
+{
+    // FakeLoad and FakeStorage have byte-identical payloads (like the real
+    // LoadContainer / StorageContainer): only the header tag differs
+    ls2g_test::FakeLoad load_obj;
+    load_obj.state = std::make_tuple(3, std::vector<ls2g::real_type>{1., 2.});
+    TempFile file;
+    save(load_obj, file.str());
+
+    CHECK(load<ls2g_test::FakeLoad>(file.str()).get_state() == load_obj.get_state());
+    REQUIRE_THROWS_MATCHES(
+        load<ls2g_test::FakeStorage>(file.str()), std::runtime_error,
+        MessageMatches(ContainsSubstring("wrong object type") &&
+                       ContainsSubstring("'FakeLoad'") &&
+                       ContainsSubstring("'FakeStorage'")));
+}
+
+TEST_CASE("fixup_binary_state is applied when declared, and only then", "[StateRes]")
+{
+    SECTION("a type declaring the hook gets it applied after the read") {
+        ls2g_test::FakeWithFixup obj;
+        obj.state = std::make_tuple(5, std::string("original"));
+        TempFile file;
+        save(obj, file.str());
+        const ls2g_test::FakeWithFixup loaded = load<ls2g_test::FakeWithFixup>(file.str());
+        CHECK(std::get<0>(loaded.get_state()) == 5);
+        CHECK(std::get<1>(loaded.get_state()) == "fixed up");
+    }
+    SECTION("a type without the hook is loaded untouched") {
+        ls2g_test::FakeLoad obj;
+        obj.state = std::make_tuple(5, std::vector<ls2g::real_type>{7.});
+        TempFile file;
+        save(obj, file.str());
+        CHECK(load<ls2g_test::FakeLoad>(file.str()).get_state() == obj.get_state());
+    }
+}
+
+TEST_CASE("loading rejects a file whose payload is longer than the StateRes", "[StateRes]")
+{
+    // a FakeContainer payload after a FakeLoad-sized read leaves trailing
+    // bytes: check_fully_consumed must reject them (wrong-class protection
+    // beyond the tag, eg after a manual rename attack on the header)
+    ls2g_test::FakeLoad obj;
+    obj.state = std::make_tuple(1, std::vector<ls2g::real_type>{1.});
+    TempFile file;
+    save(obj, file.str());
+    std::vector<char> bytes = ls2g_test::read_file(file.str());
+    bytes.push_back('\0');
+    ls2g_test::write_file(file.str(), bytes);
+    REQUIRE_THROWS_MATCHES(
+        load<ls2g_test::FakeLoad>(file.str()), std::runtime_error,
+        MessageMatches(ContainsSubstring("unexpected byte(s)")));
+}

--- a/src/tests/test_helpers.hpp
+++ b/src/tests/test_helpers.hpp
@@ -1,0 +1,166 @@
+// Copyright (c) 2026, RTE (https://www.rte-france.com)
+// See AUTHORS.txt
+// This Source Code Form is subject to the terms of the Mozilla Public License, version 2.0.
+// If a copy of the Mozilla Public License, version 2.0 was not distributed with this file,
+// you can obtain one at http://mozilla.org/MPL/2.0/.
+// SPDX-License-Identifier: MPL-2.0
+// This file is part of LightSim2grid, LightSim2grid implements a c++ backend targeting the Grid2Op platform.
+
+#ifndef LS2G_TEST_HELPERS_H
+#define LS2G_TEST_HELPERS_H
+
+// Shared helpers for the C++ unit tests (src/tests): a self-cleaning
+// temporary file, raw file IO, and the synthetic serializable types used to
+// exercise BinaryArchive without a real grid. C++14 only (project policy).
+
+#include <cstdio>    // std::remove
+#include <fstream>
+#include <sstream>
+#include <string>
+#include <tuple>
+#include <vector>
+
+#include "Utils.hpp"  // ls2g::real_type, ls2g::cplx_type
+
+namespace ls2g_test {
+
+// A unique file path in the current working directory (ctest / CI run the
+// binary from the build directory), removed on destruction together with the
+// ".lsb_tmp" sibling a BinaryArchive atomic write may have left behind.
+// mkdtemp/std::filesystem are avoided on purpose: C++14, no platform #ifdef.
+class TempFile
+{
+    public:
+        explicit TempFile(const std::string & suffix = ".lsb") {
+            static int counter = 0;
+            std::ostringstream oss;
+            oss << "ls2g_unit_test_" << counter++ << suffix;
+            path_ = oss.str();
+            // in case a previous crashed run left files behind
+            std::remove(path_.c_str());
+            std::remove((path_ + ".lsb_tmp").c_str());
+        }
+        ~TempFile() {
+            std::remove(path_.c_str());
+            std::remove((path_ + ".lsb_tmp").c_str());
+        }
+        TempFile(const TempFile &) = delete;
+        TempFile & operator=(const TempFile &) = delete;
+
+        const std::string & str() const { return path_; }
+
+    private:
+        std::string path_;
+};
+
+inline bool file_exists(const std::string & path)
+{
+    std::ifstream f(path, std::ios::binary);
+    return f.is_open();
+}
+
+inline std::vector<char> read_file(const std::string & path)
+{
+    std::ifstream f(path, std::ios::binary);
+    return std::vector<char>((std::istreambuf_iterator<char>(f)),
+                             std::istreambuf_iterator<char>());
+}
+
+inline void write_file(const std::string & path, const std::vector<char> & bytes)
+{
+    std::ofstream f(path, std::ios::binary | std::ios::trunc);
+    f.write(bytes.data(), static_cast<std::streamsize>(bytes.size()));
+}
+
+// ---- synthetic serializable types ------------------------------------------
+// They implement the same contract as the real containers (StateRes typedef +
+// get_state / set_state / binary_type_tag) with none of their dependencies.
+
+enum class FakeEnum : int { kOff = 0, kOn = 1, kAuto = 42 };
+
+// One field per ValueArchiver specialization in BinaryArchive.hpp: arithmetic
+// scalars, bool, cplx_type, enum, string, raw vectors (real / int / cplx),
+// vector<bool>, vector<string>, vector<vector<T>> and a nested tuple.
+struct FakeContainer
+{
+    using SubState = std::tuple<int, std::vector<ls2g::real_type> >;
+    using StateRes = std::tuple<
+        int,
+        ls2g::real_type,
+        bool,
+        ls2g::cplx_type,
+        FakeEnum,
+        std::string,
+        std::vector<ls2g::real_type>,
+        std::vector<int>,
+        std::vector<ls2g::cplx_type>,
+        std::vector<bool>,
+        std::vector<std::string>,
+        std::vector<std::vector<ls2g::real_type> >,
+        SubState
+    >;
+
+    StateRes state{};
+
+    StateRes get_state() const { return state; }
+    void set_state(StateRes & s) { state = s; }
+    static const char * binary_type_tag() { return "FakeContainer"; }
+};
+
+inline FakeContainer make_reference_container()
+{
+    FakeContainer res;
+    res.state = FakeContainer::StateRes(
+        -7,
+        3.141592653589793,
+        true,
+        ls2g::cplx_type(1.5, -2.5),
+        FakeEnum::kAuto,
+        "hello archive",
+        {0., -1.5, 2.25e3},
+        {1, -2, 3},
+        {ls2g::cplx_type(0., 1.), ls2g::cplx_type(-1., 0.)},
+        {true, false, true, true},
+        {"", "one", "two words"},
+        {{1., 2.}, {}, {3.}},
+        FakeContainer::SubState(99, {4., 5., 6.})
+    );
+    return res;
+}
+
+// Two types with identical StateRes layouts but different tags: the
+// LoadContainer-vs-StorageContainer confusion the type tag exists to reject.
+struct FakeLoad
+{
+    using StateRes = std::tuple<int, std::vector<ls2g::real_type> >;
+    StateRes state{};
+    StateRes get_state() const { return state; }
+    void set_state(StateRes & s) { state = s; }
+    static const char * binary_type_tag() { return "FakeLoad"; }
+};
+
+struct FakeStorage
+{
+    using StateRes = std::tuple<int, std::vector<ls2g::real_type> >;
+    StateRes state{};
+    StateRes get_state() const { return state; }
+    void set_state(StateRes & s) { state = s; }
+    static const char * binary_type_tag() { return "FakeStorage"; }
+};
+
+// Opts into the optional post-read hook (like LSGrid does): detected by
+// BinaryLoadFixup via the C++14 detection idiom and applied after the state
+// is read, before set_state().
+struct FakeWithFixup
+{
+    using StateRes = std::tuple<int, std::string>;
+    StateRes state{};
+    StateRes get_state() const { return state; }
+    void set_state(StateRes & s) { state = s; }
+    static const char * binary_type_tag() { return "FakeWithFixup"; }
+    static void fixup_binary_state(StateRes & s) { std::get<1>(s) = "fixed up"; }
+};
+
+}  // namespace ls2g_test
+
+#endif  // LS2G_TEST_HELPERS_H

--- a/src/tests/test_lsgrid.cpp
+++ b/src/tests/test_lsgrid.cpp
@@ -21,11 +21,15 @@
 
 #include <catch2/catch_approx.hpp>
 #include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_exception.hpp>
+#include <catch2/matchers/catch_matchers_string.hpp>
 
 #include "LSGrid.hpp"
 #include "test_helpers.hpp"
 
 using Catch::Approx;
+using Catch::Matchers::ContainsSubstring;
+using Catch::Matchers::MessageMatches;
 using ls2g::LSGrid;
 using ls2g::CplxVect;
 using ls2g::RealVect;
@@ -368,10 +372,13 @@ TEST_CASE("static var compensators", "[LSGrid][svc]")
 
 TEST_CASE("HVDC links between two converter stations", "[LSGrid][hvdc]")
 {
-    // one hvdc line between bus 1 (side 1, rectifier) and bus 2 (side 2),
-    // drawing 20 MW; helper filling the many init_hvdc_lines arguments
+    // one hvdc line between bus 1 (side 1, rectifier) and bus 2 (side 2);
+    // helper filling the many init_hvdc_lines arguments
     const auto add_hvdc = [](LSGrid & grid, int type2, bool vreg2_on,
-                             real_type vm2, real_type power_factor2) {
+                             real_type vm2, real_type power_factor2,
+                             real_type p_setpoint = 20.,
+                             bool droop = false, real_type droop_p0 = 0.,
+                             real_type droop_k_per_deg = 0.) {
         Eigen::VectorXi bus1(1), bus2(1);
         bus1 << 1;
         bus2 << 2;
@@ -379,18 +386,20 @@ TEST_CASE("HVDC links between two converter stations", "[LSGrid][hvdc]")
         const std::vector<int> type1{0};
         // HvdcLineContainer::ConvertersMode: SIDE_1_RECTIFIER = 0
         const std::vector<int> mode{0};
-        const std::vector<bool> vreg1{false}, vreg2{vreg2_on}, no_droop{false};
+        const std::vector<bool> vreg1{false}, vreg2{vreg2_on}, droop_on{droop};
         const RealVect zero = RealVect::Zero(1);
         RealVect vm1_pu(1), vm2_pu(1), q_min(1), q_max(1);
-        RealVect pf1(1), pf2(1), p_set(1), p_max(1);
+        RealVect pf1(1), pf2(1), p_set(1), p_max(1), p0(1), k_deg(1);
         vm1_pu << 1.0;
         vm2_pu << vm2;
         q_min << -1e6;
         q_max << 1e6;
         pf1 << 1.;
         pf2 << power_factor2;
-        p_set << 20.;
+        p_set << p_setpoint;
         p_max << 300.;
+        p0 << droop_p0;
+        k_deg << droop_k_per_deg;
         grid.init_hvdc_lines(bus1, bus2, type1, {type2},
                              zero, zero,           // no station losses
                              vreg1, vreg2, vm1_pu, vm2_pu,
@@ -398,7 +407,7 @@ TEST_CASE("HVDC links between two converter stations", "[LSGrid][hvdc]")
                              q_min, q_max, q_min, q_max,
                              pf1, pf2, mode, p_set,
                              zero, zero,           // r_ohm, nominal_v (no line loss)
-                             no_droop, zero, zero, p_max, p_max);
+                             droop_on, p0, k_deg, p_max, p_max);
         grid.tell_solver_need_reset();
     };
 
@@ -425,6 +434,28 @@ TEST_CASE("HVDC links between two converter stations", "[LSGrid][hvdc]")
         const real_type q2 = std::get<1>(grid.get_dcline_res2())(0);
         CHECK(p2 == Approx(20.).epsilon(1e-8));
         CHECK(q2 == Approx(-std::abs(p2) * std::tan(std::acos(0.9))).epsilon(1e-6));
+    }
+    SECTION("a VSC-VSC link with angle droop follows the droop law") {
+        LSGrid grid = make_three_bus_grid();
+        const real_type p0 = 10., k_per_deg = 2.;
+        add_hvdc(grid, /*type2=VSC*/ 0, false, 1.0, 1., /*p_setpoint=*/0.,
+                 /*droop=*/true, p0, k_per_deg);
+        const CplxVect V = solve_ac(grid);
+        REQUIRE(V.size() == 3);
+        // linear regime: transferred power (1 -> 2) is p0 + k * (theta1 - theta2),
+        // with k converted from MW/deg to MW/rad
+        const real_type k_per_rad = k_per_deg * 180. / std::acos(real_type(-1.));
+        const real_type expected = p0 + k_per_rad * (std::arg(V(1)) - std::arg(V(2)));
+        CHECK(std::get<0>(grid.get_dcline_res2())(0) == Approx(expected).epsilon(1e-6));
+        CHECK(std::get<0>(grid.get_dcline_res1())(0) == Approx(-expected).epsilon(1e-6));
+    }
+    SECTION("angle droop cannot be combined with an LCC station") {
+        LSGrid grid = make_three_bus_grid();
+        REQUIRE_THROWS_MATCHES(
+            add_hvdc(grid, /*type2=LCC*/ 1, false, 1.0, 0.9, /*p_setpoint=*/0.,
+                     /*droop=*/true, 10., 2.),
+            std::runtime_error,
+            MessageMatches(ContainsSubstring("only available for VSC - VSC")));
     }
 }
 
@@ -459,6 +490,138 @@ TEST_CASE("remote voltage control pins the regulated bus", "[LSGrid][vctrl]")
 
     // out-of-range regulated bus is rejected
     CHECK_THROWS_AS(grid.set_gen_regulated_bus(1, 12), std::out_of_range);
+}
+
+TEST_CASE("a local and a remote voltage controller on one bus is unfeasible", "[LSGrid][vctrl]")
+{
+    // two generators on bus 1: gen 1 regulates its own bus (ordinary PV
+    // pinning) while gen 2 regulates bus 2 remotely. Gen 2's own bus then
+    // has no reactive equation left to trade against the remote target, so
+    // the solve must reject the state instead of producing garbage.
+    LSGrid grid = make_three_bus_skeleton(0.01);
+    RealVect gen_p(3), gen_v(3), gen_min_q(3), gen_max_q(3);
+    gen_p << 0., 0., 0.;
+    gen_v << 1.02, 1.02, 1.04;
+    gen_min_q << -1000., -1000., -1000.;
+    gen_max_q << 1000., 1000., 1000.;
+    Eigen::VectorXi gen_bus(3);
+    gen_bus << 0, 1, 1;
+    grid.init_generators(gen_p, gen_v, gen_min_q, gen_max_q, gen_bus);
+    grid.add_gen_slackbus(0, 1.);
+    grid.set_gen_regulated_bus(2, 2);
+    grid.tell_solver_need_reset();
+
+    REQUIRE_THROWS_MATCHES(
+        solve_ac(grid), std::runtime_error,
+        MessageMatches(ContainsSubstring("no reactive (Q) equation")));
+}
+
+TEST_CASE("transformers: tap ratio and phase shifter", "[LSGrid][trafo]")
+{
+    // buses at 138 kV, slack gen (1.02 pu) at bus 0, 50 MW / 10 MVar load at
+    // bus 2. `loop` false: line 0-1 plus a trafo 1-2 (radial, for the ratio
+    // effect); true: lines 0-1 and 1-2 plus a trafo 0-2 closing a loop (a
+    // phase shifter only redirects flow inside a loop).
+    const auto make_trafo_grid = [](bool loop, real_type ratio, real_type shift_deg) {
+        LSGrid grid;
+        grid.set_sn_mva(100.);
+        grid.set_init_vm_pu(1.0);
+        RealVect bus_vn_kv(3);
+        bus_vn_kv << 138., 138., 138.;
+        grid.init_bus(3, 1, bus_vn_kv, 0, 0);
+
+        const int nb_line = loop ? 2 : 1;
+        RealVect line_r(nb_line), line_x(nb_line);
+        Eigen::VectorXi line_from(nb_line), line_to(nb_line);
+        if (loop) {
+            line_r << 0.01, 0.01;
+            line_x << 0.1, 0.1;
+            line_from << 0, 1;
+            line_to << 1, 2;
+        } else {
+            line_r << 0.01;
+            line_x << 0.1;
+            line_from << 0;
+            line_to << 1;
+        }
+        grid.init_powerlines(line_r, line_x, CplxVect::Zero(nb_line), line_from, line_to);
+
+        RealVect trafo_r(1), trafo_x(1), trafo_ratio(1), trafo_shift(1);
+        trafo_r << 0.01;
+        trafo_x << 0.2;
+        trafo_ratio << ratio;
+        trafo_shift << shift_deg;  // degrees at init time
+        Eigen::VectorXi trafo_bus1(1), trafo_bus2(1);
+        trafo_bus1 << (loop ? 0 : 1);
+        trafo_bus2 << 2;
+        grid.init_trafo(trafo_r, trafo_x, CplxVect::Zero(1), trafo_ratio, trafo_shift,
+                        {true}, trafo_bus1, trafo_bus2, true);
+
+        RealVect load_p(1), load_q(1);
+        load_p << 50.;
+        load_q << 10.;
+        Eigen::VectorXi load_bus(1);
+        load_bus << 2;
+        grid.init_loads(load_p, load_q, load_bus);
+
+        RealVect gen_p(1), gen_v(1), gen_min_q(1), gen_max_q(1);
+        gen_p << 0.;
+        gen_v << 1.02;
+        gen_min_q << -1000.;
+        gen_max_q << 1000.;
+        Eigen::VectorXi gen_bus(1);
+        gen_bus << 0;
+        grid.init_generators(gen_p, gen_v, gen_min_q, gen_max_q, gen_bus);
+        grid.add_gen_slackbus(0, 1.);
+        return grid;
+    };
+
+    SECTION("the tap ratio scales the downstream voltage") {
+        LSGrid grid = make_trafo_grid(false, 1., 0.);
+        REQUIRE(solve_ac(grid).size() == 3);
+        const real_type vm2_ratio1 = std::abs(grid.get_V()(2));
+
+        grid.change_ratio_trafo(0, 1.05);
+        const CplxVect V_changed = solve_ac(grid);
+        REQUIRE(V_changed.size() == 3);
+        // raising the tap on the hv side lowers the lv-side voltage, by
+        // roughly the ratio (not exactly: the load's voltage dependence)
+        CHECK(std::abs(V_changed(2)) < vm2_ratio1);
+        CHECK(std::abs(V_changed(2)) == Approx(vm2_ratio1 / 1.05).epsilon(0.02));
+
+        // changing the ratio on a solved grid == initializing with it
+        LSGrid fresh = make_trafo_grid(false, 1.05, 0.);
+        const CplxVect V_fresh = solve_ac(fresh);
+        REQUIRE(V_fresh.size() == 3);
+        CHECK((V_changed - V_fresh).norm() < 1e-8);
+    }
+
+    SECTION("the phase shifter redirects the loop flow") {
+        LSGrid grid = make_trafo_grid(true, 1., 0.);
+        REQUIRE(solve_ac(grid).size() == 3);
+        const real_type p_trafo_0 = std::get<0>(grid.get_trafo_res1())(0);
+
+        grid.change_shift_trafo_deg(0, 5.);
+        REQUIRE(solve_ac(grid).size() == 3);
+        const real_type p_trafo_plus = std::get<0>(grid.get_trafo_res1())(0);
+        const CplxVect V_plus = grid.get_V();
+
+        grid.change_shift_trafo_deg(0, -5.);
+        REQUIRE(solve_ac(grid).size() == 3);
+        const real_type p_trafo_minus = std::get<0>(grid.get_trafo_res1())(0);
+
+        // opposite shifts move the trafo flow in opposite directions, and
+        // the load is served throughout
+        CHECK(p_trafo_plus != Approx(p_trafo_0).margin(1.));
+        CHECK((p_trafo_plus - p_trafo_0) * (p_trafo_minus - p_trafo_0) < 0.);
+        CHECK(std::get<0>(grid.get_loads_res())(0) == Approx(50.).epsilon(1e-8));
+
+        // changing the shift on a solved grid == initializing with it
+        LSGrid fresh = make_trafo_grid(true, 1., 5.);
+        const CplxVect V_fresh = solve_ac(fresh);
+        REQUIRE(V_fresh.size() == 3);
+        CHECK((V_plus - V_fresh).norm() < 1e-8);
+    }
 }
 
 TEST_CASE("documented error paths", "[LSGrid]")

--- a/src/tests/test_lsgrid.cpp
+++ b/src/tests/test_lsgrid.cpp
@@ -34,10 +34,10 @@ using ls2g::real_type;
 
 namespace {
 
-// Slack generator (1.02 pu) at bus 0, two identical lines 0-1 and 1-2
-// (x = 0.1 pu each), one 50 MW / 10 MVar load at bus 2. sn_mva = 100, so the
-// load is 0.5 pu and (with r = 0) the exact DC angles are 0 / -0.05 / -0.10.
-LSGrid make_three_bus_grid(real_type r_pu = 0.01)
+// Three 138 kV buses, two identical lines 0-1 and 1-2 (x = 0.1 pu each), one
+// 50 MW / 10 MVar load at bus 2. sn_mva = 100, so the load is 0.5 pu and
+// (with r = 0) the exact DC angles are 0 / -0.05 / -0.10. No generator yet.
+LSGrid make_three_bus_skeleton(real_type r_pu)
 {
     LSGrid grid;
     grid.set_sn_mva(100.);
@@ -62,7 +62,13 @@ LSGrid make_three_bus_grid(real_type r_pu = 0.01)
     Eigen::VectorXi load_bus(1);
     load_bus << 2;
     grid.init_loads(load_p, load_q, load_bus);
+    return grid;
+}
 
+// the skeleton plus a single slack generator (1.02 pu) at bus 0
+LSGrid make_three_bus_grid(real_type r_pu = 0.01)
+{
+    LSGrid grid = make_three_bus_skeleton(r_pu);
     RealVect gen_p(1), gen_v(1), gen_min_q(1), gen_max_q(1);
     gen_p << 0.;
     gen_v << 1.02;
@@ -72,6 +78,22 @@ LSGrid make_three_bus_grid(real_type r_pu = 0.01)
     gen_bus << 0;
     grid.init_generators(gen_p, gen_v, gen_min_q, gen_max_q, gen_bus);
     grid.add_gen_slackbus(0, 1.);
+    return grid;
+}
+
+// the skeleton plus generators at bus 0 (1.02 pu) and bus 1 (gen1_v_pu).
+// NO slack is registered: each test declares the slack setup it needs.
+LSGrid make_three_bus_grid_two_gens(real_type gen1_v_pu = 1.02)
+{
+    LSGrid grid = make_three_bus_skeleton(0.01);
+    RealVect gen_p(2), gen_v(2), gen_min_q(2), gen_max_q(2);
+    gen_p << 0., 0.;
+    gen_v << 1.02, gen1_v_pu;
+    gen_min_q << -1000., -1000.;
+    gen_max_q << 1000., 1000.;
+    Eigen::VectorXi gen_bus(2);
+    gen_bus << 0, 1;
+    grid.init_generators(gen_p, gen_v, gen_min_q, gen_max_q, gen_bus);
     return grid;
 }
 
@@ -253,6 +275,190 @@ TEST_CASE("save_binary / load_binary round-trips the whole grid", "[LSGrid]")
     REQUIRE(V.size() == 3);
     REQUIRE(V_loaded.size() == 3);
     CHECK((V - V_loaded).norm() < 1e-10);
+}
+
+TEST_CASE("a capacitive shunt raises the local voltage", "[LSGrid][shunt]")
+{
+    LSGrid base = make_three_bus_grid();
+    REQUIRE(solve_ac(base).size() == 3);
+    const real_type vm2_without = std::abs(base.get_V()(2));
+
+    LSGrid grid = make_three_bus_grid();
+    // pandapower convention: q_mvar is what the shunt consumes at v = 1 pu,
+    // so -25 MVar is a 25 MVar capacitor bank
+    RealVect shunt_p(1), shunt_q(1);
+    shunt_p << 0.;
+    shunt_q << -25.;
+    Eigen::VectorXi shunt_bus(1);
+    shunt_bus << 2;
+    grid.init_shunt(shunt_p, shunt_q, shunt_bus);
+
+    REQUIRE(solve_ac(grid).size() == 3);
+    CHECK(std::abs(grid.get_V()(2)) > vm2_without);
+    // the shunt injects reactive power (generator sign convention on results)
+    CHECK(std::get<1>(grid.get_shunts_res())(0) < 0.);
+}
+
+TEST_CASE("a charging storage unit behaves as an extra load", "[LSGrid][storage]")
+{
+    LSGrid grid = make_three_bus_grid();
+    // load convention: positive target_p = charging (consumes from the grid)
+    RealVect storage_p(1), storage_q(1);
+    storage_p << 10.;
+    storage_q << 0.;
+    Eigen::VectorXi storage_bus(1);
+    storage_bus << 1;
+    grid.init_storages(storage_p, storage_q, storage_bus);
+
+    REQUIRE(solve_ac(grid).size() == 3);
+    CHECK(std::get<0>(grid.get_storages_res())(0) == Approx(10.).epsilon(1e-8));
+    // the slack now covers the load, the storage and the (positive) losses
+    CHECK(std::get<0>(grid.get_gen_res())(0) > 60.);
+}
+
+TEST_CASE("static var compensators", "[LSGrid][svc]")
+{
+    LSGrid base = make_three_bus_grid();
+    REQUIRE(solve_ac(base).size() == 3);
+    const CplxVect V_without = base.get_V();
+
+    // SvcContainer::RegulationMode: OFF = 0, VOLTAGE = 1, REACTIVE_POWER = 2
+    RealVect slope(1), b_min(1), b_max(1);
+    slope << 0.;
+    b_min << -100.;
+    b_max << 100.;
+    Eigen::VectorXi reg_bus(1), svc_bus(1);
+    reg_bus << 2;
+    svc_bus << 2;
+
+    SECTION("VOLTAGE mode holds the regulated bus at its setpoint") {
+        LSGrid grid = make_three_bus_grid();
+        RealVect target_vm(1), q_set(1);
+        target_vm << 1.03;
+        q_set << 0.;
+        grid.init_svcs({1}, target_vm, q_set, slope, b_min, b_max, reg_bus, svc_bus);
+        grid.tell_solver_need_reset();
+        REQUIRE(solve_ac(grid).size() == 3);
+        CHECK(std::abs(grid.get_V()(2)) == Approx(1.03).epsilon(1e-8));
+        // raising the bus above its natural voltage takes reactive injection
+        CHECK(std::get<1>(grid.get_svcs().get_res())(0) > 0.);
+    }
+    SECTION("REACTIVE_POWER mode injects exactly its setpoint") {
+        LSGrid grid = make_three_bus_grid();
+        RealVect target_vm(1), q_set(1);
+        target_vm << 1.0;
+        q_set << 25.;
+        grid.init_svcs({2}, target_vm, q_set, slope, b_min, b_max, reg_bus, svc_bus);
+        grid.tell_solver_need_reset();
+        REQUIRE(solve_ac(grid).size() == 3);
+        CHECK(std::get<1>(grid.get_svcs().get_res())(0) == Approx(25.).epsilon(1e-8));
+        CHECK(std::abs(grid.get_V()(2)) > std::abs(V_without(2)));
+    }
+    SECTION("OFF mode changes nothing") {
+        LSGrid grid = make_three_bus_grid();
+        RealVect target_vm(1), q_set(1);
+        target_vm << 1.03;
+        q_set << 25.;
+        grid.init_svcs({0}, target_vm, q_set, slope, b_min, b_max, reg_bus, svc_bus);
+        grid.tell_solver_need_reset();
+        REQUIRE(solve_ac(grid).size() == 3);
+        CHECK((grid.get_V() - V_without).norm() < 1e-10);
+    }
+}
+
+TEST_CASE("HVDC links between two converter stations", "[LSGrid][hvdc]")
+{
+    // one hvdc line between bus 1 (side 1, rectifier) and bus 2 (side 2),
+    // drawing 20 MW; helper filling the many init_hvdc_lines arguments
+    const auto add_hvdc = [](LSGrid & grid, int type2, bool vreg2_on,
+                             real_type vm2, real_type power_factor2) {
+        Eigen::VectorXi bus1(1), bus2(1);
+        bus1 << 1;
+        bus2 << 2;
+        // ConverterStationContainer::ConverterType: VSC = 0, LCC = 1
+        const std::vector<int> type1{0};
+        // HvdcLineContainer::ConvertersMode: SIDE_1_RECTIFIER = 0
+        const std::vector<int> mode{0};
+        const std::vector<bool> vreg1{false}, vreg2{vreg2_on}, no_droop{false};
+        const RealVect zero = RealVect::Zero(1);
+        RealVect vm1_pu(1), vm2_pu(1), q_min(1), q_max(1);
+        RealVect pf1(1), pf2(1), p_set(1), p_max(1);
+        vm1_pu << 1.0;
+        vm2_pu << vm2;
+        q_min << -1e6;
+        q_max << 1e6;
+        pf1 << 1.;
+        pf2 << power_factor2;
+        p_set << 20.;
+        p_max << 300.;
+        grid.init_hvdc_lines(bus1, bus2, type1, {type2},
+                             zero, zero,           // no station losses
+                             vreg1, vreg2, vm1_pu, vm2_pu,
+                             zero, zero,           // q setpoints
+                             q_min, q_max, q_min, q_max,
+                             pf1, pf2, mode, p_set,
+                             zero, zero,           // r_ohm, nominal_v (no line loss)
+                             no_droop, zero, zero, p_max, p_max);
+        grid.tell_solver_need_reset();
+    };
+
+    SECTION("a lossless VSC-VSC link moves its power setpoint") {
+        LSGrid grid = make_three_bus_grid();
+        add_hvdc(grid, /*type2=VSC*/ 0, false, 1.0, 1.);
+        REQUIRE(solve_ac(grid).size() == 3);
+        // generator sign convention: the rectifier consumes at bus 1, the
+        // inverter injects the (lossless) 20 MW at bus 2
+        CHECK(std::get<0>(grid.get_dcline_res1())(0) == Approx(-20.).epsilon(1e-8));
+        CHECK(std::get<0>(grid.get_dcline_res2())(0) == Approx(20.).epsilon(1e-8));
+    }
+    SECTION("a voltage-regulating VSC station holds its bus") {
+        LSGrid grid = make_three_bus_grid();
+        add_hvdc(grid, /*type2=VSC*/ 0, true, 1.03, 1.);
+        REQUIRE(solve_ac(grid).size() == 3);
+        CHECK(std::abs(grid.get_V()(2)) == Approx(1.03).epsilon(1e-8));
+    }
+    SECTION("an LCC station consumes reactive per its power factor") {
+        LSGrid grid = make_three_bus_grid();
+        add_hvdc(grid, /*type2=LCC*/ 1, false, 1.0, 0.9);
+        REQUIRE(solve_ac(grid).size() == 3);
+        const real_type p2 = std::get<0>(grid.get_dcline_res2())(0);
+        const real_type q2 = std::get<1>(grid.get_dcline_res2())(0);
+        CHECK(p2 == Approx(20.).epsilon(1e-8));
+        CHECK(q2 == Approx(-std::abs(p2) * std::tan(std::acos(0.9))).epsilon(1e-6));
+    }
+}
+
+TEST_CASE("distributed slack splits the mismatch by weight", "[LSGrid][slack]")
+{
+    LSGrid grid = make_three_bus_grid_two_gens();
+    grid.add_gen_slackbus(0, 0.7);
+    grid.add_gen_slackbus(1, 0.3);
+
+    REQUIRE(solve_ac(grid).size() == 3);
+    // both setpoints are 0 MW, so each gen's whole output is its slack share,
+    // and shares are proportional to the weights
+    const auto gen_res = grid.get_gen_res();
+    const real_type p0 = std::get<0>(gen_res)(0);
+    const real_type p1 = std::get<0>(gen_res)(1);
+    CHECK(p0 > 0.);
+    CHECK(p1 > 0.);
+    CHECK(p0 / 0.7 == Approx(p1 / 0.3).epsilon(1e-6));
+}
+
+TEST_CASE("remote voltage control pins the regulated bus", "[LSGrid][vctrl]")
+{
+    // the PV generator at bus 1 (target 1.04 pu) regulates bus 2 instead of
+    // its own bus (bordered VoltageControl extension, AC NR only)
+    LSGrid grid = make_three_bus_grid_two_gens(1.04);
+    grid.add_gen_slackbus(0, 1.);
+    grid.set_gen_regulated_bus(1, 2);
+    grid.tell_solver_need_reset();
+
+    REQUIRE(solve_ac(grid).size() == 3);
+    CHECK(std::abs(grid.get_V()(2)) == Approx(1.04).epsilon(1e-8));
+
+    // out-of-range regulated bus is rejected
+    CHECK_THROWS_AS(grid.set_gen_regulated_bus(1, 12), std::out_of_range);
 }
 
 TEST_CASE("documented error paths", "[LSGrid]")

--- a/src/tests/test_lsgrid.cpp
+++ b/src/tests/test_lsgrid.cpp
@@ -1,0 +1,278 @@
+// Copyright (c) 2026, RTE (https://www.rte-france.com)
+// See AUTHORS.txt
+// This Source Code Form is subject to the terms of the Mozilla Public License, version 2.0.
+// If a copy of the Mozilla Public License, version 2.0 was not distributed with this file,
+// you can obtain one at http://mozilla.org/MPL/2.0/.
+// SPDX-License-Identifier: MPL-2.0
+// This file is part of LightSim2grid, LightSim2grid implements a c++ backend targeting the Grid2Op platform.
+
+// Basic tests of the LSGrid main API, driven entirely from C++ (no python,
+// no grid2op, no external grid file): a 3-bus radial grid is built through
+// the init_* methods and solved with the always-available Eigen SparseLU
+// algorithms (the LSGrid constructor defaults, no KLU needed). Covers the
+// AC / DC powerflow contract (converged => per-bus V, diverged => empty
+// vector), physically-checkable results (power balance, DC angles), copy /
+// get_state / save_binary round trips, setpoint changes, element
+// deactivation, and the documented error paths.
+
+#include <cmath>
+#include <complex>
+#include <stdexcept>
+
+#include <catch2/catch_approx.hpp>
+#include <catch2/catch_test_macros.hpp>
+
+#include "LSGrid.hpp"
+#include "test_helpers.hpp"
+
+using Catch::Approx;
+using ls2g::LSGrid;
+using ls2g::CplxVect;
+using ls2g::RealVect;
+using ls2g::cplx_type;
+using ls2g::real_type;
+
+namespace {
+
+// Slack generator (1.02 pu) at bus 0, two identical lines 0-1 and 1-2
+// (x = 0.1 pu each), one 50 MW / 10 MVar load at bus 2. sn_mva = 100, so the
+// load is 0.5 pu and (with r = 0) the exact DC angles are 0 / -0.05 / -0.10.
+LSGrid make_three_bus_grid(real_type r_pu = 0.01)
+{
+    LSGrid grid;
+    grid.set_sn_mva(100.);
+    grid.set_init_vm_pu(1.0);
+
+    RealVect bus_vn_kv(3);
+    bus_vn_kv << 138., 138., 138.;
+    grid.init_bus(3, 1, bus_vn_kv, 0, 0);  // nb_line / nb_trafo args are unused
+
+    RealVect branch_r(2), branch_x(2);
+    branch_r << r_pu, r_pu;
+    branch_x << 0.1, 0.1;
+    const CplxVect branch_h = CplxVect::Zero(2);
+    Eigen::VectorXi from_id(2), to_id(2);
+    from_id << 0, 1;
+    to_id << 1, 2;
+    grid.init_powerlines(branch_r, branch_x, branch_h, from_id, to_id);
+
+    RealVect load_p(1), load_q(1);
+    load_p << 50.;
+    load_q << 10.;
+    Eigen::VectorXi load_bus(1);
+    load_bus << 2;
+    grid.init_loads(load_p, load_q, load_bus);
+
+    RealVect gen_p(1), gen_v(1), gen_min_q(1), gen_max_q(1);
+    gen_p << 0.;
+    gen_v << 1.02;
+    gen_min_q << -1000.;
+    gen_max_q << 1000.;
+    Eigen::VectorXi gen_bus(1);
+    gen_bus << 0;
+    grid.init_generators(gen_p, gen_v, gen_min_q, gen_max_q, gen_bus);
+    grid.add_gen_slackbus(0, 1.);
+    return grid;
+}
+
+CplxVect flat_start(const LSGrid & grid)
+{
+    return CplxVect::Constant(static_cast<Eigen::Index>(grid.total_bus()), cplx_type(1., 0.));
+}
+
+CplxVect solve_ac(LSGrid & grid)
+{
+    return grid.ac_pf(flat_start(grid), 20, 1e-8);
+}
+
+}  // anonymous namespace
+
+TEST_CASE("AC powerflow on a hand-built 3-bus grid converges and balances", "[LSGrid]")
+{
+    LSGrid grid = make_three_bus_grid();
+    const CplxVect V = solve_ac(grid);
+
+    // converged <=> non-empty per-bus voltage vector
+    REQUIRE(V.size() == 3);
+    CHECK(grid.get_algo().converged());
+    CHECK(grid.get_algo().get_error() == ls2g::ErrorType::NoError);
+    CHECK(grid.get_algo().get_nb_iter() >= 1);
+
+    // slack holds its voltage setpoint; magnitude drops along the feeder
+    CHECK(std::abs(V(0)) == Approx(1.02).epsilon(1e-8));
+    CHECK(std::abs(V(1)) < std::abs(V(0)));
+    CHECK(std::abs(V(2)) < std::abs(V(1)));
+
+    // the load draws exactly its setpoint
+    const auto load_res = grid.get_loads_res();  // (p_mw, q_mvar, v_kv)
+    CHECK(std::get<0>(load_res)(0) == Approx(50.).epsilon(1e-8));
+    CHECK(std::get<1>(load_res)(0) == Approx(10.).epsilon(1e-8));
+
+    // power balance: the slack covers the load plus the (positive) line
+    // losses, and its injection is what enters line 0 at bus 0
+    const auto line1 = grid.get_line_res1();  // "from" side (p_mw, q_mvar, v_kv, a)
+    const auto line2 = grid.get_line_res2();  // "to" side
+    const real_type loss0 = std::get<0>(line1)(0) + std::get<0>(line2)(0);
+    const real_type loss1 = std::get<0>(line1)(1) + std::get<0>(line2)(1);
+    CHECK(loss0 > 0.);
+    CHECK(loss1 > 0.);
+    const auto gen_res = grid.get_gen_res();
+    const real_type slack_p = std::get<0>(gen_res)(0);
+    CHECK(slack_p == Approx(50. + loss0 + loss1).epsilon(1e-6));
+    CHECK(slack_p == Approx(std::get<0>(line1)(0)).epsilon(1e-6));
+}
+
+TEST_CASE("DC powerflow reproduces the analytic angles of a lossless feeder", "[LSGrid]")
+{
+    // r = 0 so theta_k = -P * x * k holds exactly: 0.5 pu through x = 0.1 pu
+    // per line gives 0 / -0.05 / -0.10 rad
+    LSGrid grid = make_three_bus_grid(0.);
+    const CplxVect V = grid.dc_pf(flat_start(grid), 1, 1e-8);
+
+    REQUIRE(V.size() == 3);
+    CHECK(std::arg(V(0)) == Approx(0.).margin(1e-10));
+    CHECK(std::arg(V(1)) == Approx(-0.05).epsilon(1e-8));
+    CHECK(std::arg(V(2)) == Approx(-0.10).epsilon(1e-8));
+
+    // both lines carry the full 50 MW, losslessly
+    const auto line1 = grid.get_line_res1();
+    CHECK(std::get<0>(line1)(0) == Approx(50.).epsilon(1e-8));
+    CHECK(std::get<0>(line1)(1) == Approx(50.).epsilon(1e-8));
+}
+
+TEST_CASE("voltage getters follow the powerflow", "[LSGrid]")
+{
+    LSGrid grid = make_three_bus_grid();
+
+    SECTION("before any powerflow they throw") {
+        CHECK_THROWS_AS(grid.get_V(), std::runtime_error);
+        CHECK_THROWS_AS(grid.get_Va(), std::runtime_error);
+        CHECK_THROWS_AS(grid.get_Vm(), std::runtime_error);
+    }
+
+    SECTION("after a powerflow they match the returned vector") {
+        const CplxVect V = solve_ac(grid);
+        REQUIRE(V.size() == 3);
+        const CplxVect V_get = grid.get_V();
+        const RealVect Vm = grid.get_Vm();
+        const RealVect Va = grid.get_Va();
+        REQUIRE(V_get.size() == 3);
+        for (Eigen::Index i = 0; i < 3; ++i) {
+            CHECK(std::abs(V_get(i) - V(i)) < 1e-10);
+            CHECK(Vm(i) == Approx(std::abs(V(i))).epsilon(1e-10));
+            CHECK(Va(i) == Approx(std::arg(V(i))).margin(1e-10));
+        }
+    }
+}
+
+TEST_CASE("a diverging AC powerflow returns an empty vector, not garbage", "[LSGrid]")
+{
+    LSGrid grid = make_three_bus_grid();
+    // 100 GW through a 0.1 pu line cannot converge
+    grid.change_p_load(0, 1e5);
+    const CplxVect V = solve_ac(grid);
+    CHECK(V.size() == 0);
+    CHECK_FALSE(grid.get_algo().converged());
+    CHECK(grid.get_algo().get_error() != ls2g::ErrorType::NoError);
+}
+
+TEST_CASE("changing setpoints takes effect on the next solve", "[LSGrid]")
+{
+    LSGrid grid = make_three_bus_grid();
+    REQUIRE(solve_ac(grid).size() == 3);
+    const real_type slack_p_50 = std::get<0>(grid.get_gen_res())(0);
+
+    grid.change_p_load(0, 80.);
+    REQUIRE(solve_ac(grid).size() == 3);
+    CHECK(std::get<0>(grid.get_loads_res())(0) == Approx(80.).epsilon(1e-8));
+    CHECK(std::get<0>(grid.get_gen_res())(0) > slack_p_50);
+
+    grid.change_v_gen(0, 1.05);
+    const CplxVect V = solve_ac(grid);
+    REQUIRE(V.size() == 3);
+    CHECK(std::abs(V(0)) == Approx(1.05).epsilon(1e-8));
+}
+
+TEST_CASE("deactivating and reactivating a load", "[LSGrid]")
+{
+    LSGrid grid = make_three_bus_grid();
+
+    grid.deactivate_load(0);
+    REQUIRE(solve_ac(grid).size() == 3);
+    // nothing consumed: the slack only covers (near-zero) losses
+    CHECK(std::get<0>(grid.get_loads_res())(0) == Approx(0.).margin(1e-8));
+    CHECK(std::get<0>(grid.get_gen_res())(0) == Approx(0.).margin(1e-6));
+
+    grid.reactivate_load(0);
+    REQUIRE(solve_ac(grid).size() == 3);
+    CHECK(std::get<0>(grid.get_loads_res())(0) == Approx(50.).epsilon(1e-8));
+}
+
+TEST_CASE("copies are independent and solve to the same state", "[LSGrid]")
+{
+    LSGrid grid = make_three_bus_grid();
+    LSGrid other = grid.copy();
+
+    const CplxVect V = solve_ac(grid);
+    const CplxVect V_other = solve_ac(other);
+    REQUIRE(V.size() == 3);
+    REQUIRE(V_other.size() == 3);
+    CHECK((V - V_other).norm() < 1e-10);
+
+    // mutating the copy must not touch the original
+    other.change_p_load(0, 80.);
+    REQUIRE(solve_ac(grid).size() == 3);
+    CHECK(std::get<0>(grid.get_loads_res())(0) == Approx(50.).epsilon(1e-8));
+}
+
+TEST_CASE("get_state / set_state round-trips the whole grid", "[LSGrid]")
+{
+    LSGrid grid = make_three_bus_grid();
+    LSGrid::StateRes state = grid.get_state();
+
+    LSGrid restored;
+    restored.set_state(state);
+
+    const CplxVect V = solve_ac(grid);
+    const CplxVect V_restored = solve_ac(restored);
+    REQUIRE(V.size() == 3);
+    REQUIRE(V_restored.size() == 3);
+    CHECK((V - V_restored).norm() < 1e-10);
+    CHECK(restored.get_sn_mva() == Approx(100.));
+}
+
+TEST_CASE("save_binary / load_binary round-trips the whole grid", "[LSGrid]")
+{
+    LSGrid grid = make_three_bus_grid();
+    ls2g_test::TempFile file;
+    grid.save_binary(file.str());
+
+    LSGrid loaded = LSGrid::load_binary(file.str());
+    const CplxVect V = solve_ac(grid);
+    const CplxVect V_loaded = solve_ac(loaded);
+    REQUIRE(V.size() == 3);
+    REQUIRE(V_loaded.size() == 3);
+    CHECK((V - V_loaded).norm() < 1e-10);
+}
+
+TEST_CASE("documented error paths", "[LSGrid]")
+{
+    LSGrid grid = make_three_bus_grid();
+
+    SECTION("Vinit of the wrong size is rejected") {
+        CHECK_THROWS_AS(grid.ac_pf(CplxVect::Constant(2, cplx_type(1., 0.)), 20, 1e-8),
+                        std::runtime_error);
+        CHECK_THROWS_AS(grid.dc_pf(CplxVect::Constant(7, cplx_type(1., 0.)), 1, 1e-8),
+                        std::runtime_error);
+    }
+    SECTION("slack registration validates the generator id and weight") {
+        CHECK_THROWS_AS(grid.add_gen_slackbus(12, 1.), std::runtime_error);
+        CHECK_THROWS_AS(grid.add_gen_slackbus(-1, 1.), std::runtime_error);
+        CHECK_THROWS_AS(grid.add_gen_slackbus(0, 0.), std::runtime_error);
+    }
+    SECTION("element setters validate the element id") {
+        CHECK_THROWS_AS(grid.change_p_load(3, 10.), std::out_of_range);
+        CHECK_THROWS_AS(grid.change_v_gen(3, 1.), std::out_of_range);
+        CHECK_THROWS_AS(grid.deactivate_load(3), std::out_of_range);
+    }
+}


### PR DESCRIPTION
Item 4 of the serialization-hardening plan (after the ASan+UBSan job, the python corruption sweep and the debug-assertions job, all merged): the C++ core gets its own unit test suite, plus documentation for consuming `lightsim2grid_core` as a standalone C++ library.

## C++ unit tests (`src/tests/`, Catch2)

- **Catch2 v3.15.2** added as a git submodule (same precedent as eigen/SuiteSparse).
- `src/tests/CMakeLists.txt` follows the `src/core` standalone-guard idiom: `cmake -S src/tests` builds without python/pybind11/pip; also reachable from the root CMakeLists via `-DBUILD_TESTING=ON` (default **OFF**, wheels unaffected). Links `lightsim2grid_core` with the same `if(NOT TARGET)` guard as the python bindings.
- **BinaryArchive tests**: primitive + synthetic-StateRes round trips over every `ValueArchiver` specialization, every `require_count` bounds check (incl. overflow safety), magic/format/type-tag mismatches, `printable()` escaping, truncation and trailing-byte detection, the atomic temp-file commit/rollback lifecycle, the `fixup_binary_state` hook, on-disk bool normalization, and a C++ port of the python corruption sweep (byte flips, uint64 stamps, truncations at every offset).
- **LSGrid API tests**: a 3-bus grid built programmatically through the `init_*` methods and solved with the default Eigen SparseLU algorithms — AC/DC powerflow contract (converged ⇒ per-bus V, diverged ⇒ empty vector), power balance, analytic DC angles on a lossless feeder, voltage getters, copy independence, `get_state`/`set_state` and `save_binary`/`load_binary` round trips, setpoint changes, load deactivation, documented error paths.
- **New CI workflow** (`.github/workflows/cpp_unit_tests.yml`): build, ctest, then `valgrind --error-exitcode=1 --leak-check=full` over the same binary — practical only because the suite is a small plain binary (35 test cases, ~0.3 s).
- sdist excludes `Catch2/` and `src/tests/`.

## Bug found (and fixed) by the new tests

The very first valgrind run over the LSGrid tests flagged `save_binary` writing uninitialised bytes: `TrafoContainer::ignore_tap_side_for_shift_` and `shift_dependent_rx_` were only assigned in `init_trafo`, so **any grid built without trafos copied/serialized indeterminate bools** (UB; garbage bytes in binary files and pickles — the serialized bool at file offset 669 held 212). The python builders always call `init_trafo`, which is why the python suite never saw it. Both members now have default initializers.

## Docs

New `docs/cpp_library.rst` (in the Technical Documentation toctree): what `lightsim2grid_core` contains, building/installing it from source (`cmake -S src/core`, KLU detection and its graceful SparseLU fallback, the `__O3_OPTIM`-style env flags), consuming the copy shipped inside every pip wheel (`lightsim2grid.get_include()` / `get_cmake_dir()`), linking with CMake (`find_package(lightsim2grid_core CONFIG)` → `lightsim2grid::core`), the `add_subdirectory` embedding pattern, a complete build-a-grid-and-solve example, and how to run the C++ unit tests.

## Verification

- 35/35 tests green from a from-scratch standalone build; valgrind clean (0 errors, 0 leaks) after the TrafoContainer fix.
- Negative check performed (a deliberately broken assertion fails ctest).
- Docs page validated with a Sphinx build.
- Both commits are DCO signed-off.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H5MjAoBz1WWcVpZGkJTM5K

---
_Generated by [Claude Code](https://claude.ai/code/session_01H5MjAoBz1WWcVpZGkJTM5K)_