### PR TITLE
Compiler-friendliness pass: final/override hygiene, const-correctness, [[nodiscard]]

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -3,7 +3,28 @@
 # family targets exactly the class of bug found in the Eigen unnecessary-copy
 # audit (by-value Eigen/STL params, const-ref-to-value copies, ...);
 # readability-const-return-type catches `const T foo()` return types that
-# block move semantics on the caller side.
+# block move semantics on the caller side. misc-const-correctness covers the
+# same ground as the manual const-correctness sweep (see the element_container
+# / LSGrid commit it landed alongside): local variables that are never
+# reassigned but aren't declared const. Runs in ~5 minutes over src/core as of
+# this writing (own measurement, GCC 13 / clang-tidy 18) -- noticeably slower
+# than the other checks here, but still well within the report-only job's
+# budget.
+#
+# modernize-use-override: this codebase used to keep the `virtual` keyword on
+# overrides alongside `override`/`final`, which this check flags as
+# redundant on every single one of them -- ~80% pure noise against that
+# style in an initial run. Rather than suppress the check, the redundant
+# `virtual` was dropped codebase-wide (virtual is implied by `override`, and
+# by `final` on an actual override) as part of the same final/override sweep,
+# bringing this down to ~40 residual warnings, all in two explainable
+# buckets: (1) destructors not annotated `override`/`final` -- valid C++ to
+# add, but this codebase doesn't follow that particular style and it wasn't
+# worth changing here; (2) `override final` used together for defensive
+# compile-time checking (marks BOTH "this really overrides something" and
+# "no further overrides") -- the check prefers `final` alone since it
+# implies `override`, but the pair is intentional in a few places and left
+# as-is.
 #
 # Known false-positive class: performance-unnecessary-value-param flags every
 # `Eigen::Ref<...>` parameter passed by value (the idiom used throughout this
@@ -14,7 +35,9 @@
 Checks: >
   -*,
   performance-*,
-  readability-const-return-type
+  readability-const-return-type,
+  misc-const-correctness,
+  modernize-use-override
 WarningsAsErrors: ''
 # Only report on our own headers (src/core, src/bindings) -- clang-tidy's
 # default (empty) header filter would otherwise only ever look at the

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -17,14 +17,16 @@
 # style in an initial run. Rather than suppress the check, the redundant
 # `virtual` was dropped codebase-wide (virtual is implied by `override`, and
 # by `final` on an actual override) as part of the same final/override sweep,
-# bringing this down to ~40 residual warnings, all in two explainable
-# buckets: (1) destructors not annotated `override`/`final` -- valid C++ to
-# add, but this codebase doesn't follow that particular style and it wasn't
-# worth changing here; (2) `override final` used together for defensive
+# and every destructor overriding a base's virtual destructor was annotated
+# `override` too, bringing this down to 2 residual warnings, both the same
+# explainable case: `override final` used together for defensive
 # compile-time checking (marks BOTH "this really overrides something" and
-# "no further overrides") -- the check prefers `final` alone since it
-# implies `override`, but the pair is intentional in a few places and left
-# as-is.
+# "no further overrides") on a method in a class that ISN'T itself `final`
+# (OneSideContainer::disconnect_if_not_in_main_component,
+# TwoSidesContainer::nb_line_end) -- the check prefers `final` alone since it
+# implies `override`, but the pair is intentional there and left as-is.
+# (Classes that are themselves `final` don't repeat `final` on their
+# methods -- redundant, since the class already can't be subclassed at all.)
 #
 # Known false-positive class: performance-unnecessary-value-param flags every
 # `Eigen::Ref<...>` parameter passed by value (the idiom used throughout this

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -374,6 +374,16 @@ if(USE_O3_OPTIM)
 endif()
 
 if(NOT MSVC)
+    # Real (non-report-only) warnings, unlike the clang-tidy job: both are
+    # supported identically by GCC and Clang, cheap to check, and (as of this
+    # writing) clean on lightsim2grid_core -- so any future regression fails
+    # the build instead of waiting to be noticed in the advisory clang-tidy
+    # report. -Wsuggest-override catches a virtual override missing the
+    # `override`/`final` keyword; -Wnon-virtual-dtor catches a base class
+    # with virtual functions but a non-virtual (hence unsafe-to-delete-through-
+    # base-pointer) destructor.
+    target_compile_options(lightsim2grid_core PRIVATE -Wsuggest-override -Wnon-virtual-dtor)
+
     if(USE_O3_OPTIM)
         target_compile_options(lightsim2grid_core PRIVATE -O3)
     endif()

--- a/src/core/LSGrid.cpp
+++ b/src/core/LSGrid.cpp
@@ -1592,38 +1592,38 @@ void LSGrid::remove_gen_slackbus(int gen_id){
 }
 
 /** GRID2OP SPECIFIC REPRESENTATION **/
-void LSGrid::update_gens_p(Eigen::Ref<const Eigen::Array<bool, Eigen::Dynamic, Eigen::RowMajor> > has_changed,
-                              Eigen::Ref<const Eigen::Array<float, Eigen::Dynamic, Eigen::RowMajor> > new_values)
+void LSGrid::update_gens_p(const Eigen::Ref<const Eigen::Array<bool, Eigen::Dynamic, Eigen::RowMajor> > & has_changed,
+                              const Eigen::Ref<const Eigen::Array<float, Eigen::Dynamic, Eigen::RowMajor> > & new_values)
 {
     update_continuous_values(has_changed, new_values, &LSGrid::change_p_gen);
 }
 
-void LSGrid::update_sgens_p(Eigen::Ref<const Eigen::Array<bool, Eigen::Dynamic, Eigen::RowMajor> > has_changed,
-                              Eigen::Ref<const Eigen::Array<float, Eigen::Dynamic, Eigen::RowMajor> > new_values)
+void LSGrid::update_sgens_p(const Eigen::Ref<const Eigen::Array<bool, Eigen::Dynamic, Eigen::RowMajor> > & has_changed,
+                              const Eigen::Ref<const Eigen::Array<float, Eigen::Dynamic, Eigen::RowMajor> > & new_values)
 {
     update_continuous_values(has_changed, new_values, &LSGrid::change_p_sgen);
 }
 
-void LSGrid::update_gens_v(Eigen::Ref<const Eigen::Array<bool, Eigen::Dynamic, Eigen::RowMajor> > has_changed,
-                              Eigen::Ref<const Eigen::Array<float, Eigen::Dynamic, Eigen::RowMajor> > new_values)
+void LSGrid::update_gens_v(const Eigen::Ref<const Eigen::Array<bool, Eigen::Dynamic, Eigen::RowMajor> > & has_changed,
+                              const Eigen::Ref<const Eigen::Array<float, Eigen::Dynamic, Eigen::RowMajor> > & new_values)
 {
     update_continuous_values(has_changed, new_values, &LSGrid::change_v_gen);
 }
 
-void LSGrid::update_loads_p(Eigen::Ref<const Eigen::Array<bool, Eigen::Dynamic, Eigen::RowMajor> > has_changed,
-                              Eigen::Ref<const Eigen::Array<float, Eigen::Dynamic, Eigen::RowMajor> > new_values)
+void LSGrid::update_loads_p(const Eigen::Ref<const Eigen::Array<bool, Eigen::Dynamic, Eigen::RowMajor> > & has_changed,
+                              const Eigen::Ref<const Eigen::Array<float, Eigen::Dynamic, Eigen::RowMajor> > & new_values)
 {
     update_continuous_values(has_changed, new_values, &LSGrid::change_p_load);
 }
 
-void LSGrid::update_loads_q(Eigen::Ref<const Eigen::Array<bool, Eigen::Dynamic, Eigen::RowMajor> > has_changed,
-                              Eigen::Ref<const Eigen::Array<float, Eigen::Dynamic, Eigen::RowMajor> > new_values)
+void LSGrid::update_loads_q(const Eigen::Ref<const Eigen::Array<bool, Eigen::Dynamic, Eigen::RowMajor> > & has_changed,
+                              const Eigen::Ref<const Eigen::Array<float, Eigen::Dynamic, Eigen::RowMajor> > & new_values)
 {
     update_continuous_values(has_changed, new_values, &LSGrid::change_q_load);
 }
 
-void LSGrid::update_storages_p(Eigen::Ref<const Eigen::Array<bool, Eigen::Dynamic, Eigen::RowMajor> > has_changed,
-                              Eigen::Ref<const Eigen::Array<float, Eigen::Dynamic, Eigen::RowMajor> > new_values)
+void LSGrid::update_storages_p(const Eigen::Ref<const Eigen::Array<bool, Eigen::Dynamic, Eigen::RowMajor> > & has_changed,
+                              const Eigen::Ref<const Eigen::Array<float, Eigen::Dynamic, Eigen::RowMajor> > & new_values)
 {
     update_continuous_values(has_changed, new_values, &LSGrid::change_p_storage);
 }

--- a/src/core/LSGrid.cpp
+++ b/src/core/LSGrid.cpp
@@ -1592,38 +1592,38 @@ void LSGrid::remove_gen_slackbus(int gen_id){
 }
 
 /** GRID2OP SPECIFIC REPRESENTATION **/
-void LSGrid::update_gens_p(Eigen::Ref<Eigen::Array<bool, Eigen::Dynamic, Eigen::RowMajor> > has_changed,
-                              Eigen::Ref<Eigen::Array<float, Eigen::Dynamic, Eigen::RowMajor> > new_values)
+void LSGrid::update_gens_p(Eigen::Ref<const Eigen::Array<bool, Eigen::Dynamic, Eigen::RowMajor> > has_changed,
+                              Eigen::Ref<const Eigen::Array<float, Eigen::Dynamic, Eigen::RowMajor> > new_values)
 {
     update_continuous_values(has_changed, new_values, &LSGrid::change_p_gen);
 }
 
-void LSGrid::update_sgens_p(Eigen::Ref<Eigen::Array<bool, Eigen::Dynamic, Eigen::RowMajor> > has_changed,
-                              Eigen::Ref<Eigen::Array<float, Eigen::Dynamic, Eigen::RowMajor> > new_values)
+void LSGrid::update_sgens_p(Eigen::Ref<const Eigen::Array<bool, Eigen::Dynamic, Eigen::RowMajor> > has_changed,
+                              Eigen::Ref<const Eigen::Array<float, Eigen::Dynamic, Eigen::RowMajor> > new_values)
 {
     update_continuous_values(has_changed, new_values, &LSGrid::change_p_sgen);
 }
 
-void LSGrid::update_gens_v(Eigen::Ref<Eigen::Array<bool, Eigen::Dynamic, Eigen::RowMajor> > has_changed,
-                              Eigen::Ref<Eigen::Array<float, Eigen::Dynamic, Eigen::RowMajor> > new_values)
+void LSGrid::update_gens_v(Eigen::Ref<const Eigen::Array<bool, Eigen::Dynamic, Eigen::RowMajor> > has_changed,
+                              Eigen::Ref<const Eigen::Array<float, Eigen::Dynamic, Eigen::RowMajor> > new_values)
 {
     update_continuous_values(has_changed, new_values, &LSGrid::change_v_gen);
 }
 
-void LSGrid::update_loads_p(Eigen::Ref<Eigen::Array<bool, Eigen::Dynamic, Eigen::RowMajor> > has_changed,
-                              Eigen::Ref<Eigen::Array<float, Eigen::Dynamic, Eigen::RowMajor> > new_values)
+void LSGrid::update_loads_p(Eigen::Ref<const Eigen::Array<bool, Eigen::Dynamic, Eigen::RowMajor> > has_changed,
+                              Eigen::Ref<const Eigen::Array<float, Eigen::Dynamic, Eigen::RowMajor> > new_values)
 {
     update_continuous_values(has_changed, new_values, &LSGrid::change_p_load);
 }
 
-void LSGrid::update_loads_q(Eigen::Ref<Eigen::Array<bool, Eigen::Dynamic, Eigen::RowMajor> > has_changed,
-                              Eigen::Ref<Eigen::Array<float, Eigen::Dynamic, Eigen::RowMajor> > new_values)
+void LSGrid::update_loads_q(Eigen::Ref<const Eigen::Array<bool, Eigen::Dynamic, Eigen::RowMajor> > has_changed,
+                              Eigen::Ref<const Eigen::Array<float, Eigen::Dynamic, Eigen::RowMajor> > new_values)
 {
     update_continuous_values(has_changed, new_values, &LSGrid::change_q_load);
 }
 
-void LSGrid::update_storages_p(Eigen::Ref<Eigen::Array<bool, Eigen::Dynamic, Eigen::RowMajor> > has_changed,
-                              Eigen::Ref<Eigen::Array<float, Eigen::Dynamic, Eigen::RowMajor> > new_values)
+void LSGrid::update_storages_p(Eigen::Ref<const Eigen::Array<bool, Eigen::Dynamic, Eigen::RowMajor> > has_changed,
+                              Eigen::Ref<const Eigen::Array<float, Eigen::Dynamic, Eigen::RowMajor> > new_values)
 {
     update_continuous_values(has_changed, new_values, &LSGrid::change_p_storage);
 }

--- a/src/core/LSGrid.hpp
+++ b/src/core/LSGrid.hpp
@@ -990,7 +990,7 @@ class LS2G_API LSGrid final
          */
         void set_status_droop_hvdc(int dcline_id, int status) {hvdc_lines_.set_status_droop(dcline_id, status, algo_controler_); }
         [[nodiscard]] int get_status_droop_hvdc(int dcline_id) const {return hvdc_lines_.get_status_droop(dcline_id);}
-        [[nodiscard]] std::vector<int> get_status_droop_hvdc_vect() const {return hvdc_lines_.get_status_droop_vect();}
+        [[nodiscard]] Eigen::Ref<const IntVect> get_status_droop_hvdc_vect() const {return hvdc_lines_.get_status_droop_vect();}
         /**
          * Per-solve data of the connected angle-droop (AC emulation) hvdc
          * lines, in solver bus labelling and per-unit. Consumed by the Hvdc

--- a/src/core/LSGrid.hpp
+++ b/src/core/LSGrid.hpp
@@ -197,7 +197,7 @@ class LS2G_API LSGrid final
             generators_.turnedoff_pv(algo_controler_);
         }
         [[nodiscard]] bool get_turnedoff_gen_pv() const {return generators_.get_turnedoff_gen_pv();}
-        void update_slack_weights(Eigen::Ref<const Eigen::Array<bool, Eigen::Dynamic, Eigen::RowMajor> > could_be_slack){
+        void update_slack_weights(const Eigen::Ref<const Eigen::Array<bool, Eigen::Dynamic, Eigen::RowMajor> > & could_be_slack){
             generators_.update_slack_weights(could_be_slack, algo_controler_);
         }
         void update_slack_weights_by_id(Eigen::Ref<const IntVect> slack_ids){
@@ -1563,16 +1563,16 @@ class LS2G_API LSGrid final
 
         // part dedicated to grid2op backend, optimized for grid2op data representation (for speed)
         // this is not recommended to use it outside of its intended usage within grid2op !
-        void update_gens_p(Eigen::Ref<const Eigen::Array<bool, Eigen::Dynamic, Eigen::RowMajor> > has_changed,
-                           Eigen::Ref<const Eigen::Array<float, Eigen::Dynamic, Eigen::RowMajor> > new_values);
-        void update_sgens_p(Eigen::Ref<const Eigen::Array<bool, Eigen::Dynamic, Eigen::RowMajor> > has_changed,
-                           Eigen::Ref<const Eigen::Array<float, Eigen::Dynamic, Eigen::RowMajor> > new_values);
-        void update_gens_v(Eigen::Ref<const Eigen::Array<bool, Eigen::Dynamic, Eigen::RowMajor> > has_changed,
-                           Eigen::Ref<const Eigen::Array<float, Eigen::Dynamic, Eigen::RowMajor> > new_values);
-        void update_loads_p(Eigen::Ref<const Eigen::Array<bool, Eigen::Dynamic, Eigen::RowMajor> > has_changed,
-                            Eigen::Ref<const Eigen::Array<float, Eigen::Dynamic, Eigen::RowMajor> > new_values);
-        void update_loads_q(Eigen::Ref<const Eigen::Array<bool, Eigen::Dynamic, Eigen::RowMajor> > has_changed,
-                            Eigen::Ref<const Eigen::Array<float, Eigen::Dynamic, Eigen::RowMajor> > new_values);
+        void update_gens_p(const Eigen::Ref<const Eigen::Array<bool, Eigen::Dynamic, Eigen::RowMajor> > & has_changed,
+                           const Eigen::Ref<const Eigen::Array<float, Eigen::Dynamic, Eigen::RowMajor> > & new_values);
+        void update_sgens_p(const Eigen::Ref<const Eigen::Array<bool, Eigen::Dynamic, Eigen::RowMajor> > & has_changed,
+                           const Eigen::Ref<const Eigen::Array<float, Eigen::Dynamic, Eigen::RowMajor> > & new_values);
+        void update_gens_v(const Eigen::Ref<const Eigen::Array<bool, Eigen::Dynamic, Eigen::RowMajor> > & has_changed,
+                           const Eigen::Ref<const Eigen::Array<float, Eigen::Dynamic, Eigen::RowMajor> > & new_values);
+        void update_loads_p(const Eigen::Ref<const Eigen::Array<bool, Eigen::Dynamic, Eigen::RowMajor> > & has_changed,
+                            const Eigen::Ref<const Eigen::Array<float, Eigen::Dynamic, Eigen::RowMajor> > & new_values);
+        void update_loads_q(const Eigen::Ref<const Eigen::Array<bool, Eigen::Dynamic, Eigen::RowMajor> > & has_changed,
+                            const Eigen::Ref<const Eigen::Array<float, Eigen::Dynamic, Eigen::RowMajor> > & new_values);
         /**
          * Update the topology based on the topology vector id.
          *
@@ -1581,8 +1581,8 @@ class LS2G_API LSGrid final
          */
         void update_topo(Eigen::Ref<const Eigen::Array<bool, Eigen::Dynamic, Eigen::RowMajor> > has_changed,
                          Eigen::Ref<const Eigen::Array<int, Eigen::Dynamic, Eigen::RowMajor> > new_values);
-        void update_storages_p(Eigen::Ref<const Eigen::Array<bool, Eigen::Dynamic, Eigen::RowMajor> > has_changed,
-                               Eigen::Ref<const Eigen::Array<float, Eigen::Dynamic, Eigen::RowMajor> > new_values);
+        void update_storages_p(const Eigen::Ref<const Eigen::Array<bool, Eigen::Dynamic, Eigen::RowMajor> > & has_changed,
+                               const Eigen::Ref<const Eigen::Array<float, Eigen::Dynamic, Eigen::RowMajor> > & new_values);
 
         void set_load_pos_topo_vect(Eigen::Ref<const IntVect> load_pos_topo_vect)
         {
@@ -1940,8 +1940,8 @@ class LS2G_API LSGrid final
         optimization for grid2op
         **/
         template<class T>
-        void update_continuous_values(Eigen::Ref<const Eigen::Array<bool, Eigen::Dynamic, Eigen::RowMajor> > has_changed,
-                                      Eigen::Ref<const Eigen::Array<float, Eigen::Dynamic, Eigen::RowMajor> > new_values,
+        void update_continuous_values(const Eigen::Ref<const Eigen::Array<bool, Eigen::Dynamic, Eigen::RowMajor> > & has_changed,
+                                      const Eigen::Ref<const Eigen::Array<float, Eigen::Dynamic, Eigen::RowMajor> > & new_values,
                                       T fun)
         {
             // new_values is indexed by has_changed's length below; a shorter new_values

--- a/src/core/LSGrid.hpp
+++ b/src/core/LSGrid.hpp
@@ -150,8 +150,8 @@ class LS2G_API LSGrid final
 
         void set_ls_to_orig(const IntVect & ls_to_orig);  // set both _ls_to_orig and _orig_to_ls
         void set_orig_to_ls(const IntVect & orig_to_ls);  // set both _orig_to_ls and _ls_to_orig
-        const IntVect & get_ls_to_orig(void) const {return _ls_to_orig;}
-        const IntVect & get_orig_to_ls(void) const {return _orig_to_ls;}
+        [[nodiscard]] const IntVect & get_ls_to_orig(void) const {return _ls_to_orig;}
+        [[nodiscard]] const IntVect & get_orig_to_ls(void) const {return _orig_to_ls;}
         double timer_last_ac_pf() const {return timer_last_ac_pf_;}
         double timer_last_dc_pf() const {return timer_last_dc_pf_;}
 
@@ -183,7 +183,7 @@ class LS2G_API LSGrid final
         }
 
         // retrieve the underlying data (raw class)
-        const GeneratorContainer & get_generators_as_data() const {return generators_;}
+        [[nodiscard]] const GeneratorContainer & get_generators_as_data() const {return generators_;}
         // turned off generators are not pv
         void turnedoff_no_pv(){
             algo_controler_.ac_algo_controler().has_pv_changed(); 
@@ -196,7 +196,7 @@ class LS2G_API LSGrid final
             algo_controler_.dc_algo_controler().has_pv_changed();
             generators_.turnedoff_pv(algo_controler_);
         }
-        bool get_turnedoff_gen_pv() const {return generators_.get_turnedoff_gen_pv();}
+        [[nodiscard]] bool get_turnedoff_gen_pv() const {return generators_.get_turnedoff_gen_pv();}
         void update_slack_weights(Eigen::Ref<const Eigen::Array<bool, Eigen::Dynamic, Eigen::RowMajor> > could_be_slack){
             generators_.update_slack_weights(could_be_slack, algo_controler_);
         }
@@ -216,21 +216,21 @@ class LS2G_API LSGrid final
             algo_controler_.ac_algo_controler().tell_slack_participate_changed();
             algo_controler_.dc_algo_controler().tell_slack_participate_changed();
         }
-        int get_reference_slack_bus() const {return _forced_ref_slack_bus_id;}
+        [[nodiscard]] int get_reference_slack_bus() const {return _forced_ref_slack_bus_id;}
 
-        const SGenContainer & get_static_generators_as_data() const {return sgens_;}
-        const LoadContainer & get_loads_as_data() const {return loads_;}
-        const LineContainer & get_powerlines_as_data() const {return powerlines_;}
-        const TrafoContainer & get_trafos_as_data() const {return trafos_;}
-        const HvdcLineContainer & get_dclines_as_data() const {return hvdc_lines_;}
-        Eigen::Ref<const RealVect> get_bus_vn_kv() const {return substations_.get_bus_vn_kv();}
+        [[nodiscard]] const SGenContainer & get_static_generators_as_data() const {return sgens_;}
+        [[nodiscard]] const LoadContainer & get_loads_as_data() const {return loads_;}
+        [[nodiscard]] const LineContainer & get_powerlines_as_data() const {return powerlines_;}
+        [[nodiscard]] const TrafoContainer & get_trafos_as_data() const {return trafos_;}
+        [[nodiscard]] const HvdcLineContainer & get_dclines_as_data() const {return hvdc_lines_;}
+        [[nodiscard]] Eigen::Ref<const RealVect> get_bus_vn_kv() const {return substations_.get_bus_vn_kv();}
 
         // per-bus min/max operating voltage (kV), optional: empty if never set
         void set_bus_voltage_limits(const RealVect & bus_vmin_kv, const RealVect & bus_vmax_kv){
             substations_.init_bus_voltage_limits(bus_vmin_kv, bus_vmax_kv);
         }
-        Eigen::Ref<const RealVect> get_bus_vmin_kv() const {return substations_.get_bus_vmin_kv();}
-        Eigen::Ref<const RealVect> get_bus_vmax_kv() const {return substations_.get_bus_vmax_kv();}
+        [[nodiscard]] Eigen::Ref<const RealVect> get_bus_vmin_kv() const {return substations_.get_bus_vmin_kv();}
+        [[nodiscard]] Eigen::Ref<const RealVect> get_bus_vmax_kv() const {return substations_.get_bus_vmax_kv();}
 
         std::tuple<int, int> assign_slack_to_most_connected();
         void consider_only_main_component();
@@ -242,7 +242,7 @@ class LS2G_API LSGrid final
             powerlines_.set_ignore_status_global(ignore_status_global);
             trafos_.set_ignore_status_global(ignore_status_global);
         }
-        bool get_ignore_status_global() const{
+        [[nodiscard]] bool get_ignore_status_global() const{
             return powerlines_.get_ignore_status_global();
         }
         /**
@@ -253,7 +253,7 @@ class LS2G_API LSGrid final
             powerlines_.set_synch_status_both_side(synch_status_both_side);
             trafos_.set_synch_status_both_side(synch_status_both_side);
         }
-        bool get_synch_status_both_side() const{
+        [[nodiscard]] bool get_synch_status_both_side() const{
             return powerlines_.get_synch_status_both_side();
         }
 
@@ -290,10 +290,10 @@ class LS2G_API LSGrid final
         std::vector<std::string> available_algorithm_names() const {
             return AlgorithmRegistry::instance().available_algorithm_names();
         }
-        AlgorithmType get_algo_type() const {return _algo.get_type(); }
-        AlgorithmType get_dc_algo_type() const {return _dc_algo.get_type(); }
-        const AlgorithmSelector & get_algo() const {return _algo;}
-        const AlgorithmSelector & get_dc_algo() const {return _dc_algo;}
+        [[nodiscard]] AlgorithmType get_algo_type() const {return _algo.get_type(); }
+        [[nodiscard]] AlgorithmType get_dc_algo_type() const {return _dc_algo.get_type(); }
+        [[nodiscard]] const AlgorithmSelector & get_algo() const {return _algo;}
+        [[nodiscard]] const AlgorithmSelector & get_dc_algo() const {return _dc_algo;}
 
         // do i compute the results (in terms of P,Q,V or loads, generators and flows on lines
         void deactivate_result_computation(){compute_results_=false;}
@@ -302,9 +302,9 @@ class LS2G_API LSGrid final
         // All methods to init this data model, all need to be pair unit when applicable
         void init_bus(unsigned int n_sub, unsigned int n_busbar_per_sub, const Eigen::Ref<const RealVect> & bus_vn_kv, int nb_line, int nb_trafo);
         void set_init_vm_pu(real_type init_vm_pu) {init_vm_pu_ = init_vm_pu; }
-        real_type get_init_vm_pu() const {return init_vm_pu_;}
+        [[nodiscard]] real_type get_init_vm_pu() const {return init_vm_pu_;}
         void set_sn_mva(real_type sn_mva) {sn_mva_ = sn_mva; }
-        real_type get_sn_mva() const {return sn_mva_;}
+        [[nodiscard]] real_type get_sn_mva() const {return sn_mva_;}
 
         void init_powerlines(const Eigen::Ref<const RealVect> & branch_r,
                              const Eigen::Ref<const RealVect> & branch_x,
@@ -498,7 +498,7 @@ class LS2G_API LSGrid final
         void set_substation_names(const std::vector<std::string> & sub_names){
             substations_.init_sub_names(sub_names);
         }
-        const std::vector<std::string> & get_substation_names()const {
+        [[nodiscard]] const std::vector<std::string> & get_substation_names()const {
             return substations_.get_sub_names();
         }
 
@@ -524,9 +524,9 @@ class LS2G_API LSGrid final
 
         // algo config (scaling/refactor policy params) — also part of StateRes,
         // see LSGrid::get_state()/set_state()
-        AlgoConfig get_ac_algo_config() const { return _algo.get_config(); }
+        [[nodiscard]] AlgoConfig get_ac_algo_config() const { return _algo.get_config(); }
         void set_ac_algo_config(const AlgoConfig& cfg) { _algo.set_config(cfg); }
-        AlgoConfig get_dc_algo_config() const { return _dc_algo.get_config(); }
+        [[nodiscard]] AlgoConfig get_dc_algo_config() const { return _dc_algo.get_config(); }
         void set_dc_algo_config(const AlgoConfig& cfg) { _dc_algo.set_config(cfg); }
         template<class T>
         void check_size(const T& my_state)
@@ -565,8 +565,8 @@ class LS2G_API LSGrid final
             algo_controler_.dc_algo_controler().tell_solver_need_reset();
         }
         void tell_ybus_change_sparsity_pattern(){algo_controler_.ac_algo_controler().tell_ybus_change_sparsity_pattern(); algo_controler_.dc_algo_controler().tell_ybus_change_sparsity_pattern();}
-        const AlgoControl & get_ac_algo_controler() const {return algo_controler_.ac_algo_controler();}
-        const AlgoControl & get_dc_algo_controler() const {return algo_controler_.dc_algo_controler();}
+        [[nodiscard]] const AlgoControl & get_ac_algo_controler() const {return algo_controler_.ac_algo_controler();}
+        [[nodiscard]] const AlgoControl & get_dc_algo_controler() const {return algo_controler_.dc_algo_controler();}
 
         // dc powerflow
         CplxVect dc_pf(const Eigen::Ref<const CplxVect> & Vinit,
@@ -668,23 +668,23 @@ class LS2G_API LSGrid final
         size_t nb_trafo() const {return trafos_.nb();}
 
         // read only data accessor
-        const SubstationContainer & get_substations() const {return substations_;}
-        const LineContainer & get_lines() const {return powerlines_;}
-        const HvdcLineContainer & get_dclines() const {return hvdc_lines_;}
-        const TrafoContainer & get_trafos() const {return trafos_;}
-        const GeneratorContainer & get_generators() const {return generators_;}
-        const LoadContainer & get_loads() const {return loads_;}
-        const StorageContainer & get_storages() const {return storages_;}
-        const SGenContainer & get_static_generators() const {return sgens_;}
-        const SvcContainer & get_svcs() const {return svcs_;}
-        const ShuntContainer & get_shunts() const {return shunts_;}
-        const std::vector<bool> & get_bus_status() const {return substations_.get_bus_status();}
+        [[nodiscard]] const SubstationContainer & get_substations() const {return substations_;}
+        [[nodiscard]] const LineContainer & get_lines() const {return powerlines_;}
+        [[nodiscard]] const HvdcLineContainer & get_dclines() const {return hvdc_lines_;}
+        [[nodiscard]] const TrafoContainer & get_trafos() const {return trafos_;}
+        [[nodiscard]] const GeneratorContainer & get_generators() const {return generators_;}
+        [[nodiscard]] const LoadContainer & get_loads() const {return loads_;}
+        [[nodiscard]] const StorageContainer & get_storages() const {return storages_;}
+        [[nodiscard]] const SGenContainer & get_static_generators() const {return sgens_;}
+        [[nodiscard]] const SvcContainer & get_svcs() const {return svcs_;}
+        [[nodiscard]] const ShuntContainer & get_shunts() const {return shunts_;}
+        [[nodiscard]] const std::vector<bool> & get_bus_status() const {return substations_.get_bus_status();}
         
         void set_line_names(const std::vector<std::string> & names){
             GenericContainer::check_size(names, powerlines_.nb(), "set_line_names");
             powerlines_.set_names(names);
         }
-        const std::vector<std::string> & get_line_names() const {return powerlines_.get_names();}
+        [[nodiscard]] const std::vector<std::string> & get_line_names() const {return powerlines_.get_names();}
         void set_dcline_names(const std::vector<std::string> & names){
             GenericContainer::check_size(names, hvdc_lines_.nb(), "set_dcline_names");
             hvdc_lines_.set_names(names);
@@ -693,7 +693,7 @@ class LS2G_API LSGrid final
             GenericContainer::check_size(names, trafos_.nb(), "set_trafo_names");
             trafos_.set_names(names);
         }
-        const std::vector<std::string> & get_trafo_names() const {return trafos_.get_names();}
+        [[nodiscard]] const std::vector<std::string> & get_trafo_names() const {return trafos_.get_names();}
         // per-side current limit, in kA, optional: empty if never set
         void set_line_current_limit_side1(const RealVect & limit_a1_ka){
             GenericContainer::check_size(limit_a1_ka, powerlines_.nb(), "set_line_current_limit_side1");
@@ -869,7 +869,7 @@ class LS2G_API LSGrid final
         }
         void change_p_load(int load_id, real_type new_p) {loads_.change_p_nothrow(load_id, new_p, algo_controler_); }
         void change_q_load(int load_id, real_type new_q) {loads_.change_q_nothrow(load_id, new_q, algo_controler_); }
-        int get_bus_load(int load_id) const {return loads_.get_bus(load_id).cast_int();}
+        [[nodiscard]] int get_bus_load(int load_id) const {return loads_.get_bus(load_id).cast_int();}
 
         //generator
         void deactivate_gen(int gen_id) {generators_.deactivate(gen_id, algo_controler_); }
@@ -889,7 +889,7 @@ class LS2G_API LSGrid final
         void change_p_gen(int gen_id, real_type new_p) {generators_.change_p_nothrow(gen_id, new_p, algo_controler_); }
         void change_q_gen(int gen_id, real_type new_q) {generators_.change_q_nothrow(gen_id, new_q, algo_controler_); }
         void change_v_gen(int gen_id, real_type new_v_pu) {generators_.change_v_nothrow(gen_id, new_v_pu, algo_controler_); }
-        int get_bus_gen(int gen_id) const {return generators_.get_bus(gen_id).cast_int();}
+        [[nodiscard]] int get_bus_gen(int gen_id) const {return generators_.get_bus(gen_id).cast_int();}
 
         //static var compensator (SVC)
         void deactivate_svc(int svc_id) {svcs_.deactivate(svc_id, algo_controler_); }
@@ -900,7 +900,7 @@ class LS2G_API LSGrid final
         void change_bus_svc_python(int svc_id, int new_gridmodel_bus_id) {
             change_bus_svc(svc_id, GridModelBusId(new_gridmodel_bus_id));
         }
-        int get_bus_svc(int svc_id) const {return svcs_.get_bus(svc_id).cast_int();}
+        [[nodiscard]] int get_bus_svc(int svc_id) const {return svcs_.get_bus(svc_id).cast_int();}
         void set_svc_names(const std::vector<std::string> & names){
             GenericContainer::check_size(names, svcs_.nb(), "set_svc_names");
             svcs_.set_names(names);
@@ -922,7 +922,7 @@ class LS2G_API LSGrid final
         }
         void change_p_shunt(int shunt_id, real_type new_p) {shunts_.change_p_nothrow(shunt_id, new_p, algo_controler_); }
         void change_q_shunt(int shunt_id, real_type new_q) {shunts_.change_q_nothrow(shunt_id, new_q, algo_controler_); }
-        int get_bus_shunt(int shunt_id) const {return shunts_.get_bus(shunt_id).cast_int();}
+        [[nodiscard]] int get_bus_shunt(int shunt_id) const {return shunts_.get_bus(shunt_id).cast_int();}
 
         //static gen
         void deactivate_sgen(int sgen_id) {sgens_.deactivate(sgen_id, algo_controler_); }
@@ -940,7 +940,7 @@ class LS2G_API LSGrid final
         }
         void change_p_sgen(int sgen_id, real_type new_p) {sgens_.change_p_nothrow(sgen_id, new_p, algo_controler_); }
         void change_q_sgen(int sgen_id, real_type new_q) {sgens_.change_q_nothrow(sgen_id, new_q, algo_controler_); }
-        int get_bus_sgen(int sgen_id) const {return sgens_.get_bus(sgen_id).cast_int();}
+        [[nodiscard]] int get_bus_sgen(int sgen_id) const {return sgens_.get_bus(sgen_id).cast_int();}
 
         //storage units
         void deactivate_storage(int storage_id) {storages_.deactivate(storage_id, algo_controler_); }
@@ -960,7 +960,7 @@ class LS2G_API LSGrid final
                storages_.change_p_nothrow(storage_id, new_p, algo_controler_);
             }
         void change_q_storage(int storage_id, real_type new_q) {storages_.change_q_nothrow(storage_id, new_q, algo_controler_); }
-        int get_bus_storage(int storage_id) const {return storages_.get_bus(storage_id).cast_int();}
+        [[nodiscard]] int get_bus_storage(int storage_id) const {return storages_.get_bus(storage_id).cast_int();}
 
         //deactivate a powerline (disconnect it)
         void deactivate_dcline(int dcline_id) {hvdc_lines_.deactivate(dcline_id, algo_controler_); }
@@ -989,8 +989,8 @@ class LS2G_API LSGrid final
          * pmax_2to1) is meant to be run between two solves, in Python.
          */
         void set_status_droop_hvdc(int dcline_id, int status) {hvdc_lines_.set_status_droop(dcline_id, status, algo_controler_); }
-        int get_status_droop_hvdc(int dcline_id) const {return hvdc_lines_.get_status_droop(dcline_id);}
-        std::vector<int> get_status_droop_hvdc_vect() const {return hvdc_lines_.get_status_droop_vect();}
+        [[nodiscard]] int get_status_droop_hvdc(int dcline_id) const {return hvdc_lines_.get_status_droop(dcline_id);}
+        [[nodiscard]] std::vector<int> get_status_droop_hvdc_vect() const {return hvdc_lines_.get_status_droop_vect();}
         /**
          * Per-solve data of the connected angle-droop (AC emulation) hvdc
          * lines, in solver bus labelling and per-unit. Consumed by the Hvdc
@@ -1071,69 +1071,69 @@ class LS2G_API LSGrid final
         void change_bus2_dcline_python(int dcline_id, int new_gridmodel_bus_id) {
             change_bus2_dcline(dcline_id, GridModelBusId(new_gridmodel_bus_id)); 
         }
-        int get_bus1_dcline(int dcline_id) const {return hvdc_lines_.get_bus_side_1(dcline_id).cast_int();}
-        int get_bus2_dcline(int dcline_id) const {return hvdc_lines_.get_bus_side_2(dcline_id).cast_int();}
+        [[nodiscard]] int get_bus1_dcline(int dcline_id) const {return hvdc_lines_.get_bus_side_1(dcline_id).cast_int();}
+        [[nodiscard]] int get_bus2_dcline(int dcline_id) const {return hvdc_lines_.get_bus_side_2(dcline_id).cast_int();}
 
         // All results access
-        tuple3d get_loads_res() const {return loads_.get_res();}
-        const std::vector<bool>& get_loads_status() const { return loads_.get_status();}
-        tuple3d get_shunts_res() const {return shunts_.get_res();}
-        const std::vector<bool>& get_shunts_status() const { return shunts_.get_status();}
-        tuple3d get_gen_res() const {return generators_.get_res();}
-        const std::vector<bool>& get_gen_status() const { return generators_.get_status();}
-        tuple4d get_line_res1() const {return powerlines_.get_res_side_1();}
-        tuple4d get_line_res2() const {return powerlines_.get_res_side_2();}
-        const std::vector<bool>& get_lines_status() const { return powerlines_.get_status_global();}
+        [[nodiscard]] tuple3d get_loads_res() const {return loads_.get_res();}
+        [[nodiscard]] const std::vector<bool>& get_loads_status() const { return loads_.get_status();}
+        [[nodiscard]] tuple3d get_shunts_res() const {return shunts_.get_res();}
+        [[nodiscard]] const std::vector<bool>& get_shunts_status() const { return shunts_.get_status();}
+        [[nodiscard]] tuple3d get_gen_res() const {return generators_.get_res();}
+        [[nodiscard]] const std::vector<bool>& get_gen_status() const { return generators_.get_status();}
+        [[nodiscard]] tuple4d get_line_res1() const {return powerlines_.get_res_side_1();}
+        [[nodiscard]] tuple4d get_line_res2() const {return powerlines_.get_res_side_2();}
+        [[nodiscard]] const std::vector<bool>& get_lines_status() const { return powerlines_.get_status_global();}
         // per-side status (relevant for half-open lines, see `set_synch_status_both_side` /
         // `keep_half_open_lines`): `get_lines_status()` is the *global* status (both sides
         // disconnected), these report each side independently.
-        const std::vector<bool>& get_lines_status_side1() const { return powerlines_.get_status_side_1();}
-        const std::vector<bool>& get_lines_status_side2() const { return powerlines_.get_status_side_2();}
-        tuple4d get_trafo_res1() const {return trafos_.get_res_side_1();}
-        tuple4d get_trafo_res2() const {return trafos_.get_res_side_2();}
-        const std::vector<bool>& get_trafo_status() const { return trafos_.get_status_global();}
-        const std::vector<bool>& get_trafo_status_side1() const { return trafos_.get_status_side_1();}
-        const std::vector<bool>& get_trafo_status_side2() const { return trafos_.get_status_side_2();}
-        tuple3d get_storages_res() const {return storages_.get_res();}
-        const std::vector<bool>& get_storages_status() const { return storages_.get_status();}
-        tuple3d get_sgens_res() const {return sgens_.get_res();}
-        const std::vector<bool>& get_sgens_status() const { return sgens_.get_status();}
-        tuple3d get_dcline_res1() const {return hvdc_lines_.get_res_side_1();}
-        tuple3d get_dcline_res2() const {return hvdc_lines_.get_res_side_2();}
-        const std::vector<bool>& get_dclines_status() const { return hvdc_lines_.get_status_global();}
+        [[nodiscard]] const std::vector<bool>& get_lines_status_side1() const { return powerlines_.get_status_side_1();}
+        [[nodiscard]] const std::vector<bool>& get_lines_status_side2() const { return powerlines_.get_status_side_2();}
+        [[nodiscard]] tuple4d get_trafo_res1() const {return trafos_.get_res_side_1();}
+        [[nodiscard]] tuple4d get_trafo_res2() const {return trafos_.get_res_side_2();}
+        [[nodiscard]] const std::vector<bool>& get_trafo_status() const { return trafos_.get_status_global();}
+        [[nodiscard]] const std::vector<bool>& get_trafo_status_side1() const { return trafos_.get_status_side_1();}
+        [[nodiscard]] const std::vector<bool>& get_trafo_status_side2() const { return trafos_.get_status_side_2();}
+        [[nodiscard]] tuple3d get_storages_res() const {return storages_.get_res();}
+        [[nodiscard]] const std::vector<bool>& get_storages_status() const { return storages_.get_status();}
+        [[nodiscard]] tuple3d get_sgens_res() const {return sgens_.get_res();}
+        [[nodiscard]] const std::vector<bool>& get_sgens_status() const { return sgens_.get_status();}
+        [[nodiscard]] tuple3d get_dcline_res1() const {return hvdc_lines_.get_res_side_1();}
+        [[nodiscard]] tuple3d get_dcline_res2() const {return hvdc_lines_.get_res_side_2();}
+        [[nodiscard]] const std::vector<bool>& get_dclines_status() const { return hvdc_lines_.get_status_global();}
 
-        Eigen::Ref<const RealVect> get_gen_theta() const  {return generators_.get_theta();}
-        Eigen::Ref<const RealVect> get_load_theta() const  {return loads_.get_theta();}
-        Eigen::Ref<const RealVect> get_shunt_theta() const  {return shunts_.get_theta();}
-        Eigen::Ref<const RealVect> get_storage_theta() const  {return storages_.get_theta();}
-        Eigen::Ref<const RealVect> get_line_theta1() const {return powerlines_.get_theta_side_1();}
-        Eigen::Ref<const RealVect> get_line_theta2() const {return powerlines_.get_theta_side_2();}
-        Eigen::Ref<const RealVect> get_trafo_theta1() const {return trafos_.get_theta_side_1();}
-        Eigen::Ref<const RealVect> get_trafo_theta2() const {return trafos_.get_theta_side_2();}
-        Eigen::Ref<const RealVect> get_dcline_theta1() const {return hvdc_lines_.get_theta_side_1();}
-        Eigen::Ref<const RealVect> get_dcline_theta2() const {return hvdc_lines_.get_theta_side_2();}
+        [[nodiscard]] Eigen::Ref<const RealVect> get_gen_theta() const  {return generators_.get_theta();}
+        [[nodiscard]] Eigen::Ref<const RealVect> get_load_theta() const  {return loads_.get_theta();}
+        [[nodiscard]] Eigen::Ref<const RealVect> get_shunt_theta() const  {return shunts_.get_theta();}
+        [[nodiscard]] Eigen::Ref<const RealVect> get_storage_theta() const  {return storages_.get_theta();}
+        [[nodiscard]] Eigen::Ref<const RealVect> get_line_theta1() const {return powerlines_.get_theta_side_1();}
+        [[nodiscard]] Eigen::Ref<const RealVect> get_line_theta2() const {return powerlines_.get_theta_side_2();}
+        [[nodiscard]] Eigen::Ref<const RealVect> get_trafo_theta1() const {return trafos_.get_theta_side_1();}
+        [[nodiscard]] Eigen::Ref<const RealVect> get_trafo_theta2() const {return trafos_.get_theta_side_2();}
+        [[nodiscard]] Eigen::Ref<const RealVect> get_dcline_theta1() const {return hvdc_lines_.get_theta_side_1();}
+        [[nodiscard]] Eigen::Ref<const RealVect> get_dcline_theta2() const {return hvdc_lines_.get_theta_side_2();}
 
-        const GlobalBusIdVect & get_all_shunt_buses() const {return shunts_.get_buses();}
-        Eigen::Ref<const IntVect> get_all_shunt_buses_numpy() const {return shunts_.get_bus_id_numpy();}
+        [[nodiscard]] const GlobalBusIdVect & get_all_shunt_buses() const {return shunts_.get_buses();}
+        [[nodiscard]] Eigen::Ref<const IntVect> get_all_shunt_buses_numpy() const {return shunts_.get_bus_id_numpy();}
 
-        Eigen::Ref<const RealVect>  get_shunt_target_p() const {return shunts_.get_target_p();}
-        Eigen::Ref<const RealVect>  get_load_target_p() const {return loads_.get_target_p();}
-        Eigen::Ref<const RealVect>  get_gen_target_p() const {return generators_.get_target_p();}
-        Eigen::Ref<const RealVect>  get_sgen_target_p() const {return sgens_.get_target_p();}
-        Eigen::Ref<const RealVect>  get_storage_target_p() const {return storages_.get_target_p();}
+        [[nodiscard]] Eigen::Ref<const RealVect>  get_shunt_target_p() const {return shunts_.get_target_p();}
+        [[nodiscard]] Eigen::Ref<const RealVect>  get_load_target_p() const {return loads_.get_target_p();}
+        [[nodiscard]] Eigen::Ref<const RealVect>  get_gen_target_p() const {return generators_.get_target_p();}
+        [[nodiscard]] Eigen::Ref<const RealVect>  get_sgen_target_p() const {return sgens_.get_target_p();}
+        [[nodiscard]] Eigen::Ref<const RealVect>  get_storage_target_p() const {return storages_.get_target_p();}
 
         // complete results (with theta)
-        tuple4d get_loads_res_full() const {return loads_.get_res_full();}
-        tuple4d get_shunts_res_full() const {return shunts_.get_res_full();}
-        tuple4d get_gen_res_full() const {return generators_.get_res_full();}
-        tuple5d get_line_res1_full() const {return powerlines_.get_res_full_side_1();}
-        tuple5d get_line_res2_full() const {return powerlines_.get_res_full_side_2();}
-        tuple5d get_trafo_res1_full() const {return trafos_.get_res_full_side_1();}
-        tuple5d get_trafo_res2_full() const {return trafos_.get_res_full_side_2();}
-        tuple4d get_storages_res_full() const {return storages_.get_res_full();}
-        tuple4d get_sgens_res_full() const {return sgens_.get_res_full();}
-        tuple4d get_dcline_res1_full() const {return hvdc_lines_.get_res_full_side_1();}
-        tuple4d get_dcline_res2_full() const {return hvdc_lines_.get_res_full_side_2();}
+        [[nodiscard]] tuple4d get_loads_res_full() const {return loads_.get_res_full();}
+        [[nodiscard]] tuple4d get_shunts_res_full() const {return shunts_.get_res_full();}
+        [[nodiscard]] tuple4d get_gen_res_full() const {return generators_.get_res_full();}
+        [[nodiscard]] tuple5d get_line_res1_full() const {return powerlines_.get_res_full_side_1();}
+        [[nodiscard]] tuple5d get_line_res2_full() const {return powerlines_.get_res_full_side_2();}
+        [[nodiscard]] tuple5d get_trafo_res1_full() const {return trafos_.get_res_full_side_1();}
+        [[nodiscard]] tuple5d get_trafo_res2_full() const {return trafos_.get_res_full_side_2();}
+        [[nodiscard]] tuple4d get_storages_res_full() const {return storages_.get_res_full();}
+        [[nodiscard]] tuple4d get_sgens_res_full() const {return sgens_.get_res_full();}
+        [[nodiscard]] tuple4d get_dcline_res1_full() const {return hvdc_lines_.get_res_full_side_1();}
+        [[nodiscard]] tuple4d get_dcline_res2_full() const {return hvdc_lines_.get_res_full_side_2();}
 
         /**
          * @brief Get the Ybus solver object (AC)
@@ -1185,7 +1185,7 @@ class LS2G_API LSGrid final
          * 
          * @return Eigen::Ref<const CplxVect>
          */
-        Eigen::Ref<const CplxVect> get_Sbus_solver() const{
+        [[nodiscard]] Eigen::Ref<const CplxVect> get_Sbus_solver() const{
             return acSbus_;
         }
 
@@ -1203,7 +1203,7 @@ class LS2G_API LSGrid final
          * 
          * @return Eigen::Ref<const CplxVect>
          */
-        Eigen::Ref<const RealVect> get_dcSbus_solver() const{
+        [[nodiscard]] Eigen::Ref<const RealVect> get_dcSbus_solver() const{
             return dcPbus_;  // DC power injection is real (active power P)
         }
 
@@ -1223,7 +1223,7 @@ class LS2G_API LSGrid final
          * 
          * @return Eigen::Ref<const CplxVect>
          */
-        const Eigen::SparseMatrix<cplx_type> get_Ybus() const {
+        [[nodiscard]] const Eigen::SparseMatrix<cplx_type> get_Ybus() const {
             return _relabel_matrix(Ybus_ac_, id_ac_solver_to_me_);
         }
 
@@ -1243,7 +1243,7 @@ class LS2G_API LSGrid final
          * 
          * @return Eigen::Ref<const CplxVect>
          */
-        const Eigen::SparseMatrix<real_type> get_dcYbus() const {
+        [[nodiscard]] const Eigen::SparseMatrix<real_type> get_dcYbus() const {
             return _relabel_matrix(Bbus_dc_, id_dc_solver_to_me_);
         }
 
@@ -1261,7 +1261,7 @@ class LS2G_API LSGrid final
          * 
          * @return Eigen::Ref<const CplxVect>
          */
-        const CplxVect get_Sbus() const {
+        [[nodiscard]] const CplxVect get_Sbus() const {
             return _relabel_vector(acSbus_, id_ac_solver_to_me_);
         }
 
@@ -1279,7 +1279,7 @@ class LS2G_API LSGrid final
          * 
          * @return Eigen::Ref<const CplxVect>
          */
-        const RealVect get_dcSbus() const {
+        [[nodiscard]] const RealVect get_dcSbus() const {
             return _relabel_vector(dcPbus_, id_dc_solver_to_me_);
         }
 
@@ -1290,7 +1290,7 @@ class LS2G_API LSGrid final
          * 
          * @return Eigen::Ref<const Eigen::VectorXi> 
          */
-        const SolverBusIdVect & get_pv_solver() const{
+        [[nodiscard]] const SolverBusIdVect & get_pv_solver() const{
             return bus_pv_;
         }
         /**
@@ -1300,7 +1300,7 @@ class LS2G_API LSGrid final
          * 
          * @return Eigen::Ref<const Eigen::VectorXi> 
          */
-        Eigen::Ref<const IntVect> get_pv_solver_numpy() const{
+        [[nodiscard]] Eigen::Ref<const IntVect> get_pv_solver_numpy() const{
             return bus_pv_.as_eigen();  // was _to_intvect()
         }
 
@@ -1311,12 +1311,12 @@ class LS2G_API LSGrid final
          * 
          * @return const Eigen::VectorXi
          */
-        const GlobalBusIdVect get_pv() const{
+        [[nodiscard]] const GlobalBusIdVect get_pv() const{
             if(id_ac_solver_to_me_.size() > 0) return _relabel_vector2<SolverBusIdVect, GlobalBusIdVect>(get_pv_solver(), id_ac_solver_to_me_);
             if(id_dc_solver_to_me_.size() > 0) return _relabel_vector2<SolverBusIdVect, GlobalBusIdVect>(get_pv_solver(), id_dc_solver_to_me_);
             throw std::runtime_error("LSGrid::get_pv: impossible to retrieve the `gridmodel` bus label as it appears no powerflow has run.");
         }
-        const IntVect get_pv_numpy() const{
+        [[nodiscard]] const IntVect get_pv_numpy() const{
             return get_pv().as_eigen();  // was _to_intvect()
         }
 
@@ -1327,7 +1327,7 @@ class LS2G_API LSGrid final
          * 
          * @return Eigen::Ref<const Eigen::VectorXi> 
          */
-        const SolverBusIdVect & get_pq_solver() const{
+        [[nodiscard]] const SolverBusIdVect & get_pq_solver() const{
             return bus_pq_;
         }
         /**
@@ -1337,7 +1337,7 @@ class LS2G_API LSGrid final
          * 
          * @return Eigen::Ref<const Eigen::VectorXi> 
          */
-        const Eigen::Ref<const IntVect> get_pq_solver_numpy() const{
+        [[nodiscard]] const Eigen::Ref<const IntVect> get_pq_solver_numpy() const{
             return bus_pq_.as_eigen();  // was _to_intvect()
         }
 
@@ -1348,12 +1348,12 @@ class LS2G_API LSGrid final
          * 
          * @return const Eigen::VectorXi
          */
-        const GlobalBusIdVect get_pq() const{
+        [[nodiscard]] const GlobalBusIdVect get_pq() const{
             if(id_ac_solver_to_me_.size() > 0) return _relabel_vector2<SolverBusIdVect, GlobalBusIdVect>(get_pq_solver(), id_ac_solver_to_me_);
             if(id_dc_solver_to_me_.size() > 0) return _relabel_vector2<SolverBusIdVect, GlobalBusIdVect>(get_pq_solver(), id_dc_solver_to_me_);
             throw std::runtime_error("LSGrid::get_pq: impossible to retrieve the `gridmodel` bus label as it appears no powerflow has run.");
         }
-        const IntVect get_pq_numpy() const{
+        [[nodiscard]] const IntVect get_pq_numpy() const{
             return get_pq().as_eigen();  // was _to_intvect()
         }
 
@@ -1362,7 +1362,7 @@ class LS2G_API LSGrid final
          * 
          * @return Eigen::Ref<const Eigen::VectorXi> 
          */
-        const SolverBusIdVect & get_slack_ids_solver() const{
+        [[nodiscard]] const SolverBusIdVect & get_slack_ids_solver() const{
             return slack_bus_id_ac_solver_;
         }
         /**
@@ -1372,7 +1372,7 @@ class LS2G_API LSGrid final
          * 
          * @return const Eigen::VectorXi
          */
-        Eigen::Ref<const IntVect> get_slack_ids_solver_numpy() const{
+        [[nodiscard]] Eigen::Ref<const IntVect> get_slack_ids_solver_numpy() const{
             return slack_bus_id_ac_solver_.as_eigen();  // was _to_intvect()
         }
 
@@ -1381,10 +1381,10 @@ class LS2G_API LSGrid final
          * 
          * @return const Eigen::VectorXi 
          */
-        const GlobalBusIdVect get_slack_ids() const {
+        [[nodiscard]] const GlobalBusIdVect get_slack_ids() const {
             return _relabel_vector2<SolverBusIdVect, GlobalBusIdVect>(slack_bus_id_ac_solver_, id_ac_solver_to_me_);
         }
-        const IntVect get_slack_ids_numpy() const {
+        [[nodiscard]] const IntVect get_slack_ids_numpy() const {
             return get_slack_ids().as_eigen();  // was _to_intvect()
         }
 
@@ -1393,7 +1393,7 @@ class LS2G_API LSGrid final
          * 
          * @return const SolverBusIdVect &
          */
-        const SolverBusIdVect & get_slack_ids_dc_solver() const{
+        [[nodiscard]] const SolverBusIdVect & get_slack_ids_dc_solver() const{
             return slack_bus_id_dc_solver_;
         }
         /**
@@ -1401,11 +1401,11 @@ class LS2G_API LSGrid final
          * 
          * @return Eigen::Ref<const IntVect> 
          */
-        Eigen::Ref<const IntVect> get_slack_ids_dc_solver_numpy() const{
+        [[nodiscard]] Eigen::Ref<const IntVect> get_slack_ids_dc_solver_numpy() const{
             return slack_bus_id_dc_solver_.as_eigen();  // was _to_intvect()
         }
 
-        const GlobalBusIdVect get_slack_ids_dc() const{
+        [[nodiscard]] const GlobalBusIdVect get_slack_ids_dc() const{
             return _relabel_vector2<SolverBusIdVect, GlobalBusIdVect>(
                 slack_bus_id_dc_solver_, 
                 id_dc_solver_to_me_);
@@ -1415,7 +1415,7 @@ class LS2G_API LSGrid final
          * 
          * @return const Eigen::VectorXi 
          */
-        const IntVect get_slack_ids_dc_numpy() const{
+        [[nodiscard]] const IntVect get_slack_ids_dc_numpy() const{
             return get_slack_ids_dc().as_eigen();  // was _to_intvect()
         }
 
@@ -1426,7 +1426,7 @@ class LS2G_API LSGrid final
          * 
          * @return Eigen::Ref<const RealVect> 
          */
-        Eigen::Ref<const RealVect> get_slack_weights_solver() const{
+        [[nodiscard]] Eigen::Ref<const RealVect> get_slack_weights_solver() const{
             return slack_weights_;
         }
 
@@ -1437,7 +1437,7 @@ class LS2G_API LSGrid final
          * 
          * @return Eigen::Ref<const RealVect> 
          */
-        const RealVect get_slack_weights() const{
+        [[nodiscard]] const RealVect get_slack_weights() const{
             if(id_ac_solver_to_me_.size() > 0) return _relabel_vector(get_slack_weights_solver(), id_ac_solver_to_me_);
             if(id_dc_solver_to_me_.size() > 0) return _relabel_vector(get_slack_weights_solver(), id_dc_solver_to_me_);
             throw std::runtime_error("LSGrid::get_slack_weights: impossible to retrieve the `gridmodel` bus label as it appears no powerflow has run.");
@@ -1448,7 +1448,7 @@ class LS2G_API LSGrid final
          * 
          * @return Eigen::Ref<const CplxVect> 
          */
-        Eigen::Ref<const CplxVect> get_V_solver() const{
+        [[nodiscard]] Eigen::Ref<const CplxVect> get_V_solver() const{
             return _algo.get_V();
         }
 
@@ -1457,7 +1457,7 @@ class LS2G_API LSGrid final
          * 
          * @return CplxVect
          */
-        const CplxVect get_V() const{
+        [[nodiscard]] const CplxVect get_V() const{
             if(id_ac_solver_to_me_.size() > 0) return _relabel_vector(get_V_solver(), id_ac_solver_to_me_);
             if(id_dc_solver_to_me_.size() > 0) return _relabel_vector(get_V_solver(), id_dc_solver_to_me_);
             throw std::runtime_error("LSGrid::get_V: impossible to retrieve the `gridmodel` bus label as it appears no powerflow has run.");
@@ -1468,7 +1468,7 @@ class LS2G_API LSGrid final
          * 
          * @return Eigen::Ref<const RealVect> 
          */
-        Eigen::Ref<const RealVect> get_Va_solver() const{
+        [[nodiscard]] Eigen::Ref<const RealVect> get_Va_solver() const{
             return _algo.get_Va();
         }
 
@@ -1477,7 +1477,7 @@ class LS2G_API LSGrid final
          * 
          * @return const RealVect
          */
-        const RealVect get_Va() const{
+        [[nodiscard]] const RealVect get_Va() const{
             if(id_ac_solver_to_me_.size() > 0) return _relabel_vector(get_Va_solver(), id_ac_solver_to_me_);
             if(id_dc_solver_to_me_.size() > 0) return _relabel_vector(get_Va_solver(), id_dc_solver_to_me_);
             throw std::runtime_error("LSGrid::get_Va: impossible to retrieve the `gridmodel` bus label as it appears no powerflow has run.");
@@ -1488,7 +1488,7 @@ class LS2G_API LSGrid final
          * 
          * @return Eigen::Ref<const RealVect> 
          */
-        Eigen::Ref<const RealVect> get_Vm_solver() const{
+        [[nodiscard]] Eigen::Ref<const RealVect> get_Vm_solver() const{
             return _algo.get_Vm();
         }
 
@@ -1497,13 +1497,13 @@ class LS2G_API LSGrid final
          * 
          * @return const RealVect
          */
-        const RealVect get_Vm() const{
+        [[nodiscard]] const RealVect get_Vm() const{
             if(id_ac_solver_to_me_.size() > 0) return _relabel_vector(get_Vm_solver(), id_ac_solver_to_me_);
             if(id_dc_solver_to_me_.size() > 0) return _relabel_vector(get_Vm_solver(), id_dc_solver_to_me_);
             throw std::runtime_error("LSGrid::get_Vm: impossible to retrieve the `gridmodel` bus label as it appears no powerflow has run.");
         }
 
-        Eigen::Ref<const Eigen::SparseMatrix<real_type> > get_J_solver() const{
+        [[nodiscard]] Eigen::Ref<const Eigen::SparseMatrix<real_type> > get_J_solver() const{
             return _algo.get_J();
         }
 
@@ -1512,7 +1512,7 @@ class LS2G_API LSGrid final
          * 
          * @return Eigen::SparseMatrix<real_type> 
          */
-        Eigen::SparseMatrix<real_type> get_J_python_solver() const{
+        [[nodiscard]] Eigen::SparseMatrix<real_type> get_J_python_solver() const{
             return _algo.get_J_python();  // This is copied to python
         }
 
@@ -1522,11 +1522,11 @@ class LS2G_API LSGrid final
         // gpusim2grid) rebuild the dS scatter / residual layout without
         // re-deriving it from Ybus. Only valid for Newton-Raphson algorithms
         // after a solve; throw otherwise (via the active algo).
-        IntVect get_theta_to_J_col_solver() const { return _algo.get_theta_to_J_col_python(); }
-        IntVect get_vm_to_J_col_solver()    const { return _algo.get_vm_to_J_col_python(); }
-        IntVect get_q_to_J_col_solver()     const { return _algo.get_q_to_J_col_python(); }
-        IntVect get_p_to_J_row_solver()     const { return _algo.get_p_to_J_row_python(); }
-        IntVect get_q_to_J_row_solver()     const { return _algo.get_q_to_J_row_python(); }
+        [[nodiscard]] IntVect get_theta_to_J_col_solver() const { return _algo.get_theta_to_J_col_python(); }
+        [[nodiscard]] IntVect get_vm_to_J_col_solver()    const { return _algo.get_vm_to_J_col_python(); }
+        [[nodiscard]] IntVect get_q_to_J_col_solver()     const { return _algo.get_q_to_J_col_python(); }
+        [[nodiscard]] IntVect get_p_to_J_row_solver()     const { return _algo.get_p_to_J_row_python(); }
+        [[nodiscard]] IntVect get_q_to_J_row_solver()     const { return _algo.get_q_to_J_row_python(); }
 
         // Compact (bus, row/col) registration pair lists -- the row/col
         // counterpart of the *_to_J_col / *_to_J_row maps above, but preserving
@@ -1536,30 +1536,30 @@ class LS2G_API LSGrid final
         // rules"). NRSystem::_residual() itself iterates these, not the
         // bus-keyed maps; external batched solvers must do the same to
         // reproduce every contribution.
-        IntVect get_p_buses_solver()     const { return _algo.get_p_buses_python(); }
-        IntVect get_p_rows_solver()      const { return _algo.get_p_rows_python(); }
-        IntVect get_q_buses_solver()     const { return _algo.get_q_buses_python(); }
-        IntVect get_q_rows_solver()      const { return _algo.get_q_rows_python(); }
-        IntVect get_theta_buses_solver() const { return _algo.get_theta_buses_python(); }
-        IntVect get_theta_cols_solver()  const { return _algo.get_theta_cols_python(); }
-        IntVect get_vm_buses_solver()    const { return _algo.get_vm_buses_python(); }
-        IntVect get_vm_cols_solver()     const { return _algo.get_vm_cols_python(); }
+        [[nodiscard]] IntVect get_p_buses_solver()     const { return _algo.get_p_buses_python(); }
+        [[nodiscard]] IntVect get_p_rows_solver()      const { return _algo.get_p_rows_python(); }
+        [[nodiscard]] IntVect get_q_buses_solver()     const { return _algo.get_q_buses_python(); }
+        [[nodiscard]] IntVect get_q_rows_solver()      const { return _algo.get_q_rows_python(); }
+        [[nodiscard]] IntVect get_theta_buses_solver() const { return _algo.get_theta_buses_python(); }
+        [[nodiscard]] IntVect get_theta_cols_solver()  const { return _algo.get_theta_cols_python(); }
+        [[nodiscard]] IntVect get_vm_buses_solver()    const { return _algo.get_vm_buses_python(); }
+        [[nodiscard]] IntVect get_vm_cols_solver()     const { return _algo.get_vm_cols_python(); }
         // MultiSlack slack_absorbed J column (-1 when distributed slack inactive).
-        int     get_slack_col_solver()      const { return _algo.get_slack_col(); }
+        [[nodiscard]] int     get_slack_col_solver()      const { return _algo.get_slack_col(); }
         // MultiSlack converged slack_absorbed VALUE (pu; 0 when inactive). This
         // is the ground-truth state after convergence -- NOT the 0 initial
         // guess an external solver's own linearized derivation starts from.
-        real_type get_slack_absorbed_solver() const { return _algo.get_slack_absorbed(); }
+        [[nodiscard]] real_type get_slack_absorbed_solver() const { return _algo.get_slack_absorbed(); }
         // VoltageControl (remote gen + SVC) converged reactive injection per
         // controller (pu), + its (kind: 0=GEN,1=SVC; element id) identity, in
         // controller registration order (empty when the extension is inactive).
         // Ground truth for external solvers deriving their own controller_q.
-        RealVect get_controller_q_solver()       const { return _algo.get_controller_q(); }
-        IntVect  get_controller_kind_solver()    const { return _algo.get_controller_kind(); }
-        IntVect  get_controller_elem_id_solver() const { return _algo.get_controller_elem_id(); }
+        [[nodiscard]] RealVect get_controller_q_solver()       const { return _algo.get_controller_q(); }
+        [[nodiscard]] IntVect  get_controller_kind_solver()    const { return _algo.get_controller_kind(); }
+        [[nodiscard]] IntVect  get_controller_elem_id_solver() const { return _algo.get_controller_elem_id(); }
 
-        real_type get_computation_time() const{ return _algo.get_computation_time();}
-        real_type get_dc_computation_time() const{ return _dc_algo.get_computation_time();}
+        [[nodiscard]] real_type get_computation_time() const{ return _algo.get_computation_time();}
+        [[nodiscard]] real_type get_dc_computation_time() const{ return _dc_algo.get_computation_time();}
 
         // part dedicated to grid2op backend, optimized for grid2op data representation (for speed)
         // this is not recommended to use it outside of its intended usage within grid2op !
@@ -1667,7 +1667,7 @@ class LS2G_API LSGrid final
             }
             max_nb_bus_per_sub_ = max_nb_bus_per_sub;
         }
-        int get_max_nb_bus_per_sub() const { return max_nb_bus_per_sub_;}
+        [[nodiscard]] int get_max_nb_bus_per_sub() const { return max_nb_bus_per_sub_;}
 
         /**
          * Relevant kwargs the grid was built with (eg by `init_from_pypowsybl`), as a
@@ -1678,7 +1678,7 @@ class LS2G_API LSGrid final
          * pypowsybl-shaped result view) to recover conversion-time settings that are
          * otherwise plain Python arguments lost after `init()` returns.
          */
-        const std::map<std::string, std::string> & get_init_kwargs() const { return init_kwargs_;}
+        [[nodiscard]] const std::map<std::string, std::string> & get_init_kwargs() const { return init_kwargs_;}
         void set_init_kwargs(const std::map<std::string, std::string> & init_kwargs) { init_kwargs_ = init_kwargs;}
 
         void fillSbus_other(CplxVect & res, bool ac, const SolverBusIdVect& id_me_to_solver){

--- a/src/core/LSGrid.hpp
+++ b/src/core/LSGrid.hpp
@@ -196,8 +196,8 @@ class LS2G_API LSGrid final
             algo_controler_.dc_algo_controler().has_pv_changed();
             generators_.turnedoff_pv(algo_controler_);
         }
-        bool get_turnedoff_gen_pv() {return generators_.get_turnedoff_gen_pv();}
-        void update_slack_weights(Eigen::Ref<Eigen::Array<bool, Eigen::Dynamic, Eigen::RowMajor> > could_be_slack){
+        bool get_turnedoff_gen_pv() const {return generators_.get_turnedoff_gen_pv();}
+        void update_slack_weights(Eigen::Ref<const Eigen::Array<bool, Eigen::Dynamic, Eigen::RowMajor> > could_be_slack){
             generators_.update_slack_weights(could_be_slack, algo_controler_);
         }
         void update_slack_weights_by_id(Eigen::Ref<const IntVect> slack_ids){
@@ -302,9 +302,9 @@ class LS2G_API LSGrid final
         // All methods to init this data model, all need to be pair unit when applicable
         void init_bus(unsigned int n_sub, unsigned int n_busbar_per_sub, const Eigen::Ref<const RealVect> & bus_vn_kv, int nb_line, int nb_trafo);
         void set_init_vm_pu(real_type init_vm_pu) {init_vm_pu_ = init_vm_pu; }
-        real_type get_init_vm_pu() {return init_vm_pu_;}
+        real_type get_init_vm_pu() const {return init_vm_pu_;}
         void set_sn_mva(real_type sn_mva) {sn_mva_ = sn_mva; }
-        real_type get_sn_mva() {return sn_mva_;}
+        real_type get_sn_mva() const {return sn_mva_;}
 
         void init_powerlines(const Eigen::Ref<const RealVect> & branch_r,
                              const Eigen::Ref<const RealVect> & branch_x,
@@ -869,7 +869,7 @@ class LS2G_API LSGrid final
         }
         void change_p_load(int load_id, real_type new_p) {loads_.change_p_nothrow(load_id, new_p, algo_controler_); }
         void change_q_load(int load_id, real_type new_q) {loads_.change_q_nothrow(load_id, new_q, algo_controler_); }
-        int get_bus_load(int load_id) {return loads_.get_bus(load_id).cast_int();}
+        int get_bus_load(int load_id) const {return loads_.get_bus(load_id).cast_int();}
 
         //generator
         void deactivate_gen(int gen_id) {generators_.deactivate(gen_id, algo_controler_); }
@@ -889,7 +889,7 @@ class LS2G_API LSGrid final
         void change_p_gen(int gen_id, real_type new_p) {generators_.change_p_nothrow(gen_id, new_p, algo_controler_); }
         void change_q_gen(int gen_id, real_type new_q) {generators_.change_q_nothrow(gen_id, new_q, algo_controler_); }
         void change_v_gen(int gen_id, real_type new_v_pu) {generators_.change_v_nothrow(gen_id, new_v_pu, algo_controler_); }
-        int get_bus_gen(int gen_id) {return generators_.get_bus(gen_id).cast_int();}
+        int get_bus_gen(int gen_id) const {return generators_.get_bus(gen_id).cast_int();}
 
         //static var compensator (SVC)
         void deactivate_svc(int svc_id) {svcs_.deactivate(svc_id, algo_controler_); }
@@ -900,7 +900,7 @@ class LS2G_API LSGrid final
         void change_bus_svc_python(int svc_id, int new_gridmodel_bus_id) {
             change_bus_svc(svc_id, GridModelBusId(new_gridmodel_bus_id));
         }
-        int get_bus_svc(int svc_id) {return svcs_.get_bus(svc_id).cast_int();}
+        int get_bus_svc(int svc_id) const {return svcs_.get_bus(svc_id).cast_int();}
         void set_svc_names(const std::vector<std::string> & names){
             GenericContainer::check_size(names, svcs_.nb(), "set_svc_names");
             svcs_.set_names(names);
@@ -922,7 +922,7 @@ class LS2G_API LSGrid final
         }
         void change_p_shunt(int shunt_id, real_type new_p) {shunts_.change_p_nothrow(shunt_id, new_p, algo_controler_); }
         void change_q_shunt(int shunt_id, real_type new_q) {shunts_.change_q_nothrow(shunt_id, new_q, algo_controler_); }
-        int get_bus_shunt(int shunt_id) {return shunts_.get_bus(shunt_id).cast_int();}
+        int get_bus_shunt(int shunt_id) const {return shunts_.get_bus(shunt_id).cast_int();}
 
         //static gen
         void deactivate_sgen(int sgen_id) {sgens_.deactivate(sgen_id, algo_controler_); }
@@ -940,7 +940,7 @@ class LS2G_API LSGrid final
         }
         void change_p_sgen(int sgen_id, real_type new_p) {sgens_.change_p_nothrow(sgen_id, new_p, algo_controler_); }
         void change_q_sgen(int sgen_id, real_type new_q) {sgens_.change_q_nothrow(sgen_id, new_q, algo_controler_); }
-        int get_bus_sgen(int sgen_id) {return sgens_.get_bus(sgen_id).cast_int();}
+        int get_bus_sgen(int sgen_id) const {return sgens_.get_bus(sgen_id).cast_int();}
 
         //storage units
         void deactivate_storage(int storage_id) {storages_.deactivate(storage_id, algo_controler_); }
@@ -960,7 +960,7 @@ class LS2G_API LSGrid final
                storages_.change_p_nothrow(storage_id, new_p, algo_controler_);
             }
         void change_q_storage(int storage_id, real_type new_q) {storages_.change_q_nothrow(storage_id, new_q, algo_controler_); }
-        int get_bus_storage(int storage_id) {return storages_.get_bus(storage_id).cast_int();}
+        int get_bus_storage(int storage_id) const {return storages_.get_bus(storage_id).cast_int();}
 
         //deactivate a powerline (disconnect it)
         void deactivate_dcline(int dcline_id) {hvdc_lines_.deactivate(dcline_id, algo_controler_); }
@@ -1563,26 +1563,26 @@ class LS2G_API LSGrid final
 
         // part dedicated to grid2op backend, optimized for grid2op data representation (for speed)
         // this is not recommended to use it outside of its intended usage within grid2op !
-        void update_gens_p(Eigen::Ref<Eigen::Array<bool, Eigen::Dynamic, Eigen::RowMajor> > has_changed,
-                           Eigen::Ref<Eigen::Array<float, Eigen::Dynamic, Eigen::RowMajor> > new_values);
-        void update_sgens_p(Eigen::Ref<Eigen::Array<bool, Eigen::Dynamic, Eigen::RowMajor> > has_changed,
-                           Eigen::Ref<Eigen::Array<float, Eigen::Dynamic, Eigen::RowMajor> > new_values);
-        void update_gens_v(Eigen::Ref<Eigen::Array<bool, Eigen::Dynamic, Eigen::RowMajor> > has_changed,
-                           Eigen::Ref<Eigen::Array<float, Eigen::Dynamic, Eigen::RowMajor> > new_values);
-        void update_loads_p(Eigen::Ref<Eigen::Array<bool, Eigen::Dynamic, Eigen::RowMajor> > has_changed,
-                            Eigen::Ref<Eigen::Array<float, Eigen::Dynamic, Eigen::RowMajor> > new_values);
-        void update_loads_q(Eigen::Ref<Eigen::Array<bool, Eigen::Dynamic, Eigen::RowMajor> > has_changed,
-                            Eigen::Ref<Eigen::Array<float, Eigen::Dynamic, Eigen::RowMajor> > new_values);
+        void update_gens_p(Eigen::Ref<const Eigen::Array<bool, Eigen::Dynamic, Eigen::RowMajor> > has_changed,
+                           Eigen::Ref<const Eigen::Array<float, Eigen::Dynamic, Eigen::RowMajor> > new_values);
+        void update_sgens_p(Eigen::Ref<const Eigen::Array<bool, Eigen::Dynamic, Eigen::RowMajor> > has_changed,
+                           Eigen::Ref<const Eigen::Array<float, Eigen::Dynamic, Eigen::RowMajor> > new_values);
+        void update_gens_v(Eigen::Ref<const Eigen::Array<bool, Eigen::Dynamic, Eigen::RowMajor> > has_changed,
+                           Eigen::Ref<const Eigen::Array<float, Eigen::Dynamic, Eigen::RowMajor> > new_values);
+        void update_loads_p(Eigen::Ref<const Eigen::Array<bool, Eigen::Dynamic, Eigen::RowMajor> > has_changed,
+                            Eigen::Ref<const Eigen::Array<float, Eigen::Dynamic, Eigen::RowMajor> > new_values);
+        void update_loads_q(Eigen::Ref<const Eigen::Array<bool, Eigen::Dynamic, Eigen::RowMajor> > has_changed,
+                            Eigen::Ref<const Eigen::Array<float, Eigen::Dynamic, Eigen::RowMajor> > new_values);
         /**
          * Update the topology based on the topology vector id.
-         * 
+         *
          * The new_values are given in LocalBusId (-1, 1, 2 etc.) and not in
          * SolverBusId nor GridModelBusId
          */
         void update_topo(Eigen::Ref<const Eigen::Array<bool, Eigen::Dynamic, Eigen::RowMajor> > has_changed,
                          Eigen::Ref<const Eigen::Array<int, Eigen::Dynamic, Eigen::RowMajor> > new_values);
-        void update_storages_p(Eigen::Ref<Eigen::Array<bool, Eigen::Dynamic, Eigen::RowMajor> > has_changed,
-                               Eigen::Ref<Eigen::Array<float, Eigen::Dynamic, Eigen::RowMajor> > new_values);
+        void update_storages_p(Eigen::Ref<const Eigen::Array<bool, Eigen::Dynamic, Eigen::RowMajor> > has_changed,
+                               Eigen::Ref<const Eigen::Array<float, Eigen::Dynamic, Eigen::RowMajor> > new_values);
 
         void set_load_pos_topo_vect(Eigen::Ref<const IntVect> load_pos_topo_vect)
         {
@@ -1940,8 +1940,8 @@ class LS2G_API LSGrid final
         optimization for grid2op
         **/
         template<class T>
-        void update_continuous_values(Eigen::Ref<Eigen::Array<bool, Eigen::Dynamic, Eigen::RowMajor> > & has_changed,
-                                      Eigen::Ref<Eigen::Array<float, Eigen::Dynamic, Eigen::RowMajor> > & new_values,
+        void update_continuous_values(Eigen::Ref<const Eigen::Array<bool, Eigen::Dynamic, Eigen::RowMajor> > has_changed,
+                                      Eigen::Ref<const Eigen::Array<float, Eigen::Dynamic, Eigen::RowMajor> > new_values,
                                       T fun)
         {
             // new_values is indexed by has_changed's length below; a shorter new_values

--- a/src/core/batch_algorithm/ContingencyAnalysis.hpp
+++ b/src/core/batch_algorithm/ContingencyAnalysis.hpp
@@ -84,7 +84,7 @@ class LS2G_API ContingencyAnalysis final: public BaseBatchSolverSynch
         }
 
         // utilities to remove defaults to simulate (TODO)
-        virtual void clear() override {
+        void clear() override {
             BaseBatchSolverSynch::clear();
             _li_defaults.clear();
             _li_coeffs.clear();

--- a/src/core/batch_algorithm/ContingencyAnalysis.hpp
+++ b/src/core/batch_algorithm/ContingencyAnalysis.hpp
@@ -84,7 +84,7 @@ class LS2G_API ContingencyAnalysis final: public BaseBatchSolverSynch
         }
 
         // utilities to remove defaults to simulate (TODO)
-        virtual void clear(){
+        virtual void clear() override {
             BaseBatchSolverSynch::clear();
             _li_defaults.clear();
             _li_coeffs.clear();

--- a/src/core/batch_algorithm/ContingencyAnalysis.hpp
+++ b/src/core/batch_algorithm/ContingencyAnalysis.hpp
@@ -48,7 +48,7 @@ class LS2G_API ContingencyAnalysis final: public BaseBatchSolverSynch
             clear();
         }
 
-        ~ContingencyAnalysis() noexcept = default;
+        ~ContingencyAnalysis() noexcept override = default;
         ContingencyAnalysis(const ContingencyAnalysis&) = delete;
         ContingencyAnalysis(ContingencyAnalysis&&) = delete;
         ContingencyAnalysis & operator=(ContingencyAnalysis&&) = delete;

--- a/src/core/batch_algorithm/TimeSeries.hpp
+++ b/src/core/batch_algorithm/TimeSeries.hpp
@@ -58,7 +58,7 @@ class LS2G_API TimeSeries final: public BaseBatchSolverSynch
                        const int max_iter,
                        const real_type tol);
                        
-        virtual void clear() override {
+        void clear() override {
             BaseBatchSolverSynch::clear();
             _Sbuses = CplxMat();
             _status = 1;

--- a/src/core/batch_algorithm/TimeSeries.hpp
+++ b/src/core/batch_algorithm/TimeSeries.hpp
@@ -58,7 +58,7 @@ class LS2G_API TimeSeries final: public BaseBatchSolverSynch
                        const int max_iter,
                        const real_type tol);
                        
-        virtual void clear(){
+        virtual void clear() override {
             BaseBatchSolverSynch::clear();
             _Sbuses = CplxMat();
             _status = 1;

--- a/src/core/batch_algorithm/TimeSeries.hpp
+++ b/src/core/batch_algorithm/TimeSeries.hpp
@@ -26,7 +26,7 @@ class LS2G_API TimeSeries final: public BaseBatchSolverSynch
             _status(1), // 1: success, 0: failure
             _compute_flows(true)
             {}
-        ~TimeSeries() noexcept = default;
+        ~TimeSeries() noexcept override = default;
 
         TimeSeries(const TimeSeries&) = delete;
         TimeSeries(TimeSeries&&) = delete;

--- a/src/core/element_container/ConverterStationContainer.hpp
+++ b/src/core/element_container/ConverterStationContainer.hpp
@@ -58,7 +58,7 @@ A station with a (derived) active power of exactly 0 MW is considered
 (this mirrors the behaviour of the legacy DC lines, whose embedded generators
 were configured with `turnedoff_no_pv`).
 **/
-class LS2G_API ConverterStationContainer : public OneSideContainer_PQ, public IteratorAdder<ConverterStationContainer, ConverterStationInfo>
+class LS2G_API ConverterStationContainer final : public OneSideContainer_PQ, public IteratorAdder<ConverterStationContainer, ConverterStationInfo>
 {
     friend class ConverterStationInfo;
 
@@ -151,7 +151,7 @@ class LS2G_API ConverterStationContainer : public OneSideContainer_PQ, public It
         virtual void fillpv(std::vector<int>& bus_pv,
                             std::vector<bool> & has_bus_been_added,
                             const SolverBusIdVect & slack_bus_id_solver,
-                            const SolverBusIdVect & id_grid_to_solver) const;
+                            const SolverBusIdVect & id_grid_to_solver) const override;
         void init_q_vector(int nb_bus,
                            Eigen::VectorXi & total_gen_per_bus,
                            RealVect & total_q_min_per_bus,

--- a/src/core/element_container/ConverterStationContainer.hpp
+++ b/src/core/element_container/ConverterStationContainer.hpp
@@ -148,7 +148,7 @@ class LS2G_API ConverterStationContainer final : public OneSideContainer_PQ, pub
                               const SolverBusIdVect & id_grid_to_solver,
                               bool ac,
                               const std::vector<bool> & skip_p) const;
-        virtual void fillpv(std::vector<int>& bus_pv,
+        void fillpv(std::vector<int>& bus_pv,
                             std::vector<bool> & has_bus_been_added,
                             const SolverBusIdVect & slack_bus_id_solver,
                             const SolverBusIdVect & id_grid_to_solver) const override;
@@ -166,7 +166,7 @@ class LS2G_API ConverterStationContainer final : public OneSideContainer_PQ, pub
         void set_vm(CplxVect & V, const SolverBusIdVect & id_grid_to_solver) const;
 
     protected:
-        virtual void _compute_results(
+        void _compute_results(
             const Eigen::Ref<const RealVect> & Va,
             const Eigen::Ref<const RealVect> & Vm,
             const Eigen::Ref<const CplxVect> & V,

--- a/src/core/element_container/ConverterStationContainer.hpp
+++ b/src/core/element_container/ConverterStationContainer.hpp
@@ -101,7 +101,7 @@ class LS2G_API ConverterStationContainer final : public OneSideContainer_PQ, pub
                       "ConverterStationContainer::StateRes and StateResIdx do not match");
 
         ConverterStationContainer() noexcept = default;
-        virtual ~ConverterStationContainer() noexcept = default;
+        ~ConverterStationContainer() noexcept override = default;
 
         void init(const std::vector<int> & type,
                   const Eigen::Ref<const RealVect> & loss_factor,

--- a/src/core/element_container/GeneratorContainer.cpp
+++ b/src/core/element_container/GeneratorContainer.cpp
@@ -539,7 +539,7 @@ void GeneratorContainer::set_q(
 }
 
 void GeneratorContainer::update_slack_weights(
-    Eigen::Ref<Eigen::Array<bool, Eigen::Dynamic, Eigen::RowMajor> > could_be_slack,
+    Eigen::Ref<const Eigen::Array<bool, Eigen::Dynamic, Eigen::RowMajor> > could_be_slack,
     DualAlgoControl & solver_control)
 {
     const int nb_gen = nb();

--- a/src/core/element_container/GeneratorContainer.cpp
+++ b/src/core/element_container/GeneratorContainer.cpp
@@ -539,7 +539,7 @@ void GeneratorContainer::set_q(
 }
 
 void GeneratorContainer::update_slack_weights(
-    Eigen::Ref<const Eigen::Array<bool, Eigen::Dynamic, Eigen::RowMajor> > could_be_slack,
+    const Eigen::Ref<const Eigen::Array<bool, Eigen::Dynamic, Eigen::RowMajor> > & could_be_slack,
     DualAlgoControl & solver_control)
 {
     const int nb_gen = nb();

--- a/src/core/element_container/GeneratorContainer.hpp
+++ b/src/core/element_container/GeneratorContainer.hpp
@@ -184,7 +184,7 @@ class LS2G_API GeneratorContainer final: public OneSideContainer_PQ, public Iter
         RealVect get_slack_weights_solver(size_t nb_bus_solver, const SolverBusIdVect & id_grid_to_solver);
     
         GlobalBusIdVect get_slack_bus_id() const;
-        virtual void set_p_slack(const RealVect& node_mismatch, const SolverBusIdVect & id_grid_to_solver);
+        virtual void set_p_slack(const RealVect& node_mismatch, const SolverBusIdVect & id_grid_to_solver) override;
     
         // modification
         void turnedoff_no_pv(DualAlgoControl & solver_control){
@@ -257,11 +257,11 @@ class LS2G_API GeneratorContainer final: public OneSideContainer_PQ, public Iter
         void change_v(int gen_id, real_type new_v_pu, DualAlgoControl & solver_control);
         void change_v_nothrow(int gen_id, real_type new_v_pu, DualAlgoControl & solver_control);
         
-        virtual void fillSbus(CplxVect & Sbus, const SolverBusIdVect & id_grid_to_solver, bool ac) const;
+        virtual void fillSbus(CplxVect & Sbus, const SolverBusIdVect & id_grid_to_solver, bool ac) const override;
         virtual void fillpv(std::vector<int>& bus_pv,
                             std::vector<bool> & has_bus_been_added,
                             const SolverBusIdVect & slack_bus_id_solver,
-                            const SolverBusIdVect & id_grid_to_solver) const;
+                            const SolverBusIdVect & id_grid_to_solver) const override;
         void init_q_vector(int nb_bus,
                            Eigen::VectorXi & total_gen_per_bus,
                            RealVect & total_q_min_per_bus,

--- a/src/core/element_container/GeneratorContainer.hpp
+++ b/src/core/element_container/GeneratorContainer.hpp
@@ -198,14 +198,11 @@ class LS2G_API GeneratorContainer final: public OneSideContainer_PQ, public Iter
             turnedoff_gen_pv_=true;  // turned off generators are pv. This is the default.
             }  
         bool get_turnedoff_gen_pv() const {return turnedoff_gen_pv_;}
-        void update_slack_weights(Eigen::Ref<Eigen::Array<bool, Eigen::Dynamic, Eigen::RowMajor> > could_be_slack,
+        void update_slack_weights(Eigen::Ref<const Eigen::Array<bool, Eigen::Dynamic, Eigen::RowMajor> > could_be_slack,
                                   DualAlgoControl & solver_control);
         void update_slack_weights_by_id(Eigen::Ref<const IntVect> gen_slack_id, DualAlgoControl & solver_control);
         
         
-        real_type get_qmin(int gen_id) {return min_q_.coeff(gen_id);}
-        real_type get_qmax(int gen_id) {return max_q_.coeff(gen_id);}
-
         // ---- remote voltage control --------------------------------------------
         // grid bus id whose voltage this generator regulates (== its own bus for
         // ordinary local control). A remote-regulating gen does NOT join the PV

--- a/src/core/element_container/GeneratorContainer.hpp
+++ b/src/core/element_container/GeneratorContainer.hpp
@@ -70,7 +70,7 @@ class LS2G_API GeneratorContainer final: public OneSideContainer_PQ, public Iter
         
         GeneratorContainer() noexcept :OneSideContainer_PQ(), turnedoff_gen_pv_(true){};
         explicit GeneratorContainer(bool turnedoff_gen_pv) noexcept :OneSideContainer_PQ(), turnedoff_gen_pv_(turnedoff_gen_pv) {};
-        virtual ~GeneratorContainer() noexcept = default;
+        ~GeneratorContainer() noexcept override = default;
         
         // TODO add pmin and pmax here !
         void init(const Eigen::Ref<const RealVect> & generators_p,
@@ -198,7 +198,7 @@ class LS2G_API GeneratorContainer final: public OneSideContainer_PQ, public Iter
             turnedoff_gen_pv_=true;  // turned off generators are pv. This is the default.
             }  
         bool get_turnedoff_gen_pv() const {return turnedoff_gen_pv_;}
-        void update_slack_weights(Eigen::Ref<const Eigen::Array<bool, Eigen::Dynamic, Eigen::RowMajor> > could_be_slack,
+        void update_slack_weights(const Eigen::Ref<const Eigen::Array<bool, Eigen::Dynamic, Eigen::RowMajor> > & could_be_slack,
                                   DualAlgoControl & solver_control);
         void update_slack_weights_by_id(Eigen::Ref<const IntVect> gen_slack_id, DualAlgoControl & solver_control);
         

--- a/src/core/element_container/GeneratorContainer.hpp
+++ b/src/core/element_container/GeneratorContainer.hpp
@@ -151,7 +151,7 @@ class LS2G_API GeneratorContainer final: public OneSideContainer_PQ, public Iter
             return res_gen_id;
         }
 
-        virtual void _compute_results(
+        void _compute_results(
             const Eigen::Ref<const RealVect> & /*Va*/,
             const Eigen::Ref<const RealVect> & /*Vm*/,
             const Eigen::Ref<const CplxVect> & /*V*/,
@@ -184,7 +184,7 @@ class LS2G_API GeneratorContainer final: public OneSideContainer_PQ, public Iter
         RealVect get_slack_weights_solver(size_t nb_bus_solver, const SolverBusIdVect & id_grid_to_solver);
     
         GlobalBusIdVect get_slack_bus_id() const;
-        virtual void set_p_slack(const RealVect& node_mismatch, const SolverBusIdVect & id_grid_to_solver) override;
+        void set_p_slack(const RealVect& node_mismatch, const SolverBusIdVect & id_grid_to_solver) override;
     
         // modification
         void turnedoff_no_pv(DualAlgoControl & solver_control){
@@ -254,8 +254,8 @@ class LS2G_API GeneratorContainer final: public OneSideContainer_PQ, public Iter
         void change_v(int gen_id, real_type new_v_pu, DualAlgoControl & solver_control);
         void change_v_nothrow(int gen_id, real_type new_v_pu, DualAlgoControl & solver_control);
         
-        virtual void fillSbus(CplxVect & Sbus, const SolverBusIdVect & id_grid_to_solver, bool ac) const override;
-        virtual void fillpv(std::vector<int>& bus_pv,
+        void fillSbus(CplxVect & Sbus, const SolverBusIdVect & id_grid_to_solver, bool ac) const override;
+        void fillpv(std::vector<int>& bus_pv,
                             std::vector<bool> & has_bus_been_added,
                             const SolverBusIdVect & slack_bus_id_solver,
                             const SolverBusIdVect & id_grid_to_solver) const override;

--- a/src/core/element_container/HvdcLineContainer.hpp
+++ b/src/core/element_container/HvdcLineContainer.hpp
@@ -266,10 +266,10 @@ class LS2G_API HvdcLineContainer final : public TwoSidesContainer<ConverterStati
             }
         }
 
-        real_type get_qmin_or(int hvdc_id) {return side_1_.get_qmin(hvdc_id);}
-        real_type get_qmax_or(int hvdc_id) {return side_1_.get_qmax(hvdc_id);}
-        real_type get_qmin_ex(int hvdc_id) {return side_2_.get_qmin(hvdc_id);}
-        real_type get_qmax_ex(int hvdc_id) {return side_2_.get_qmax(hvdc_id);}
+        real_type get_qmin_or(int hvdc_id) const {return side_1_.get_qmin(hvdc_id);}
+        real_type get_qmax_or(int hvdc_id) const {return side_1_.get_qmax(hvdc_id);}
+        real_type get_qmin_ex(int hvdc_id) const {return side_2_.get_qmin(hvdc_id);}
+        real_type get_qmax_ex(int hvdc_id) const {return side_2_.get_qmax(hvdc_id);}
 
         /**
          * Change the active power of the line, legacy convention: `new_p` is

--- a/src/core/element_container/HvdcLineContainer.hpp
+++ b/src/core/element_container/HvdcLineContainer.hpp
@@ -110,7 +110,7 @@ class LS2G_API HvdcLineContainer final : public TwoSidesContainer<ConverterStati
         // TwoSidesContainer's generic default (mirror both sides), HVDC lines default
         // to independent sides.
         HvdcLineContainer() noexcept { synch_status_both_side_ = false; }
-        virtual ~HvdcLineContainer() noexcept = default;
+        ~HvdcLineContainer() noexcept override = default;
 
         // pickle
         // /!\ if you change this layout, bump BINARY_FORMAT_VERSION (BinaryArchive.hpp)

--- a/src/core/element_container/HvdcLineContainer.hpp
+++ b/src/core/element_container/HvdcLineContainer.hpp
@@ -308,8 +308,8 @@ class LS2G_API HvdcLineContainer final : public TwoSidesContainer<ConverterStati
             _check_in_range(hvdc_id, status_droop_, "get_status_droop");
             return status_droop_(hvdc_id);
         }
-        std::vector<int> get_status_droop_vect() const {
-            return std::vector<int>(status_droop_.begin(), status_droop_.end());
+        Eigen::Ref<const IntVect> get_status_droop_vect() const {
+            return status_droop_;
         }
         const std::vector<bool> & get_droop_enabled() const {return droop_enabled_;}
         real_type get_droop_p0_mw(int hvdc_id) const {return p0_mw_(hvdc_id);}

--- a/src/core/element_container/HvdcLineContainer.hpp
+++ b/src/core/element_container/HvdcLineContainer.hpp
@@ -211,12 +211,12 @@ class LS2G_API HvdcLineContainer final : public TwoSidesContainer<ConverterStati
                          );
 
         // accessor / modifiers
-        virtual void reconnect_connected_buses(SubstationContainer & substation) const override {
+        void reconnect_connected_buses(SubstationContainer & substation) const override {
             side_1_.reconnect_connected_buses(substation);
             side_2_.reconnect_connected_buses(substation);
         }
 
-        virtual void get_graph(std::vector<Eigen::Triplet<real_type> > & /*res*/) const override {
+        void get_graph(std::vector<Eigen::Triplet<real_type> > & /*res*/) const override {
             // for buses only connected through a hvdc line, i don't add them
             // they are not in the same "connected component"
         }
@@ -232,7 +232,7 @@ class LS2G_API HvdcLineContainer final : public TwoSidesContainer<ConverterStati
         // NOT deactivate the whole line when a single side is outside the main
         // component: we keep the in-main converter injecting and open only the
         // out-of-main one. A line with BOTH sides outside is still fully dropped.
-        virtual void disconnect_if_not_in_main_component(std::vector<bool> & busbar_in_main_component) override {
+        void disconnect_if_not_in_main_component(std::vector<bool> & busbar_in_main_component) override {
             const int nb_el = nb();
             DualAlgoControl unused_solver_control;
             const GlobalBusIdVect & bus_side_1_id_ = get_buses_side_1();
@@ -345,9 +345,9 @@ class LS2G_API HvdcLineContainer final : public TwoSidesContainer<ConverterStati
         void droop_flows_mw(int hvdc_id, real_type raw_mw, real_type & p1_flow_mw, real_type & p2_flow_mw) const;
 
         // solver stuff
-        virtual void fillSbus(CplxVect & Sbus, const SolverBusIdVect & id_grid_to_solver, bool ac) const override;
+        void fillSbus(CplxVect & Sbus, const SolverBusIdVect & id_grid_to_solver, bool ac) const override;
 
-        virtual void fillpv(std::vector<int>& bus_pv,
+        void fillpv(std::vector<int>& bus_pv,
                             std::vector<bool> & has_bus_been_added,
                             const SolverBusIdVect & slack_bus_id_solver,
                             const SolverBusIdVect & id_grid_to_solver) const override {
@@ -355,7 +355,7 @@ class LS2G_API HvdcLineContainer final : public TwoSidesContainer<ConverterStati
             side_2_.fillpv(bus_pv, has_bus_been_added, slack_bus_id_solver, id_grid_to_solver);
         }
 
-        virtual void fillBp_Bpp(std::vector<Eigen::Triplet<real_type> > & /*Bp*/,
+        void fillBp_Bpp(std::vector<Eigen::Triplet<real_type> > & /*Bp*/,
                                 std::vector<Eigen::Triplet<real_type> > & /*Bpp*/,
                                 const SolverBusIdVect & /*id_grid_to_solver*/,
                                 real_type /*sn_mva*/,

--- a/src/core/element_container/LineContainer.hpp
+++ b/src/core/element_container/LineContainer.hpp
@@ -47,7 +47,7 @@ class LS2G_API LineContainer final: public TwoSidesContainer_rxh_A<OneSideContai
                    >;
         
         LineContainer() noexcept = default;
-        virtual ~LineContainer() noexcept = default;
+        ~LineContainer() noexcept override = default;
         
         void init(const Eigen::Ref<const RealVect> & branch_r,
                   const Eigen::Ref<const RealVect> & branch_x,

--- a/src/core/element_container/LoadContainer.hpp
+++ b/src/core/element_container/LoadContainer.hpp
@@ -80,10 +80,10 @@ class LS2G_API LoadContainer final: public OneSideContainer_PQ, public IteratorA
             reset_results();
         }
     
-        virtual void fillSbus(CplxVect & Sbus, const SolverBusIdVect & id_grid_to_solver, bool ac) const override;
+        void fillSbus(CplxVect & Sbus, const SolverBusIdVect & id_grid_to_solver, bool ac) const override;
 
     protected:
-        virtual void _compute_results(const Eigen::Ref<const RealVect> & /*Va*/,
+        void _compute_results(const Eigen::Ref<const RealVect> & /*Va*/,
                                     const Eigen::Ref<const RealVect> & /*Vm*/,
                                     const Eigen::Ref<const CplxVect> & /*V*/,
                                     const SolverBusIdVect & /*id_grid_to_solver*/,

--- a/src/core/element_container/LoadContainer.hpp
+++ b/src/core/element_container/LoadContainer.hpp
@@ -80,7 +80,7 @@ class LS2G_API LoadContainer final: public OneSideContainer_PQ, public IteratorA
             reset_results();
         }
     
-        virtual void fillSbus(CplxVect & Sbus, const SolverBusIdVect & id_grid_to_solver, bool ac) const;
+        virtual void fillSbus(CplxVect & Sbus, const SolverBusIdVect & id_grid_to_solver, bool ac) const override;
 
     protected:
         virtual void _compute_results(const Eigen::Ref<const RealVect> & /*Va*/,

--- a/src/core/element_container/LoadContainer.hpp
+++ b/src/core/element_container/LoadContainer.hpp
@@ -57,7 +57,7 @@ class LS2G_API LoadContainer final: public OneSideContainer_PQ, public IteratorA
            > ;
         
         LoadContainer() noexcept = default;
-        virtual ~LoadContainer() noexcept = default;
+        ~LoadContainer() noexcept override = default;
         
         // pickle (python)
         LoadContainer::StateRes get_state() const;

--- a/src/core/element_container/OneSideContainer.hpp
+++ b/src/core/element_container/OneSideContainer.hpp
@@ -193,7 +193,7 @@ class OneSideContainer : public GenericContainer
             }
         }
 
-        virtual void disconnect_if_not_in_main_component(std::vector<bool> & busbar_in_main_component) final {
+        virtual void disconnect_if_not_in_main_component(std::vector<bool> & busbar_in_main_component) override final {
             const int nb_el = nb();
             DualAlgoControl unused_solver_control;
             for(int el_id = 0; el_id < nb_el; ++el_id)

--- a/src/core/element_container/OneSideContainer.hpp
+++ b/src/core/element_container/OneSideContainer.hpp
@@ -156,7 +156,7 @@ class OneSideContainer : public GenericContainer
 
     public:
         OneSideContainer() noexcept = default;
-        virtual ~OneSideContainer() noexcept = default;
+        ~OneSideContainer() noexcept override = default;
         // OneSideInfo get_osc_info(int id_) {return OneSideInfo(*this, id_);}
 
         // public generic API

--- a/src/core/element_container/OneSideContainer.hpp
+++ b/src/core/element_container/OneSideContainer.hpp
@@ -175,7 +175,7 @@ class OneSideContainer : public GenericContainer
             return bus_id_.as_eigen();
         }
 
-        void reconnect_connected_buses(SubstationContainer & substation) const{
+        void reconnect_connected_buses(SubstationContainer & substation) const override{
             const int nb_els = nb();
             for(int el_id = 0; el_id < nb_els; ++el_id)
             {
@@ -193,7 +193,7 @@ class OneSideContainer : public GenericContainer
             }
         }
 
-        virtual void disconnect_if_not_in_main_component(std::vector<bool> & busbar_in_main_component) override final {
+        void disconnect_if_not_in_main_component(std::vector<bool> & busbar_in_main_component) override final {
             const int nb_el = nb();
             DualAlgoControl unused_solver_control;
             for(int el_id = 0; el_id < nb_el; ++el_id)

--- a/src/core/element_container/OneSideContainer_PQ.hpp
+++ b/src/core/element_container/OneSideContainer_PQ.hpp
@@ -55,7 +55,7 @@ class OneSideContainer_PQ : public OneSideContainer
     // regular implementation
     public:
         OneSideContainer_PQ() noexcept = default;
-        virtual ~OneSideContainer_PQ() noexcept = default;
+        ~OneSideContainer_PQ() noexcept override = default;
 
         // public generic API
 

--- a/src/core/element_container/OneSideContainer_PQ.hpp
+++ b/src/core/element_container/OneSideContainer_PQ.hpp
@@ -62,7 +62,7 @@ class OneSideContainer_PQ : public OneSideContainer
         Eigen::Ref<const RealVect> get_target_p() const {return target_p_mw_;}
 
         // base function that can be called
-        void gen_p_per_bus(std::vector<real_type> & res) const
+        void gen_p_per_bus(std::vector<real_type> & res) const override
         {
             const int nb_gen = nb();
             for(int sgen_id = 0; sgen_id < nb_gen; ++sgen_id)
@@ -196,11 +196,11 @@ class OneSideContainer_PQ : public OneSideContainer
         }
 
     protected:
-        virtual void _reset_results() override {
+        void _reset_results() override {
             // nothing to do by default, as this class should be used as template for "one side" (eg loads or generators)
             // elements
         };
-        virtual void _compute_results(const Eigen::Ref<const RealVect> & /*Va*/,
+        void _compute_results(const Eigen::Ref<const RealVect> & /*Va*/,
                                       const Eigen::Ref<const RealVect> & /*Vm*/,
                                       const Eigen::Ref<const CplxVect> & /*V*/,
                                       const SolverBusIdVect & /*id_grid_to_solver*/,
@@ -211,7 +211,7 @@ class OneSideContainer_PQ : public OneSideContainer
             // elements
                                       };
 
-        virtual bool _deactivate(int el_id, DualAlgoControl & solver_control) override {
+        bool _deactivate(int el_id, DualAlgoControl & solver_control) override {
             if(status_[el_id]){
                 solver_control.ac_algo_controler().tell_recompute_sbus(); solver_control.dc_algo_controler().tell_recompute_sbus();
                 solver_control.ac_algo_controler().tell_one_el_changed_bus(); solver_control.dc_algo_controler().tell_one_el_changed_bus();
@@ -219,7 +219,7 @@ class OneSideContainer_PQ : public OneSideContainer
             }
             return false;
         };
-        virtual bool _reactivate(int el_id, DualAlgoControl & solver_control) override {
+        bool _reactivate(int el_id, DualAlgoControl & solver_control) override {
             if(!status_[el_id]){
                 solver_control.ac_algo_controler().tell_recompute_sbus(); solver_control.dc_algo_controler().tell_recompute_sbus();
                 solver_control.ac_algo_controler().tell_one_el_changed_bus(); solver_control.dc_algo_controler().tell_one_el_changed_bus();
@@ -227,7 +227,7 @@ class OneSideContainer_PQ : public OneSideContainer
             }
             return false;
         };
-        virtual bool _change_bus(int el_id, GridModelBusId new_bus_id, DualAlgoControl & solver_control, int /*nb_bus*/) override {
+        bool _change_bus(int el_id, GridModelBusId new_bus_id, DualAlgoControl & solver_control, int /*nb_bus*/) override {
             if(bus_id_(el_id) != new_bus_id){
                 solver_control.ac_algo_controler().tell_recompute_sbus(); solver_control.dc_algo_controler().tell_recompute_sbus();
                 solver_control.ac_algo_controler().tell_one_el_changed_bus(); solver_control.dc_algo_controler().tell_one_el_changed_bus();
@@ -235,12 +235,12 @@ class OneSideContainer_PQ : public OneSideContainer
             }
             return false;
         };
-        virtual void _change_p(int el_id, real_type new_p, bool /*my_status*/, DualAlgoControl & solver_control) override {
+        void _change_p(int el_id, real_type new_p, bool /*my_status*/, DualAlgoControl & solver_control) override {
             if (abs(target_p_mw_(el_id) - new_p) > _tol_equal_float) {
                 solver_control.ac_algo_controler().tell_recompute_sbus(); solver_control.dc_algo_controler().tell_recompute_sbus();
             }
         };
-        virtual void _change_q(int el_id, real_type new_q, bool /*my_status*/,DualAlgoControl & solver_control) override {
+        void _change_q(int el_id, real_type new_q, bool /*my_status*/,DualAlgoControl & solver_control) override {
             if (abs(target_q_mvar_(el_id) - new_q) > _tol_equal_float) {
                 solver_control.ac_algo_controler().tell_recompute_sbus(); solver_control.dc_algo_controler().tell_recompute_sbus();
             }

--- a/src/core/element_container/OneSideContainer_forBranch.hpp
+++ b/src/core/element_container/OneSideContainer_forBranch.hpp
@@ -63,7 +63,7 @@ class OneSideContainer_ForBranch : public OneSideContainer
     public:
         OneSideContainer_ForBranch() noexcept = default;
         explicit OneSideContainer_ForBranch(bool /*is_trafo*/) noexcept{};
-        virtual ~OneSideContainer_ForBranch() noexcept = default;
+        ~OneSideContainer_ForBranch() noexcept override = default;
 
         // public generic API
 

--- a/src/core/element_container/OneSideContainer_forBranch.hpp
+++ b/src/core/element_container/OneSideContainer_forBranch.hpp
@@ -108,11 +108,11 @@ class OneSideContainer_ForBranch : public OneSideContainer
         }
 
     protected:
-        virtual void _reset_results() override {
+        void _reset_results() override {
             // nothing to do by default, as this class should be used as template for "branch" (eg lines or trafos)
             // elements
         };
-        virtual void _compute_results(const Eigen::Ref<const RealVect> & /*Va*/,
+        void _compute_results(const Eigen::Ref<const RealVect> & /*Va*/,
                                       const Eigen::Ref<const RealVect> & /*Vm*/,
                                       const Eigen::Ref<const CplxVect> & /*V*/,
                                       const SolverBusIdVect & /*id_grid_to_solver*/,
@@ -124,7 +124,7 @@ class OneSideContainer_ForBranch : public OneSideContainer
             // elements
             };
 
-        virtual bool _deactivate(int el_id, DualAlgoControl & solver_control) override {
+        bool _deactivate(int el_id, DualAlgoControl & solver_control) override {
             if(status_[el_id]){
                 solver_control.ac_algo_controler().tell_ybus_some_coeffs_zero(); solver_control.dc_algo_controler().tell_ybus_some_coeffs_zero();
                 solver_control.ac_algo_controler().tell_recompute_ybus(); solver_control.dc_algo_controler().tell_recompute_ybus();
@@ -134,7 +134,7 @@ class OneSideContainer_ForBranch : public OneSideContainer
             }
             return false;
         };
-        virtual bool _reactivate(int el_id, DualAlgoControl & solver_control) override {
+        bool _reactivate(int el_id, DualAlgoControl & solver_control) override {
             if(!status_[el_id]){
                 solver_control.ac_algo_controler().tell_recompute_ybus(); solver_control.dc_algo_controler().tell_recompute_ybus();
                 // solver_control.ac_algo_controler().tell_recompute_sbus(); solver_control.dc_algo_controler().tell_recompute_sbus();  // only for trafo in DC
@@ -144,7 +144,7 @@ class OneSideContainer_ForBranch : public OneSideContainer
             }
             return false;
         };
-        virtual bool _change_bus(int el_id, GridModelBusId new_bus_id, DualAlgoControl & solver_control, int /*nb_bus*/) override {
+        bool _change_bus(int el_id, GridModelBusId new_bus_id, DualAlgoControl & solver_control, int /*nb_bus*/) override {
             const GridModelBusId & bus_me_id = bus_id_(el_id);
             
             if(bus_me_id != new_bus_id) {

--- a/src/core/element_container/SGenContainer.hpp
+++ b/src/core/element_container/SGenContainer.hpp
@@ -65,7 +65,7 @@ class LS2G_API SGenContainer final: public OneSideContainer_PQ, public IteratorA
            >;
         
         SGenContainer() noexcept = default;
-        virtual ~SGenContainer() noexcept = default;
+        ~SGenContainer() noexcept override = default;
         
         // pickle (python)
         SGenContainer::StateRes get_state() const;

--- a/src/core/element_container/SGenContainer.hpp
+++ b/src/core/element_container/SGenContainer.hpp
@@ -86,10 +86,10 @@ class LS2G_API SGenContainer final: public OneSideContainer_PQ, public IteratorA
                   const Eigen::Ref<const Eigen::VectorXi> & sgen_bus_id
                   );
               
-        virtual void fillSbus(CplxVect & Sbus, const SolverBusIdVect & id_grid_to_solver, bool ac) const override;
+        void fillSbus(CplxVect & Sbus, const SolverBusIdVect & id_grid_to_solver, bool ac) const override;
 
     protected:
-        virtual void _compute_results(
+        void _compute_results(
             const Eigen::Ref<const RealVect> & /*Va*/,
             const Eigen::Ref<const RealVect> & /*Vm*/,
             const Eigen::Ref<const CplxVect> & /*V*/,

--- a/src/core/element_container/SGenContainer.hpp
+++ b/src/core/element_container/SGenContainer.hpp
@@ -86,7 +86,7 @@ class LS2G_API SGenContainer final: public OneSideContainer_PQ, public IteratorA
                   const Eigen::Ref<const Eigen::VectorXi> & sgen_bus_id
                   );
               
-        virtual void fillSbus(CplxVect & Sbus, const SolverBusIdVect & id_grid_to_solver, bool ac) const ;
+        virtual void fillSbus(CplxVect & Sbus, const SolverBusIdVect & id_grid_to_solver, bool ac) const override;
 
     protected:
         virtual void _compute_results(

--- a/src/core/element_container/ShuntContainer.hpp
+++ b/src/core/element_container/ShuntContainer.hpp
@@ -71,19 +71,19 @@ class LS2G_API ShuntContainer final: public OneSideContainer_PQ, public Iterator
         static ShuntContainer load_binary(const std::string & path);
         static const char * binary_type_tag() { return "ShuntContainer"; }  // written into / checked against the binary file header
         
-        virtual void fillYbus(std::vector<Eigen::Triplet<cplx_type> > & res,
+        void fillYbus(std::vector<Eigen::Triplet<cplx_type> > & res,
                               bool ac,
                               const SolverBusIdVect & id_grid_to_solver,
                               real_type sn_mva) const override;
-        virtual void fillBp_Bpp(std::vector<Eigen::Triplet<real_type> > & Bp,
+        void fillBp_Bpp(std::vector<Eigen::Triplet<real_type> > & Bp,
                                 std::vector<Eigen::Triplet<real_type> > & Bpp,
                                 const SolverBusIdVect & id_grid_to_solver,
                                 real_type sn_mva,
                                 FDPFMethod xb_or_bx) const override;
-        virtual void fillSbus(CplxVect & Sbus, const SolverBusIdVect & id_grid_to_solver, bool ac) const override;  // in DC i need that
+        void fillSbus(CplxVect & Sbus, const SolverBusIdVect & id_grid_to_solver, bool ac) const override;  // in DC i need that
         
     protected:
-        virtual void _change_p(int shunt_id, real_type new_p, bool /*my_status*/, DualAlgoControl & solver_control) override
+        void _change_p(int shunt_id, real_type new_p, bool /*my_status*/, DualAlgoControl & solver_control) override
         {
             if(abs(target_p_mw_(shunt_id) - new_p) > _tol_equal_float){
                 solver_control.ac_algo_controler().tell_recompute_ybus(); solver_control.dc_algo_controler().tell_recompute_ybus();
@@ -91,14 +91,14 @@ class LS2G_API ShuntContainer final: public OneSideContainer_PQ, public Iterator
             }
         }
 
-        virtual void _change_q(int shunt_id, real_type new_q, bool /*my_status*/, DualAlgoControl & solver_control) override
+        void _change_q(int shunt_id, real_type new_q, bool /*my_status*/, DualAlgoControl & solver_control) override
         {
             if(abs(target_q_mvar_(shunt_id) - new_q) > _tol_equal_float){
                 solver_control.ac_algo_controler().tell_recompute_ybus(); solver_control.dc_algo_controler().tell_recompute_ybus();
             }
         }
 
-        virtual bool _change_bus(int el_id, GridModelBusId new_bus_id, DualAlgoControl & solver_control, int /*nb_bus*/) override {
+        bool _change_bus(int el_id, GridModelBusId new_bus_id, DualAlgoControl & solver_control, int /*nb_bus*/) override {
             if(bus_id_(el_id) != new_bus_id){
                 solver_control.ac_algo_controler().tell_recompute_ybus(); solver_control.dc_algo_controler().tell_recompute_ybus();
                 solver_control.ac_algo_controler().tell_one_el_changed_bus(); solver_control.dc_algo_controler().tell_one_el_changed_bus();
@@ -107,7 +107,7 @@ class LS2G_API ShuntContainer final: public OneSideContainer_PQ, public Iterator
             }
             return false;
         };
-        virtual bool _deactivate(int el_id, DualAlgoControl & solver_control) override {
+        bool _deactivate(int el_id, DualAlgoControl & solver_control) override {
             if(status_[el_id]){
                 solver_control.ac_algo_controler().tell_recompute_ybus(); solver_control.dc_algo_controler().tell_recompute_ybus();
                 solver_control.ac_algo_controler().tell_one_el_changed_bus(); solver_control.dc_algo_controler().tell_one_el_changed_bus();
@@ -116,7 +116,7 @@ class LS2G_API ShuntContainer final: public OneSideContainer_PQ, public Iterator
             }
             return false;
         };
-        virtual bool _reactivate(int el_id, DualAlgoControl & solver_control) override {
+        bool _reactivate(int el_id, DualAlgoControl & solver_control) override {
             if(!status_[el_id]){
                 solver_control.ac_algo_controler().tell_recompute_ybus(); solver_control.dc_algo_controler().tell_recompute_ybus();
                 solver_control.ac_algo_controler().tell_one_el_changed_bus(); solver_control.dc_algo_controler().tell_one_el_changed_bus();
@@ -126,7 +126,7 @@ class LS2G_API ShuntContainer final: public OneSideContainer_PQ, public Iterator
             return false;
         };
 
-        virtual void _compute_results(
+        void _compute_results(
             const Eigen::Ref<const RealVect> & Va,
             const Eigen::Ref<const RealVect> & Vm,
             const Eigen::Ref<const CplxVect> & V,

--- a/src/core/element_container/ShuntContainer.hpp
+++ b/src/core/element_container/ShuntContainer.hpp
@@ -74,13 +74,13 @@ class LS2G_API ShuntContainer final: public OneSideContainer_PQ, public Iterator
         virtual void fillYbus(std::vector<Eigen::Triplet<cplx_type> > & res,
                               bool ac,
                               const SolverBusIdVect & id_grid_to_solver,
-                              real_type sn_mva) const;
+                              real_type sn_mva) const override;
         virtual void fillBp_Bpp(std::vector<Eigen::Triplet<real_type> > & Bp,
                                 std::vector<Eigen::Triplet<real_type> > & Bpp,
                                 const SolverBusIdVect & id_grid_to_solver,
                                 real_type sn_mva,
-                                FDPFMethod xb_or_bx) const;
-        virtual void fillSbus(CplxVect & Sbus, const SolverBusIdVect & id_grid_to_solver, bool ac) const;  // in DC i need that
+                                FDPFMethod xb_or_bx) const override;
+        virtual void fillSbus(CplxVect & Sbus, const SolverBusIdVect & id_grid_to_solver, bool ac) const override;  // in DC i need that
         
     protected:
         virtual void _change_p(int shunt_id, real_type new_p, bool /*my_status*/, DualAlgoControl & solver_control) override

--- a/src/core/element_container/ShuntContainer.hpp
+++ b/src/core/element_container/ShuntContainer.hpp
@@ -47,7 +47,7 @@ class LS2G_API ShuntContainer final: public OneSideContainer_PQ, public Iterator
         using StateRes = std::tuple<OneSideContainer_PQ::StateRes >;
         
         ShuntContainer() noexcept = default;
-        virtual ~ShuntContainer() noexcept = default;
+        ~ShuntContainer() noexcept override = default;
         
         
         void init(const Eigen::Ref<const RealVect> & shunt_p_mw,

--- a/src/core/element_container/StorageContainer.hpp
+++ b/src/core/element_container/StorageContainer.hpp
@@ -82,10 +82,10 @@ class LS2G_API StorageContainer final: public OneSideContainer_PQ, public Iterat
             reset_results();
         }
 
-        virtual void fillSbus(CplxVect & Sbus, const SolverBusIdVect & id_grid_to_solver, bool ac) const override;
+        void fillSbus(CplxVect & Sbus, const SolverBusIdVect & id_grid_to_solver, bool ac) const override;
 
     protected:
-        virtual void _compute_results(const Eigen::Ref<const RealVect> & /*Va*/,
+        void _compute_results(const Eigen::Ref<const RealVect> & /*Va*/,
                                     const Eigen::Ref<const RealVect> & /*Vm*/,
                                     const Eigen::Ref<const CplxVect> & /*V*/,
                                     const SolverBusIdVect & /*id_grid_to_solver*/,

--- a/src/core/element_container/StorageContainer.hpp
+++ b/src/core/element_container/StorageContainer.hpp
@@ -82,7 +82,7 @@ class LS2G_API StorageContainer final: public OneSideContainer_PQ, public Iterat
             reset_results();
         }
 
-        virtual void fillSbus(CplxVect & Sbus, const SolverBusIdVect & id_grid_to_solver, bool ac) const;
+        virtual void fillSbus(CplxVect & Sbus, const SolverBusIdVect & id_grid_to_solver, bool ac) const override;
 
     protected:
         virtual void _compute_results(const Eigen::Ref<const RealVect> & /*Va*/,

--- a/src/core/element_container/StorageContainer.hpp
+++ b/src/core/element_container/StorageContainer.hpp
@@ -59,7 +59,7 @@ class LS2G_API StorageContainer final: public OneSideContainer_PQ, public Iterat
            > ;
 
         StorageContainer() noexcept = default;
-        virtual ~StorageContainer() noexcept = default;
+        ~StorageContainer() noexcept override = default;
 
         // pickle (python)
         StorageContainer::StateRes get_state() const;

--- a/src/core/element_container/SvcContainer.hpp
+++ b/src/core/element_container/SvcContainer.hpp
@@ -94,7 +94,7 @@ class LS2G_API SvcContainer final : public OneSideContainer_PQ, public IteratorA
                       "SvcContainer::StateRes and StateResIdx do not match");
 
         SvcContainer() noexcept = default;
-        virtual ~SvcContainer() noexcept = default;
+        ~SvcContainer() noexcept override = default;
 
         void init(const std::vector<int> & regulation_mode,
                   const Eigen::Ref<const RealVect> & target_vm_pu,

--- a/src/core/element_container/SvcContainer.hpp
+++ b/src/core/element_container/SvcContainer.hpp
@@ -52,7 +52,7 @@ IIDM model of powsybl: three regulation modes
 `b_min_` / `b_max_` are stored for introspection but NEVER enforced (no outer
 loop, no limit check), mirroring the generator Qmin/Qmax handling.
 **/
-class LS2G_API SvcContainer : public OneSideContainer_PQ, public IteratorAdder<SvcContainer, SvcInfo>
+class LS2G_API SvcContainer final : public OneSideContainer_PQ, public IteratorAdder<SvcContainer, SvcInfo>
 {
     friend class SvcInfo;
 

--- a/src/core/element_container/SvcContainer.hpp
+++ b/src/core/element_container/SvcContainer.hpp
@@ -136,12 +136,12 @@ class LS2G_API SvcContainer final : public OneSideContainer_PQ, public IteratorA
         void set_voltage_control_q(int svc_id, real_type q_mvar) {res_q_(svc_id) = q_mvar;}
 
         // solver interface
-        virtual void fillSbus(CplxVect & Sbus, const SolverBusIdVect & id_grid_to_solver, bool ac) const override;
+        void fillSbus(CplxVect & Sbus, const SolverBusIdVect & id_grid_to_solver, bool ac) const override;
         void get_vm_for_dc(RealVect & Vm);
         void set_vm(CplxVect & V, const SolverBusIdVect & id_grid_to_solver) const;
 
     protected:
-        virtual void _compute_results(
+        void _compute_results(
             const Eigen::Ref<const RealVect> & Va,
             const Eigen::Ref<const RealVect> & Vm,
             const Eigen::Ref<const CplxVect> & V,

--- a/src/core/element_container/TrafoContainer.hpp
+++ b/src/core/element_container/TrafoContainer.hpp
@@ -213,12 +213,12 @@ class LS2G_API TrafoContainer final : public TwoSidesContainer_rxh_A<OneSideCont
         
     protected:
         // void _update_model_coeffs();
-        virtual void _update_model_coeffs_one_el(int el_id) override;
-        virtual void _update_other_model_coeffs() override {
+        void _update_model_coeffs_one_el(int el_id) override;
+        void _update_other_model_coeffs() override {
             dc_x_tau_shift_ = RealVect::Zero(nb());
         }
 
-        virtual bool _deactivate(int el_id, DualAlgoControl & solver_control) override {
+        bool _deactivate(int el_id, DualAlgoControl & solver_control) override {
             bool has_been_changed = TwoSidesContainer_rxh_A<OneSideContainer_ForBranch>:: _deactivate(el_id, solver_control);
             if(has_been_changed){
                 // TODO speed: only when dc_x_tau_shift_ is not 0, but be carefull, dc_x_tau_shift_ can be changed later
@@ -227,7 +227,7 @@ class LS2G_API TrafoContainer final : public TwoSidesContainer_rxh_A<OneSideCont
             return has_been_changed;
         }
 
-        virtual bool _reactivate(int el_id, DualAlgoControl & solver_control) override {
+        bool _reactivate(int el_id, DualAlgoControl & solver_control) override {
             bool has_been_changed = TwoSidesContainer_rxh_A<OneSideContainer_ForBranch>:: _reactivate(el_id, solver_control);
             if(has_been_changed){
                 // TODO speed: only when dc_x_tau_shift_ is not 0, but be carefull, dc_x_tau_shift_ can be changed later
@@ -236,7 +236,7 @@ class LS2G_API TrafoContainer final : public TwoSidesContainer_rxh_A<OneSideCont
             return has_been_changed;
         }
 
-        virtual void _change_bus_side_1(
+        void _change_bus_side_1(
             int /*el_id*/,
             GridModelBusId /*new_gridmodel_bus_id*/,
             DualAlgoControl & solver_control,
@@ -249,7 +249,7 @@ class LS2G_API TrafoContainer final : public TwoSidesContainer_rxh_A<OneSideCont
             }
         }
 
-        virtual void _change_bus_side_2(
+        void _change_bus_side_2(
             int /*el_id*/,
             GridModelBusId /*new_gridmodel_bus_id*/,
             DualAlgoControl & solver_control,
@@ -262,7 +262,7 @@ class LS2G_API TrafoContainer final : public TwoSidesContainer_rxh_A<OneSideCont
             }
         }
 
-        virtual void _update_topo(
+        void _update_topo(
             DualAlgoControl & solver_control,
             SubstationContainer & /*substations*/,
             const std::vector<bool> & side1_changed,
@@ -332,17 +332,17 @@ class LS2G_API TrafoContainer final : public TwoSidesContainer_rxh_A<OneSideCont
 
     protected:
 
-        virtual real_type fillBf_for_PTDF_coeff(int tr_id) const override {
+        real_type fillBf_for_PTDF_coeff(int tr_id) const override {
             real_type res = x_(tr_id);
             real_type tau = is_tap_side1_[tr_id] ? ratio_(tr_id) : 1. / ratio_(tr_id);
             return res * tau;
         }
 
-        virtual int fillBf_for_PTDF_id(int tr_id, int nb_powerline) const override {
+        int fillBf_for_PTDF_id(int tr_id, int nb_powerline) const override {
             return tr_id + nb_powerline;
         }
 
-        virtual FDPFCoeffs get_fdpf_coeffs(int tr_id, FDPFMethod xb_or_bx) const override;
+        FDPFCoeffs get_fdpf_coeffs(int tr_id, FDPFMethod xb_or_bx) const override;
 };
 
 inline TrafoInfo::TrafoInfo(const TrafoContainer & r_data_trafo, int my_id) noexcept:

--- a/src/core/element_container/TrafoContainer.hpp
+++ b/src/core/element_container/TrafoContainer.hpp
@@ -82,7 +82,7 @@ class LS2G_API TrafoContainer final : public TwoSidesContainer_rxh_A<OneSideCont
                >;
 
         TrafoContainer() noexcept = default;
-        virtual ~TrafoContainer() noexcept = default;
+        ~TrafoContainer() noexcept override = default;
 
         void init(const Eigen::Ref<const RealVect> & trafo_r,
                   const Eigen::Ref<const RealVect> & trafo_x,

--- a/src/core/element_container/TrafoContainer.hpp
+++ b/src/core/element_container/TrafoContainer.hpp
@@ -135,10 +135,10 @@ class LS2G_API TrafoContainer final : public TwoSidesContainer_rxh_A<OneSideCont
                                     const std::vector<std::vector<real_type> > & rx_corr_pct,
                                     DualAlgoControl & solver_control);
 
-        virtual void hack_Sbus_for_dc_phase_shifter(
+        void hack_Sbus_for_dc_phase_shifter(
             CplxVect & Sbus,
             bool ac,
-            const SolverBusIdVect & id_grid_to_solver);  // needed for dc mode  
+            const SolverBusIdVect & id_grid_to_solver);  // needed for dc mode
 
         void compute_results(const Eigen::Ref<const RealVect> & Va,
                              const Eigen::Ref<const RealVect> & Vm,
@@ -237,12 +237,12 @@ class LS2G_API TrafoContainer final : public TwoSidesContainer_rxh_A<OneSideCont
         }
 
         virtual void _change_bus_side_1(
-            int /*el_id*/, 
-            GridModelBusId /*new_gridmodel_bus_id*/, 
-            DualAlgoControl & solver_control, 
+            int /*el_id*/,
+            GridModelBusId /*new_gridmodel_bus_id*/,
+            DualAlgoControl & solver_control,
             const SubstationContainer & /*substation*/,
             bool has_effectively_changed
-        ) {
+        ) override {
             if(has_effectively_changed){
                 // TODO speed: only when dc_x_tau_shift_ is not 0, but be carefull, dc_x_tau_shift_ can be changed later
                 solver_control.dc_algo_controler().tell_recompute_sbus();
@@ -255,7 +255,7 @@ class LS2G_API TrafoContainer final : public TwoSidesContainer_rxh_A<OneSideCont
             DualAlgoControl & solver_control,
             const SubstationContainer & /*substation*/,
             bool has_effectively_changed
-        ) {
+        ) override {
             if(has_effectively_changed){
                 // TODO speed: only when dc_x_tau_shift_ is not 0, but be carefull, dc_x_tau_shift_ can be changed later
                 solver_control.dc_algo_controler().tell_recompute_sbus();
@@ -267,7 +267,7 @@ class LS2G_API TrafoContainer final : public TwoSidesContainer_rxh_A<OneSideCont
             SubstationContainer & /*substations*/,
             const std::vector<bool> & side1_changed,
             const std::vector<bool> & side2_changed
-        )
+        ) override
         {
             bool onechanged_1 = std::any_of(side1_changed.begin(), side1_changed.end(), [](bool v) { return v; });
             bool onechanged_2 = std::any_of(side2_changed.begin(), side2_changed.end(), [](bool v) { return v; });

--- a/src/core/element_container/TwoSidesContainer.hpp
+++ b/src/core/element_container/TwoSidesContainer.hpp
@@ -116,7 +116,7 @@ class TwoSidesContainer : public GenericContainer
 
     public:
         TwoSidesContainer() noexcept :ignore_status_global_(false), synch_status_both_side_(true){}
-        virtual ~TwoSidesContainer() noexcept = default;
+        ~TwoSidesContainer() noexcept override = default;
 
         // public generic API
         size_t nb() const { return side_1_.nb(); }

--- a/src/core/element_container/TwoSidesContainer.hpp
+++ b/src/core/element_container/TwoSidesContainer.hpp
@@ -207,7 +207,7 @@ class TwoSidesContainer : public GenericContainer
                 }
             }
         }
-        virtual void nb_line_end(std::vector<int> & res) const final {
+        virtual void nb_line_end(std::vector<int> & res) const override final {
             const int nb_el = nb();
             for(int el_id = 0; el_id < nb_el; ++el_id){
                 // don't do anything if the element is disconnected

--- a/src/core/element_container/TwoSidesContainer.hpp
+++ b/src/core/element_container/TwoSidesContainer.hpp
@@ -169,7 +169,7 @@ class TwoSidesContainer : public GenericContainer
         Eigen::Ref<const IntVect> get_bus_id_side_1_numpy() const {return side_1_.get_bus_id_numpy();}
         Eigen::Ref<const IntVect> get_bus_id_side_2_numpy() const {return side_2_.get_bus_id_numpy();}
 
-        void reconnect_connected_buses(SubstationContainer & substation) const{
+        void reconnect_connected_buses(SubstationContainer & substation) const override{
             side_1_.reconnect_connected_buses(substation);
             side_2_.reconnect_connected_buses(substation);
             // TODO think about status here !
@@ -177,7 +177,7 @@ class TwoSidesContainer : public GenericContainer
             // (in this case this can do nothing if side_1 or side_2 is not connected)
         }
 
-        virtual void disconnect_if_not_in_main_component(std::vector<bool> & busbar_in_main_component) override {
+        void disconnect_if_not_in_main_component(std::vector<bool> & busbar_in_main_component) override {
             const int nb_el = nb();
             DualAlgoControl unused_solver_control;
             const GlobalBusIdVect & bus_side_1_id_ = get_buses_side_1();
@@ -207,7 +207,7 @@ class TwoSidesContainer : public GenericContainer
                 }
             }
         }
-        virtual void nb_line_end(std::vector<int> & res) const override final {
+        void nb_line_end(std::vector<int> & res) const override final {
             const int nb_el = nb();
             for(int el_id = 0; el_id < nb_el; ++el_id){
                 // don't do anything if the element is disconnected

--- a/src/core/element_container/TwoSidesContainer_rxh_A.hpp
+++ b/src/core/element_container/TwoSidesContainer_rxh_A.hpp
@@ -406,7 +406,7 @@ class TwoSidesContainer_rxh_A: public TwoSidesContainer<OneSideType>
             compute_amps_after_all_set();
         }
         
-        virtual void get_graph(std::vector<Eigen::Triplet<real_type> > & res) const override
+        void get_graph(std::vector<Eigen::Triplet<real_type> > & res) const override
         {
             const auto my_size = nb();
             for(size_t el_id = 0; el_id < my_size; ++el_id){
@@ -445,7 +445,7 @@ class TwoSidesContainer_rxh_A: public TwoSidesContainer<OneSideType>
         const std::vector<bool>& get_status_global()  const { return status_global_; }
 
         // solver interface
-        virtual void fillYbus(
+        void fillYbus(
             std::vector<Eigen::Triplet<cplx_type> > & res,
             bool ac,
             const SolverBusIdVect & id_grid_to_solver,
@@ -532,7 +532,7 @@ class TwoSidesContainer_rxh_A: public TwoSidesContainer<OneSideType>
 
         // Real DC equivalent of fillYbus (DC branch): pushes the real susceptance coefficients
         // directly into a real triplet list (no complex temporary).
-        virtual void fillBdc(
+        void fillBdc(
             std::vector<Eigen::Triplet<real_type> > & res,
             const SolverBusIdVect & id_grid_to_solver,
             real_type /*sn_mva*/) const override
@@ -571,7 +571,7 @@ class TwoSidesContainer_rxh_A: public TwoSidesContainer<OneSideType>
             }
         }
 
-        virtual void fillBp_Bpp(std::vector<Eigen::Triplet<real_type> > & Bp,
+        void fillBp_Bpp(std::vector<Eigen::Triplet<real_type> > & Bp,
                                 std::vector<Eigen::Triplet<real_type> > & Bpp,
                                 const SolverBusIdVect & id_grid_to_solver,
                                 real_type /*sn_mva*/,
@@ -673,7 +673,7 @@ class TwoSidesContainer_rxh_A: public TwoSidesContainer<OneSideType>
                              const SolverBusIdVect & id_grid_to_solver,
                              real_type /*sn_mva*/,
                              int nb_powerline,
-                             bool transpose) const
+                             bool transpose) const override
         {
             const size_t nb_line = nb();
             const std::vector<bool> & side1_conn = side_1_.get_status();
@@ -683,7 +683,7 @@ class TwoSidesContainer_rxh_A: public TwoSidesContainer<OneSideType>
                 if(!status_global_[line_id]) continue;
                 if(!side1_conn[line_id]) continue;
                 if(!side2_conn[line_id]) continue;
-                
+
                 // get the from / to bus id
                 GlobalBusId bus_or_id_me = get_bus_side_1(line_id);
                 if(bus_or_id_me.cast_int() == _deactivated_bus_id){
@@ -735,7 +735,7 @@ class TwoSidesContainer_rxh_A: public TwoSidesContainer<OneSideType>
         }
 
         // gridmodel utilities
-        void reconnect_connected_buses(SubstationContainer & substation) const{
+        void reconnect_connected_buses(SubstationContainer & substation) const override{
             const size_t nb_els = nb();
             const std::vector<bool>& status_side_1_ = get_status_side_1();
             const std::vector<bool>& status_side_2_ = get_status_side_2();
@@ -875,7 +875,7 @@ class TwoSidesContainer_rxh_A: public TwoSidesContainer<OneSideType>
             res_a_side_2_ = RealVect(nb());  // in kA
         }
 
-        virtual bool _deactivate(int el_id, DualAlgoControl & solver_control) override {
+        bool _deactivate(int el_id, DualAlgoControl & solver_control) override {
             if(status_global_[el_id]){
                 // update solver control
                 solver_control.ac_algo_controler().tell_recompute_ybus(); solver_control.dc_algo_controler().tell_recompute_ybus();
@@ -886,7 +886,7 @@ class TwoSidesContainer_rxh_A: public TwoSidesContainer<OneSideType>
             }
             return false;
         }
-        virtual bool _reactivate(int el_id, DualAlgoControl & solver_control) override {
+        bool _reactivate(int el_id, DualAlgoControl & solver_control) override {
             if(!status_global_[el_id]){
                 // update solver control
                 solver_control.ac_algo_controler().tell_recompute_ybus(); solver_control.dc_algo_controler().tell_recompute_ybus();
@@ -985,7 +985,7 @@ class TwoSidesContainer_rxh_A: public TwoSidesContainer<OneSideType>
          * This requires that status_global, status of side 1 and status of side 2 
          * are set correctly
          */
-        virtual void _update_effective_coeffs_one_el(int el_id) override {
+        void _update_effective_coeffs_one_el(int el_id) override {
             const bool s1 = side_1_.get_status(el_id);
             const bool s2 = side_2_.get_status(el_id);
             if (!status_global_[el_id] || (!s1 && !s2)) {

--- a/src/core/element_container/TwoSidesContainer_rxh_A.hpp
+++ b/src/core/element_container/TwoSidesContainer_rxh_A.hpp
@@ -406,7 +406,7 @@ class TwoSidesContainer_rxh_A: public TwoSidesContainer<OneSideType>
             compute_amps_after_all_set();
         }
         
-        virtual void get_graph(std::vector<Eigen::Triplet<real_type> > & res) const
+        virtual void get_graph(std::vector<Eigen::Triplet<real_type> > & res) const override
         {
             const auto my_size = nb();
             for(size_t el_id = 0; el_id < my_size; ++el_id){
@@ -449,7 +449,7 @@ class TwoSidesContainer_rxh_A: public TwoSidesContainer<OneSideType>
             std::vector<Eigen::Triplet<cplx_type> > & res,
             bool ac,
             const SolverBusIdVect & id_grid_to_solver,
-            real_type /*sn_mva*/) const
+            real_type /*sn_mva*/) const override
         {
             const size_t nb_els = nb();
             const std::vector<bool> & status1 = side_1_.get_status();
@@ -575,7 +575,7 @@ class TwoSidesContainer_rxh_A: public TwoSidesContainer<OneSideType>
                                 std::vector<Eigen::Triplet<real_type> > & Bpp,
                                 const SolverBusIdVect & id_grid_to_solver,
                                 real_type /*sn_mva*/,
-                                FDPFMethod xb_or_bx) const
+                                FDPFMethod xb_or_bx) const override
         {
 
             // For Bp

--- a/src/core/element_container/TwoSidesContainer_rxh_A.hpp
+++ b/src/core/element_container/TwoSidesContainer_rxh_A.hpp
@@ -157,7 +157,7 @@ class TwoSidesContainer_rxh_A: public TwoSidesContainer<OneSideType>
 
     public:
         TwoSidesContainer_rxh_A() noexcept = default;
-        virtual ~TwoSidesContainer_rxh_A() noexcept = default;
+        ~TwoSidesContainer_rxh_A() noexcept override = default;
         
         // pickle
         // /!\ if you change this layout, bump BINARY_FORMAT_VERSION (BinaryArchive.hpp)

--- a/src/core/powerflow_algorithm/BaseDCAlgo.hpp
+++ b/src/core/powerflow_algorithm/BaseDCAlgo.hpp
@@ -40,8 +40,8 @@ class BaseDCAlgo final: public BaseAlgo
 
         virtual ~BaseDCAlgo() noexcept = default;
 
-        virtual void reset() final;
-        virtual void reset_timer() final{
+        virtual void reset() override final;
+        virtual void reset_timer() override final{
             BaseAlgo::reset_timer();
             timer_refactor_ = 0.;
             timer_factor_ = 0.;
@@ -53,7 +53,7 @@ class BaseDCAlgo final: public BaseAlgo
             timer_lodf_ = 0.;
         }
 
-        virtual TimerJac get_timers_jacobian() const final
+        virtual TimerJac get_timers_jacobian() const override final
         {
             TimerJac res;
             res.timer_Fx_         = timer_Fx_;
@@ -68,7 +68,7 @@ class BaseDCAlgo final: public BaseAlgo
             return res;
         }
 
-        virtual TimerPTDFLODFType get_timers_ptdf_lodf() const final
+        virtual TimerPTDFLODFType get_timers_ptdf_lodf() const override final
         {
             TimerPTDFLODFType res = {
                 timer_ptdf_,  
@@ -89,14 +89,14 @@ class BaseDCAlgo final: public BaseAlgo
                            Eigen::Ref<const RealVect> slack_weights,
                            Eigen::Ref<const IntVect> pv,
                            Eigen::Ref<const IntVect> pq
-                           ) final;
+                           ) override final;
 
-        virtual RealMat get_ptdf() final;
+        virtual RealMat get_ptdf() override final;
         virtual RealMat get_lodf(const IntVect & from_bus,
-                                 const IntVect & to_bus) final;
-        virtual Eigen::SparseMatrix<real_type> get_bsdf() final;  // TODO BSDF
-        
-        virtual void update_internal_Ybus(const Coeff & coeff, bool add) final{
+                                 const IntVect & to_bus) override final;
+        virtual Eigen::SparseMatrix<real_type> get_bsdf() override final;  // TODO BSDF
+
+        virtual void update_internal_Ybus(const Coeff & coeff, bool add) override final{
             int row_res = static_cast<int>(coeff.row_id);
             row_res = mat_bus_id_(row_res);
             if(row_res == -1) return;
@@ -118,8 +118,8 @@ class BaseDCAlgo final: public BaseAlgo
         // a working copy of dcYbus_noslack_, so the (incrementally maintained)
         // persistent matrix and the symbolic factorization are left untouched (only a
         // numeric refactorize is needed). See compute_pf_dc.
-        virtual bool supports_bus_masking() const final { return true; }
-        virtual void set_masked_buses(const std::vector<int> & solver_bus_ids) final{
+        virtual bool supports_bus_masking() const override final { return true; }
+        virtual void set_masked_buses(const std::vector<int> & solver_bus_ids) override final{
             masked_buses_ = solver_bus_ids;
         }
 

--- a/src/core/powerflow_algorithm/BaseDCAlgo.hpp
+++ b/src/core/powerflow_algorithm/BaseDCAlgo.hpp
@@ -38,10 +38,10 @@ class BaseDCAlgo final: public BaseAlgo
             sizeYbus_with_slack_(0),
             sizeYbus_without_slack_(0){};
 
-        virtual ~BaseDCAlgo() noexcept = default;
+        ~BaseDCAlgo() noexcept override = default;
 
-        void reset() override final;
-        void reset_timer() override final{
+        void reset() override;
+        void reset_timer() override{
             BaseAlgo::reset_timer();
             timer_refactor_ = 0.;
             timer_factor_ = 0.;
@@ -53,7 +53,7 @@ class BaseDCAlgo final: public BaseAlgo
             timer_lodf_ = 0.;
         }
 
-        TimerJac get_timers_jacobian() const override final
+        TimerJac get_timers_jacobian() const override
         {
             TimerJac res;
             res.timer_Fx_         = timer_Fx_;
@@ -68,7 +68,7 @@ class BaseDCAlgo final: public BaseAlgo
             return res;
         }
 
-        TimerPTDFLODFType get_timers_ptdf_lodf() const override final
+        TimerPTDFLODFType get_timers_ptdf_lodf() const override
         {
             TimerPTDFLODFType res = {
                 timer_ptdf_,  
@@ -88,14 +88,14 @@ class BaseDCAlgo final: public BaseAlgo
                            Eigen::Ref<const RealVect> slack_weights,
                            Eigen::Ref<const IntVect> pv,
                            Eigen::Ref<const IntVect> pq
-                           ) override final;
+                           ) override;
 
-        RealMat get_ptdf() override final;
+        RealMat get_ptdf() override;
         RealMat get_lodf(const IntVect & from_bus,
-                                 const IntVect & to_bus) override final;
-        Eigen::SparseMatrix<real_type> get_bsdf() override final;  // TODO BSDF
+                                 const IntVect & to_bus) override;
+        Eigen::SparseMatrix<real_type> get_bsdf() override;  // TODO BSDF
 
-        void update_internal_Ybus(const Coeff & coeff, bool add) override final{
+        void update_internal_Ybus(const Coeff & coeff, bool add) override{
             int row_res = static_cast<int>(coeff.row_id);
             row_res = mat_bus_id_(row_res);
             if(row_res == -1) return;
@@ -117,8 +117,8 @@ class BaseDCAlgo final: public BaseAlgo
         // a working copy of dcYbus_noslack_, so the (incrementally maintained)
         // persistent matrix and the symbolic factorization are left untouched (only a
         // numeric refactorize is needed). See compute_pf_dc.
-        bool supports_bus_masking() const override final { return true; }
-        void set_masked_buses(const std::vector<int> & solver_bus_ids) override final{
+        bool supports_bus_masking() const override { return true; }
+        void set_masked_buses(const std::vector<int> & solver_bus_ids) override{
             masked_buses_ = solver_bus_ids;
         }
 

--- a/src/core/powerflow_algorithm/BaseDCAlgo.hpp
+++ b/src/core/powerflow_algorithm/BaseDCAlgo.hpp
@@ -40,8 +40,8 @@ class BaseDCAlgo final: public BaseAlgo
 
         virtual ~BaseDCAlgo() noexcept = default;
 
-        virtual void reset() override final;
-        virtual void reset_timer() override final{
+        void reset() override final;
+        void reset_timer() override final{
             BaseAlgo::reset_timer();
             timer_refactor_ = 0.;
             timer_factor_ = 0.;
@@ -53,7 +53,7 @@ class BaseDCAlgo final: public BaseAlgo
             timer_lodf_ = 0.;
         }
 
-        virtual TimerJac get_timers_jacobian() const override final
+        TimerJac get_timers_jacobian() const override final
         {
             TimerJac res;
             res.timer_Fx_         = timer_Fx_;
@@ -68,7 +68,7 @@ class BaseDCAlgo final: public BaseAlgo
             return res;
         }
 
-        virtual TimerPTDFLODFType get_timers_ptdf_lodf() const override final
+        TimerPTDFLODFType get_timers_ptdf_lodf() const override final
         {
             TimerPTDFLODFType res = {
                 timer_ptdf_,  
@@ -81,7 +81,6 @@ class BaseDCAlgo final: public BaseAlgo
         // Native real-valued DC power flow: solves `Bbus . theta = Pbus`.
         // (the DC solver does not implement the complex `compute_pf`: it inherits the throwing
         //  default from BaseAlgo, since every DC code path goes through `compute_pf_dc`)
-        virtual
         bool compute_pf_dc(const Eigen::SparseMatrix<real_type> & Bbus,
                            CplxVect & V,
                            Eigen::Ref<const RealVect> Pbus,
@@ -91,12 +90,12 @@ class BaseDCAlgo final: public BaseAlgo
                            Eigen::Ref<const IntVect> pq
                            ) override final;
 
-        virtual RealMat get_ptdf() override final;
-        virtual RealMat get_lodf(const IntVect & from_bus,
+        RealMat get_ptdf() override final;
+        RealMat get_lodf(const IntVect & from_bus,
                                  const IntVect & to_bus) override final;
-        virtual Eigen::SparseMatrix<real_type> get_bsdf() override final;  // TODO BSDF
+        Eigen::SparseMatrix<real_type> get_bsdf() override final;  // TODO BSDF
 
-        virtual void update_internal_Ybus(const Coeff & coeff, bool add) override final{
+        void update_internal_Ybus(const Coeff & coeff, bool add) override final{
             int row_res = static_cast<int>(coeff.row_id);
             row_res = mat_bus_id_(row_res);
             if(row_res == -1) return;
@@ -118,8 +117,8 @@ class BaseDCAlgo final: public BaseAlgo
         // a working copy of dcYbus_noslack_, so the (incrementally maintained)
         // persistent matrix and the symbolic factorization are left untouched (only a
         // numeric refactorize is needed). See compute_pf_dc.
-        virtual bool supports_bus_masking() const override final { return true; }
-        virtual void set_masked_buses(const std::vector<int> & solver_bus_ids) override final{
+        bool supports_bus_masking() const override final { return true; }
+        void set_masked_buses(const std::vector<int> & solver_bus_ids) override final{
             masked_buses_ = solver_bus_ids;
         }
 

--- a/src/core/powerflow_algorithm/BaseFDPFAlgo.hpp
+++ b/src/core/powerflow_algorithm/BaseFDPFAlgo.hpp
@@ -21,7 +21,7 @@ class BaseFDPFAlgo final: public BaseAlgo
 {
     public:
         BaseFDPFAlgo() noexcept :BaseAlgo(true), need_factorize_(true) {}
-        virtual ~BaseFDPFAlgo() noexcept = default;
+        ~BaseFDPFAlgo() noexcept override = default;
 
         bool compute_pf(const Eigen::SparseMatrix<cplx_type> & Ybus,
                         CplxVect & V,

--- a/src/core/powerflow_algorithm/BaseFDPFAlgo.hpp
+++ b/src/core/powerflow_algorithm/BaseFDPFAlgo.hpp
@@ -17,7 +17,7 @@ namespace ls2g {
 Base class for Fast Decoupled Powerflow based solver
 **/
 template<class LinearSolver, FDPFMethod XB_BX>
-class BaseFDPFAlgo: public BaseAlgo
+class BaseFDPFAlgo final: public BaseAlgo
 {
     public:
         BaseFDPFAlgo() noexcept :BaseAlgo(true), need_factorize_(true) {}
@@ -77,7 +77,6 @@ class BaseFDPFAlgo: public BaseAlgo
         
         void fillBp_Bpp(Eigen::SparseMatrix<real_type> & Bp, Eigen::SparseMatrix<real_type> & Bpp) const;  // defined in Solvers.cpp !
 
-        virtual
         void initialize() {
             auto timer = CustTimer();
             err_ = ErrorType::NoError; // reset error message
@@ -111,7 +110,6 @@ class BaseFDPFAlgo: public BaseAlgo
             timer_initialize_ += timer.duration();
         }
 
-        virtual
         void solve(LinearSolver& linear_solver,
                    RealVect & b){
             auto timer = CustTimer();

--- a/src/core/powerflow_algorithm/BaseFDPFAlgo.hpp
+++ b/src/core/powerflow_algorithm/BaseFDPFAlgo.hpp
@@ -23,7 +23,6 @@ class BaseFDPFAlgo final: public BaseAlgo
         BaseFDPFAlgo() noexcept :BaseAlgo(true), need_factorize_(true) {}
         virtual ~BaseFDPFAlgo() noexcept = default;
 
-        virtual
         bool compute_pf(const Eigen::SparseMatrix<cplx_type> & Ybus,
                         CplxVect & V,
                         Eigen::Ref<const CplxVect> Sbus,
@@ -35,7 +34,7 @@ class BaseFDPFAlgo final: public BaseAlgo
                         real_type tol
                         ) override;  // requires a gridmodel !
 
-        virtual void reset() override
+        void reset() override
         {   
             BaseAlgo::reset();
             // solution of the problem
@@ -58,7 +57,7 @@ class BaseFDPFAlgo final: public BaseAlgo
         Eigen::SparseMatrix<real_type> debug_get_Bpp_python() { return Bpp_;}
 
     protected:
-        virtual void reset_timer() override {
+        void reset_timer() override {
             BaseAlgo::reset_timer();
         }
 

--- a/src/core/powerflow_algorithm/GaussSeidelAlgo.hpp
+++ b/src/core/powerflow_algorithm/GaussSeidelAlgo.hpp
@@ -21,12 +21,11 @@ class LS2G_API GaussSeidelAlgo : public BaseAlgo
         virtual ~GaussSeidelAlgo() noexcept = default;
 
         // todo  can be factorized
-        virtual Eigen::Ref<const Eigen::SparseMatrix<real_type> > get_J() const override {
+        Eigen::Ref<const Eigen::SparseMatrix<real_type> > get_J() const override {
             throw std::runtime_error("get_J: There is no jacobian in the Gauss Seidel method");
         }
 
         // todo change the name!
-        virtual
         bool compute_pf(const Eigen::SparseMatrix<cplx_type> & Ybus,
                         CplxVect & V,
                         Eigen::Ref<const CplxVect> Sbus,

--- a/src/core/powerflow_algorithm/GaussSeidelAlgo.hpp
+++ b/src/core/powerflow_algorithm/GaussSeidelAlgo.hpp
@@ -18,7 +18,7 @@ class LS2G_API GaussSeidelAlgo : public BaseAlgo
     public:
         GaussSeidelAlgo() noexcept :BaseAlgo(true) {};
 
-        virtual ~GaussSeidelAlgo() noexcept = default;
+        ~GaussSeidelAlgo() noexcept override = default;
 
         // todo  can be factorized
         Eigen::Ref<const Eigen::SparseMatrix<real_type> > get_J() const override {

--- a/src/core/powerflow_algorithm/GaussSeidelSynchAlgo.hpp
+++ b/src/core/powerflow_algorithm/GaussSeidelSynchAlgo.hpp
@@ -22,7 +22,7 @@ class LS2G_API GaussSeidelSynchAlgo final: public GaussSeidelAlgo
     public:
         GaussSeidelSynchAlgo() noexcept : GaussSeidelAlgo() {};
 
-        virtual ~GaussSeidelSynchAlgo() noexcept = default;
+        ~GaussSeidelSynchAlgo() noexcept override = default;
 
     protected:
         void one_iter(CplxVect & tmp_Sbus,

--- a/src/core/powerflow_algorithm/GaussSeidelSynchAlgo.hpp
+++ b/src/core/powerflow_algorithm/GaussSeidelSynchAlgo.hpp
@@ -29,7 +29,7 @@ class LS2G_API GaussSeidelSynchAlgo final: public GaussSeidelAlgo
                       const Eigen::SparseMatrix<cplx_type> & Ybus,
                       Eigen::Ref<const IntVect> pv,
                       Eigen::Ref<const IntVect> pq
-                      );
+                      ) override;
 
     private:
         // no copy allowed

--- a/src/core/powerflow_algorithm/NRAlgo.hpp
+++ b/src/core/powerflow_algorithm/NRAlgo.hpp
@@ -52,7 +52,7 @@ public:
         timer_scale_(0.),
         timer_mismatch_(0.) {}
 
-    virtual ~NRAlgo() noexcept = default;
+    ~NRAlgo() noexcept override = default;
 
     // ----- Jacobian accessor ---------------------------------------------------
 

--- a/src/core/powerflow_algorithm/NRAlgo.hpp
+++ b/src/core/powerflow_algorithm/NRAlgo.hpp
@@ -26,7 +26,7 @@ namespace ls2g {
  * not template parameters, so the same binary can switch strategy at run time.
  */
 template<class LinearSolver, class NRSystem>
-class NRAlgo : public BaseAlgo
+class NRAlgo final : public BaseAlgo
 {
 public:
     NRAlgo() noexcept :
@@ -61,7 +61,6 @@ public:
         return _system.J();
     }
 
-    virtual
     Eigen::SparseMatrix<real_type> get_J_python() const {
         Eigen::SparseMatrix<real_type> res = get_J();
         return res;

--- a/src/core/powerflow_algorithm/NRAlgo.hpp
+++ b/src/core/powerflow_algorithm/NRAlgo.hpp
@@ -56,7 +56,6 @@ public:
 
     // ----- Jacobian accessor ---------------------------------------------------
 
-    virtual
     Eigen::Ref<const Eigen::SparseMatrix<real_type>> get_J() const override {
         return _system.J();
     }
@@ -70,38 +69,37 @@ public:
     // bus_id -> Jacobian column of that bus' theta / vm / q unknown (-1 if none).
     // Only meaningful after a topology has been initialised (i.e. after at least
     // one compute_pf), same lifetime as get_J.
-    virtual IntVect get_theta_to_J_col_python() const override { return _to_intvect(_system.theta_to_J_col()); }
-    virtual IntVect get_vm_to_J_col_python()    const override { return _to_intvect(_system.vm_to_J_col()); }
-    virtual IntVect get_q_to_J_col_python()     const override { return _to_intvect(_system.q_to_J_col()); }
+    IntVect get_theta_to_J_col_python() const override { return _to_intvect(_system.theta_to_J_col()); }
+    IntVect get_vm_to_J_col_python()    const override { return _to_intvect(_system.vm_to_J_col()); }
+    IntVect get_q_to_J_col_python()     const override { return _to_intvect(_system.q_to_J_col()); }
 
     // ----- row (equation) -> bus-id converters (NR-only) -----------------------
     // bus_id -> Jacobian row of that bus' P / Q mismatch equation (-1 if none).
     // Same lifetime / semantics as the *_to_J_col converters above.
-    virtual IntVect get_p_to_J_row_python() const override { return _to_intvect(_system.p_to_J_row()); }
-    virtual IntVect get_q_to_J_row_python() const override { return _to_intvect(_system.q_to_J_row()); }
+    IntVect get_p_to_J_row_python() const override { return _to_intvect(_system.p_to_J_row()); }
+    IntVect get_q_to_J_row_python() const override { return _to_intvect(_system.q_to_J_row()); }
 
     // ----- compact (bus, row/col) registration pair lists (NR-only) ------------
     // Row/col counterpart of the *_to_J_col / *_to_J_row bus-keyed maps above,
     // but preserving every registration (see NRSystem::p_buses() etc.).
-    virtual IntVect get_p_buses_python()     const override { return _to_intvect(_system.p_buses()); }
-    virtual IntVect get_p_rows_python()      const override { return _to_intvect(_system.p_rows()); }
-    virtual IntVect get_q_buses_python()     const override { return _to_intvect(_system.q_buses()); }
-    virtual IntVect get_q_rows_python()      const override { return _to_intvect(_system.q_rows()); }
-    virtual IntVect get_theta_buses_python() const override { return _to_intvect(_system.theta_buses()); }
-    virtual IntVect get_theta_cols_python()  const override { return _to_intvect(_system.theta_cols()); }
-    virtual IntVect get_vm_buses_python()    const override { return _to_intvect(_system.vm_buses()); }
-    virtual IntVect get_vm_cols_python()     const override { return _to_intvect(_system.vm_cols()); }
+    IntVect get_p_buses_python()     const override { return _to_intvect(_system.p_buses()); }
+    IntVect get_p_rows_python()      const override { return _to_intvect(_system.p_rows()); }
+    IntVect get_q_buses_python()     const override { return _to_intvect(_system.q_buses()); }
+    IntVect get_q_rows_python()      const override { return _to_intvect(_system.q_rows()); }
+    IntVect get_theta_buses_python() const override { return _to_intvect(_system.theta_buses()); }
+    IntVect get_theta_cols_python()  const override { return _to_intvect(_system.theta_cols()); }
+    IntVect get_vm_buses_python()    const override { return _to_intvect(_system.vm_buses()); }
+    IntVect get_vm_cols_python()     const override { return _to_intvect(_system.vm_cols()); }
 
     // ----- VoltageControl (remote gen + SVC) converged results -----------------
-    virtual RealVect get_controller_q()       const override { return _system.controller_q(); }
-    virtual IntVect  get_controller_kind()    const override { return _system.controller_kind(); }
-    virtual IntVect  get_controller_elem_id() const override { return _system.controller_elem_id(); }
-    virtual int      get_slack_col()          const override { return _system.slack_col(); }
-    virtual real_type get_slack_absorbed()    const override { return _system.slack_absorbed(); }
+    RealVect get_controller_q()       const override { return _system.controller_q(); }
+    IntVect  get_controller_kind()    const override { return _system.controller_kind(); }
+    IntVect  get_controller_elem_id() const override { return _system.controller_elem_id(); }
+    int      get_slack_col()          const override { return _system.slack_col(); }
+    real_type get_slack_absorbed()    const override { return _system.slack_absorbed(); }
 
     // ----- timers --------------------------------------------------------------
 
-    virtual
     TimerJac get_timers_jacobian() const override
     {
         TimerJac res;
@@ -123,7 +121,6 @@ public:
 
     // ----- powerflow -----------------------------------------------------------
 
-    virtual
     bool compute_pf(const Eigen::SparseMatrix<cplx_type>& Ybus,
                     CplxVect& V,
                     Eigen::Ref<const CplxVect> Sbus,
@@ -135,11 +132,11 @@ public:
                     real_type tol
                     ) override;
 
-    virtual void reset() override;
+    void reset() override;
 
     // ----- bus masking ---------------------------------------------------------
-    virtual bool supports_bus_masking() const override { return true; }
-    virtual void set_masked_buses(const std::vector<int> & solver_bus_ids) override {
+    bool supports_bus_masking() const override { return true; }
+    void set_masked_buses(const std::vector<int> & solver_bus_ids) override {
         _system.set_masked_buses(solver_bus_ids);
     }
 
@@ -186,7 +183,7 @@ public:
 
     // ----- AlgoConfig serialization -------------------------------------------
 
-    virtual AlgoConfig get_config() const override {
+    AlgoConfig get_config() const override {
         AlgoConfig cfg;
         cfg.int_params  = { static_cast<int>(scaling_policy_->type()),
                             static_cast<int>(refactor_policy_),
@@ -201,7 +198,7 @@ public:
         return cfg;
     }
 
-    virtual void set_config(const AlgoConfig& cfg) override {
+    void set_config(const AlgoConfig& cfg) override {
         if (cfg.int_params.size()  < 4) throw std::runtime_error("NRAlgo::set_config: int_params must have at least 4 elements");
         if (cfg.real_params.size() < 6) throw std::runtime_error("NRAlgo::set_config: real_params must have at least 6 elements");
         max_dVa_         = static_cast<real_type>(cfg.real_params[0]);
@@ -243,7 +240,7 @@ public:
     // }
 
 protected:
-    virtual void reset_timer() override {
+    void reset_timer() override {
         BaseAlgo::reset_timer();
         timer_factor_     = 0.;
         timer_refactor_   = 0.;

--- a/src/core/powerflow_algorithm/NRSystem.hpp
+++ b/src/core/powerflow_algorithm/NRSystem.hpp
@@ -877,9 +877,9 @@ public:
 
     // ----- NR iteration primitives -----------------------------------------------
 
-    virtual RealVect   mismatch()                           const;
-    virtual void       apply_step(const RealVect& dx);
-    virtual real_type  mismatch_sq_norm_at(const RealVect& dx) const;
+    RealVect   mismatch()                           const;
+    void       apply_step(const RealVect& dx);
+    real_type  mismatch_sq_norm_at(const RealVect& dx) const;
 
     // ----- Housekeeping ----------------------------------------------------------
 

--- a/src/core/powerflow_algorithm/ScalingPolicies.hpp
+++ b/src/core/powerflow_algorithm/ScalingPolicies.hpp
@@ -51,8 +51,8 @@ template<class NRSystem>
 class LS2G_API NoScalingPolicy final : public ScalingPolicy<NRSystem>
 {
     public:
-        virtual ScalingPolicyType type() const final {return ScalingPolicyType::NoScaling;}
-        virtual real_type scale(const NRSystem& /*system*/, const RealVect & /*F*/) final
+        virtual ScalingPolicyType type() const override final {return ScalingPolicyType::NoScaling;}
+        virtual real_type scale(const NRSystem& /*system*/, const RealVect & /*F*/) override final
         {
             return 1.;
         }
@@ -63,8 +63,8 @@ template<class NRSystem>
 class LS2G_API MaxVoltageChangeScalingPolicy final : public ScalingPolicy<NRSystem>
 {
     public:
-        virtual ScalingPolicyType type() const final {return ScalingPolicyType::MaxVoltageChange;}
-        virtual real_type scale(const NRSystem& system, const RealVect & F) final
+        virtual ScalingPolicyType type() const override final {return ScalingPolicyType::MaxVoltageChange;}
+        virtual real_type scale(const NRSystem& system, const RealVect & F) override final
         {
             real_type alpha = static_cast<real_type>(1.0);
             // max_abs_dtheta / max_abs_dvm account for both the base block and any
@@ -96,9 +96,9 @@ template<class NRSystem>
 class LS2G_API LineSearchScalingPolicy final : public ScalingPolicy<NRSystem>
 {
     public:
-        virtual ScalingPolicyType type() const final {return ScalingPolicyType::LineSearch;}
+        virtual ScalingPolicyType type() const override final {return ScalingPolicyType::LineSearch;}
 
-        virtual real_type scale(const NRSystem& system, const RealVect & F) final
+        virtual real_type scale(const NRSystem& system, const RealVect & F) override final
         {
             // Current merit (||mismatch(x)||^2 before the step). By the time scale()
             // runs, F has already been overwritten in place by the linear solve
@@ -151,9 +151,9 @@ template<class NRSystem>
 class IwamotoScalingPolicy final : public ScalingPolicy<NRSystem>
 {
     public:
-        virtual ScalingPolicyType type() const final {return ScalingPolicyType::Iwamoto;}
+        virtual ScalingPolicyType type() const override final {return ScalingPolicyType::Iwamoto;}
 
-        virtual real_type scale(const NRSystem& system, const RealVect & F) final
+        virtual real_type scale(const NRSystem& system, const RealVect & F) override final
         {
             // g0 = ||mismatch(x)||^2 (current state, BEFORE the step) -- see the
             // identical note in LineSearchScalingPolicy::scale: F is already dx by

--- a/src/core/powerflow_algorithm/ScalingPolicies.hpp
+++ b/src/core/powerflow_algorithm/ScalingPolicies.hpp
@@ -51,8 +51,8 @@ template<class NRSystem>
 class LS2G_API NoScalingPolicy final : public ScalingPolicy<NRSystem>
 {
     public:
-        ScalingPolicyType type() const override final {return ScalingPolicyType::NoScaling;}
-        real_type scale(const NRSystem& /*system*/, const RealVect & /*F*/) override final
+        ScalingPolicyType type() const override {return ScalingPolicyType::NoScaling;}
+        real_type scale(const NRSystem& /*system*/, const RealVect & /*F*/) override
         {
             return 1.;
         }
@@ -63,8 +63,8 @@ template<class NRSystem>
 class LS2G_API MaxVoltageChangeScalingPolicy final : public ScalingPolicy<NRSystem>
 {
     public:
-        ScalingPolicyType type() const override final {return ScalingPolicyType::MaxVoltageChange;}
-        real_type scale(const NRSystem& system, const RealVect & F) override final
+        ScalingPolicyType type() const override {return ScalingPolicyType::MaxVoltageChange;}
+        real_type scale(const NRSystem& system, const RealVect & F) override
         {
             real_type alpha = static_cast<real_type>(1.0);
             // max_abs_dtheta / max_abs_dvm account for both the base block and any
@@ -96,9 +96,9 @@ template<class NRSystem>
 class LS2G_API LineSearchScalingPolicy final : public ScalingPolicy<NRSystem>
 {
     public:
-        ScalingPolicyType type() const override final {return ScalingPolicyType::LineSearch;}
+        ScalingPolicyType type() const override {return ScalingPolicyType::LineSearch;}
 
-        real_type scale(const NRSystem& system, const RealVect & F) override final
+        real_type scale(const NRSystem& system, const RealVect & F) override
         {
             // Current merit (||mismatch(x)||^2 before the step). By the time scale()
             // runs, F has already been overwritten in place by the linear solve
@@ -151,9 +151,9 @@ template<class NRSystem>
 class IwamotoScalingPolicy final : public ScalingPolicy<NRSystem>
 {
     public:
-        ScalingPolicyType type() const override final {return ScalingPolicyType::Iwamoto;}
+        ScalingPolicyType type() const override {return ScalingPolicyType::Iwamoto;}
 
-        real_type scale(const NRSystem& system, const RealVect & F) override final
+        real_type scale(const NRSystem& system, const RealVect & F) override
         {
             // g0 = ||mismatch(x)||^2 (current state, BEFORE the step) -- see the
             // identical note in LineSearchScalingPolicy::scale: F is already dx by

--- a/src/core/powerflow_algorithm/ScalingPolicies.hpp
+++ b/src/core/powerflow_algorithm/ScalingPolicies.hpp
@@ -51,8 +51,8 @@ template<class NRSystem>
 class LS2G_API NoScalingPolicy final : public ScalingPolicy<NRSystem>
 {
     public:
-        virtual ScalingPolicyType type() const override final {return ScalingPolicyType::NoScaling;}
-        virtual real_type scale(const NRSystem& /*system*/, const RealVect & /*F*/) override final
+        ScalingPolicyType type() const override final {return ScalingPolicyType::NoScaling;}
+        real_type scale(const NRSystem& /*system*/, const RealVect & /*F*/) override final
         {
             return 1.;
         }
@@ -63,8 +63,8 @@ template<class NRSystem>
 class LS2G_API MaxVoltageChangeScalingPolicy final : public ScalingPolicy<NRSystem>
 {
     public:
-        virtual ScalingPolicyType type() const override final {return ScalingPolicyType::MaxVoltageChange;}
-        virtual real_type scale(const NRSystem& system, const RealVect & F) override final
+        ScalingPolicyType type() const override final {return ScalingPolicyType::MaxVoltageChange;}
+        real_type scale(const NRSystem& system, const RealVect & F) override final
         {
             real_type alpha = static_cast<real_type>(1.0);
             // max_abs_dtheta / max_abs_dvm account for both the base block and any
@@ -96,9 +96,9 @@ template<class NRSystem>
 class LS2G_API LineSearchScalingPolicy final : public ScalingPolicy<NRSystem>
 {
     public:
-        virtual ScalingPolicyType type() const override final {return ScalingPolicyType::LineSearch;}
+        ScalingPolicyType type() const override final {return ScalingPolicyType::LineSearch;}
 
-        virtual real_type scale(const NRSystem& system, const RealVect & F) override final
+        real_type scale(const NRSystem& system, const RealVect & F) override final
         {
             // Current merit (||mismatch(x)||^2 before the step). By the time scale()
             // runs, F has already been overwritten in place by the linear solve
@@ -121,7 +121,7 @@ class LS2G_API LineSearchScalingPolicy final : public ScalingPolicy<NRSystem>
             return alpha;
         }
 
-    // virtual void update(const NRSystem& system, const RealVect & F) final {
+    // void update(const NRSystem& system, const RealVect & F) final {
     //     F_norm_sq_0_ = system.mismatch_sq_norm_at(RealVect::Zero(F.size()));
     // }
 
@@ -151,9 +151,9 @@ template<class NRSystem>
 class IwamotoScalingPolicy final : public ScalingPolicy<NRSystem>
 {
     public:
-        virtual ScalingPolicyType type() const override final {return ScalingPolicyType::Iwamoto;}
+        ScalingPolicyType type() const override final {return ScalingPolicyType::Iwamoto;}
 
-        virtual real_type scale(const NRSystem& system, const RealVect & F) override final
+        real_type scale(const NRSystem& system, const RealVect & F) override final
         {
             // g0 = ||mismatch(x)||^2 (current state, BEFORE the step) -- see the
             // identical note in LineSearchScalingPolicy::scale: F is already dx by
@@ -173,7 +173,7 @@ class IwamotoScalingPolicy final : public ScalingPolicy<NRSystem>
             return mu;
         }
 
-    // virtual void update(const NRSystem& system, const RealVect & F) final {
+    // void update(const NRSystem& system, const RealVect & F) final {
     //     g0_ = system.mismatch_sq_norm_at(RealVect::Zero(F.size()));
     //     g1_ = system.mismatch_sq_norm_at(F);
     // }


### PR DESCRIPTION
## Summary

Continues the "help the compiler generate better code" work from `n1_full_compute` (the Eigen-copy-elimination pass, the report-only clang-tidy job) with a final/override/const-correctness sweep, plus a couple of related, smaller wins found along the way.

- **`final` on leaf classes / `override` everywhere it was missing** in `element_container/` and `powerflow_algorithm/`+`batch_algorithm/`. Verified signature-by-signature (not just grepped) — this caught real gaps a first pass missed (declarations overriding a base virtual without even the `virtual` keyword) and one false lead (a method with no base declaration at all, where the fix was to drop `virtual`, not add `override`).
- **Dropped 4 vestigial `virtual` keywords** on methods that declare nothing a base class declares and have no overrider, including `NRSystem<Base,Rest...>::mismatch/apply_step/mismatch_sq_norm_at` — called only through a concrete `NRSystem` member (never a base pointer) in the hottest part of the Newton-Raphson loop, so the vtable indirection they were paying for was pure waste.
- **Const-correctness**: const-qualified read-only getters, switched several `Eigen::Ref<...>` setter parameters to `Eigen::Ref<const ...>`. Also caught a case that looked const-safe but wasn't (`get_slack_weights_solver` mutates `bus_slack_weight_` as a side effect consumed later by `set_p_slack` — left non-const).
- **Dropped `virtual` wherever `override`/`final` already implies it** (codebase-wide), which let `modernize-use-override` actually be enabled in the report-only clang-tidy job with low noise (was ~80% noise against the pre-existing style before this cleanup). Also surfaced 5 more genuine override gaps invisible to a `virtual`-keyword-based manual search.
- **CI/build**: `.clang-tidy` gains `modernize-use-override` and `misc-const-correctness` (report-only). `src/core/CMakeLists.txt` gains `-Wsuggest-override -Wnon-virtual-dtor` as real (build-breaking) warnings on `lightsim2grid_core` — both zero-warning clean as of this PR, so a future regression fails the build instead of waiting to be read in the advisory report.
- **`[[nodiscard]]`** on `LSGrid`'s public getters (154 of them). Scoped to `LSGrid.hpp` for this pass since its getters are non-virtual; the virtual-heavy hierarchies would need per-override-chain review, left as a follow-up. `noexcept` was evaluated and intentionally skipped for the same reason (a `noexcept` base virtual constrains every override).

## Test plan

- [x] Standalone C++ build (`cmake -S src/tests -B build -DCMAKE_EXPORT_COMPILE_COMMANDS=ON && cmake --build build`) after every commit: zero warnings, zero errors.
- [x] Full Catch2 suite (`ctest`): 43/43 passing after every commit.
- [x] `modernize-use-override` / `misc-const-correctness` / `-Wsuggest-override` / `-Wnon-virtual-dtor` all spot-checked directly with clang-tidy / GCC to confirm noise levels and zero regressions before enabling.
- [ ] Python extension build / pytest — not run in this environment (pybind11 not installed, no `setup.py` at the standalone-test layer); the `Eigen::Ref<const ...>` signature changes are ABI-visible to the bindings but follow an idiom (`update_topo`) already proven to bind cleanly with pybind11 in this codebase.
