### PR TITLE
Add Levenberg-Marquardt Newton-Raphson as an out-of-tree example plugin

### DIFF
--- a/examples/lm_algorithm/CMakeLists.txt
+++ b/examples/lm_algorithm/CMakeLists.txt
@@ -1,0 +1,99 @@
+cmake_minimum_required(VERSION 3.15)
+project(lm_algorithm CXX)
+set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+# -----------------------------------------------------------------------
+# Strategy 1: find via installed CMake config
+#   pip install lightsim2grid  →  lightsim2grid.get_cmake_dir()
+#   cmake --install             →  _install/lib/cmake/lightsim2grid_core/
+# Pass -DLIGHTSIM2GRID_CMAKE_DIR=<path> to hint the location, or rely on
+# CMAKE_PREFIX_PATH.
+# -----------------------------------------------------------------------
+find_package(lightsim2grid_core CONFIG QUIET
+    HINTS "${LIGHTSIM2GRID_CMAKE_DIR}")
+
+# -----------------------------------------------------------------------
+# Strategy 2: fall back to source tree (in-repo development builds).
+# -----------------------------------------------------------------------
+if(NOT lightsim2grid_core_FOUND)
+    if(NOT DEFINED LIGHTSIM2GRID_SRC)
+        set(LIGHTSIM2GRID_SRC "${CMAKE_CURRENT_SOURCE_DIR}/../../src/core")
+    endif()
+    if(NOT DEFINED Eigen3_INCLUDE)
+        set(Eigen3_INCLUDE "${CMAKE_CURRENT_SOURCE_DIR}/../../eigen")
+    endif()
+    if(NOT EXISTS "${LIGHTSIM2GRID_SRC}/AlgorithmRegistry.hpp")
+        message(FATAL_ERROR
+            "lightsim2grid_core not found.\n"
+            "Either install lightsim2grid and pass:\n"
+            "  -DLIGHTSIM2GRID_CMAKE_DIR=<cmake-dir>\n"
+            "(obtain the path via: python -c \"import lightsim2grid; print(lightsim2grid.get_cmake_dir())\")\n"
+            "or pass -DLIGHTSIM2GRID_SRC=<path/to/src/core> for a source-tree build.")
+    endif()
+    add_library(lightsim2grid_core_iface INTERFACE)
+    target_include_directories(lightsim2grid_core_iface INTERFACE
+        "${LIGHTSIM2GRID_SRC}"
+        "${Eigen3_INCLUDE}"
+    )
+    add_library(lightsim2grid::core ALIAS lightsim2grid_core_iface)
+    message(STATUS "lightsim2grid_core: using source tree at ${LIGHTSIM2GRID_SRC}")
+endif()
+
+# The plugin is a MODULE (loadable at runtime via dlopen/LoadLibrary).
+add_library(lm_algorithm MODULE LMNRAlgo_plugin.cpp)
+target_link_libraries(lm_algorithm PRIVATE lightsim2grid::core)
+
+# Match lightsim2grid_core's -march=native / -O3 -- see docs/solver_plugin.rst
+# and examples/cmake/MatchLightsim2gridBuildFlags.cmake for why this matters
+# (skipping it is a real, silent heap-corruption risk, not just a perf loss).
+include("${CMAKE_CURRENT_SOURCE_DIR}/../cmake/MatchLightsim2gridBuildFlags.cmake")
+ls2g_match_core_build_flags(lm_algorithm)
+
+# -----------------------------------------------------------------------
+# KLUSolver.hpp (pulled in transitively via Solvers.hpp) needs SuiteSparse's
+# own headers (cs.h, klu.h, amd.h, colamd.h, btf.h, SuiteSparse_config.h) to
+# parse the KLULinearSolver class declaration. Unlike
+# examples/dist_slack_algorithm (which reuses an existing `extern template`
+# NRAlgo<..., KLULinearSolver, ...> instantiation and links straight against
+# it), this plugin instantiates its own fresh
+# LMNRAlgo<LinearSolverPolicy<KLULinearSolver>, ...> / NRSystem<...,
+# DiagonalEntry> from headers -- but LinearSolverPolicy<KLULinearSolver> is a
+# thin counting/timing wrapper: its methods just forward into
+# KLULinearSolver's own analyze/factorize/refactorize/solve, which remain
+# ordinary, already-compiled-into-core symbols. So we still only need KLU's
+# *headers* here, never its implementation. Neither an installed
+# lightsim2grid_core CMake package nor a plain source-tree checkout exposes
+# those on its public include path (a private implementation detail of the
+# core .so), so point at the SuiteSparse submodule directly, header-only, as
+# a repo-relative fallback.
+# -----------------------------------------------------------------------
+if(NOT DEFINED SUITESPARSE_SRC)
+    set(SUITESPARSE_SRC "${CMAKE_CURRENT_SOURCE_DIR}/../../SuiteSparse")
+endif()
+if(EXISTS "${SUITESPARSE_SRC}/KLU/Include/klu.h")
+    target_include_directories(lm_algorithm PRIVATE
+        "${SUITESPARSE_SRC}/KLU/Include"
+        "${SUITESPARSE_SRC}/AMD/Include"
+        "${SUITESPARSE_SRC}/COLAMD/Include"
+        "${SUITESPARSE_SRC}/BTF/Include"
+        "${SUITESPARSE_SRC}/SuiteSparse_config"
+        "${SUITESPARSE_SRC}/CXSparse/Include"
+    )
+endif()
+
+if(WIN32)
+    # find_package provides the import lib via the IMPORTED target — nothing extra needed.
+elseif(UNIX AND NOT APPLE)
+    if(NOT lightsim2grid_core_FOUND)
+        # Source-tree mode: no shared library to link against.
+        # Symbols are resolved from the already-loaded lightsim2grid_cpp.so at runtime.
+        target_link_options(lm_algorithm PRIVATE -Wl,--allow-shlib-undefined)
+    endif()
+    set_target_properties(lm_algorithm PROPERTIES PREFIX "lib" SUFFIX ".so")
+elseif(APPLE)
+    if(NOT lightsim2grid_core_FOUND)
+        target_link_options(lm_algorithm PRIVATE -undefined dynamic_lookup)
+    endif()
+    set_target_properties(lm_algorithm PROPERTIES PREFIX "lib" SUFFIX ".so")
+endif()

--- a/examples/lm_algorithm/DiagonalDamping.hpp
+++ b/examples/lm_algorithm/DiagonalDamping.hpp
@@ -1,0 +1,94 @@
+// Copyright (c) 2026
+// Experimental plugin, not part of the lightsim2grid core distribution.
+//
+// DiagonalEntry: a minimal NRSystem extension that reserves one Jacobian
+// feature slot per existing unknown column (i, i), so a diagonal load can
+// later be added to J without changing its sparsity pattern -- the standard
+// trick behind Levenberg-Marquardt / Tikhonov-regularized Newton: solving
+// (J + lambda*D) dx = -F instead of J dx = -F to regularize an ill-conditioned
+// or near-singular Newton direction (as opposed to Iwamoto/MaxVoltageChange,
+// which only ever rescale the *same*, already-bad, direction).
+//
+// DiagonalEntry claims no rows/cols of its own (register_in is a no-op
+// besides remembering the ledger) and its fill_feature_values is a
+// deliberate no-op: the damping value is never written through the normal,
+// once-per-outer-NR-iteration component protocol path. It is written
+// directly, per LM trial, via NRSystem::update_trailing_feature_values (the
+// small, generic core addition this example relies on) -- see LMNRAlgo.hpp
+// for how. This keeps every LM-specific concept (lambda, accept/reject, the
+// Levenberg-vs-Marquardt-scaled delta choice) out of core entirely; core
+// only knows "some extension reserved n trailing feature slots that can be
+// updated fast."
+//
+// Must be the LAST extension in the NRSystem<Base, Rest...> pack: its n
+// reserved feature handles are exactly the trailing block of NRSystem's
+// internal `sink_`/`feature_pos_`, which is what lets
+// update_trailing_feature_values locate them with nothing more than a count
+// (see with_diagonal_entry below, which enforces this by construction).
+
+#ifndef LM_DIAGONAL_DAMPING_H
+#define LM_DIAGONAL_DAMPING_H
+
+#include <powerflow_algorithm/NRSystem.hpp>
+
+namespace ls2g {
+
+class DiagonalEntry
+{
+public:
+    void update_state(
+        const Base                       * /*nr_system_base_ptr*/,
+        const LSGrid                     * /*lsgrid_ptr*/,
+        const EigenRefConstCplxSpMat     & /*Ybus*/,
+        const Eigen::Ref<const CplxVect> & /*Sbus*/,
+        const Eigen::Ref<const RealVect> & /*slack_weights*/) {}
+
+    void init_topology(
+        const Eigen::Ref<const IntVect>  & /*slack_ids*/,
+        const Eigen::Ref<const RealVect> & /*slack_weights*/,
+        const Eigen::Ref<const IntVect>  & /*pv*/,
+        const Eigen::Ref<const IntVect>  & /*pq*/) {}
+
+    // Claims no rows/cols of its own -- just remembers the ledger so
+    // declare_feature_entries (called strictly later, from build_J_sparsity,
+    // after every component's register_in has run) can read its final size.
+    void register_in(NRLedger& ledger) { ledger_ptr_ = &ledger; }
+
+    // One feature slot per EXISTING unknown column (i, i). A pure numerical
+    // regularization term, not tied to any bus/physical quantity -- it needs
+    // nothing beyond the final unknown count.
+    void declare_feature_entries(FeatureSink& sink) {
+        const int n = static_cast<int>(ledger_ptr_->size());
+        for (int i = 0; i < n; ++i) sink.add(i, i);
+    }
+
+    // No-op on purpose: see the file header comment. Damping values are
+    // written directly by NRSystem::update_trailing_feature_values, not
+    // through this once-per-outer-iteration path.
+    void fill_feature_values(FeatureWriter& /*writer*/, const Eigen::Ref<const RealVect>& /*Va*/) const {}
+
+    void adjust_mismatch(const Eigen::Ref<const CplxVect>& /*V_t*/,
+                         const Eigen::Ref<const RealVect>& /*dx*/,
+                         Eigen::Ref<CplxVect> /*mis*/) const {}
+    void fill_custom_rows(Eigen::Ref<RealVect> /*res*/,
+                          const Eigen::Ref<const RealVect>& /*Va*/,
+                          const Eigen::Ref<const RealVect>& /*Vm*/,
+                          const Eigen::Ref<const RealVect>& /*dx*/) const {}
+    void apply_step(const Eigen::Ref<const RealVect>& /*dx*/) {}
+
+    void clear() { ledger_ptr_ = nullptr; }
+
+private:
+    const NRLedger* ledger_ptr_ = nullptr;
+};
+
+// ---- Injects DiagonalEntry as the LAST extension of an existing NRSystem<Base, Rest...> ----
+template <class T> struct with_diagonal_entry;
+template <class... Rest>
+struct with_diagonal_entry<NRSystem<Base, Rest...>> {
+    using type = NRSystem<Base, Rest..., DiagonalEntry>;
+};
+
+} // namespace ls2g
+
+#endif // LM_DIAGONAL_DAMPING_H

--- a/examples/lm_algorithm/LMNRAlgo.hpp
+++ b/examples/lm_algorithm/LMNRAlgo.hpp
@@ -1,0 +1,232 @@
+// Copyright (c) 2026
+// Experimental plugin, not part of the lightsim2grid core distribution.
+//
+// LMNRAlgo: Newton-Raphson with Levenberg-Marquardt diagonal damping,
+// (J + lambda*D) dx = -F instead of J dx = -F, lambda adapted by an
+// accept/reject loop on the actual (nonlinear) mismatch reduction of each
+// trial step.
+//
+// Motivation: on some real grids, clusters that are high-resistance,
+// heavily loaded and short of local generation make the local Jacobian
+// sub-block ill-conditioned/near-singular. Plain NR can diverge there, and
+// so can the Iwamoto optimal multiplier (ScalingPolicyType::Iwamoto) or the
+// MaxVoltageChange clamp (ScalingPolicyType::MaxVoltageChange): both of
+// those only ever rescale the *same* Newton direction J^-1 F, which is
+// already the problem when J itself is ill-conditioned. LM instead
+// regularizes the direction, by damping J's diagonal before solving.
+//
+// This is deliberately a SIBLING of NRAlgo, not built on top of it: the
+// accept/reject inner loop (potentially several factorize+solve+mismatch-eval
+// cycles per outer NR iteration) does not fit NRAlgo's single
+// solve-per-iteration control flow, nor its RefactorPolicy (which assumes J's
+// numeric values are stable enough across iterations to reuse a
+// factorization -- false here, since lambda legitimately changes) or
+// ScalingPolicy (whose scale() hook only rescales an already-solved Newton
+// step post-hoc; it cannot touch the matrix being solved).
+//
+// The diagonal damping itself is implemented as a NRSystem extension
+// (DiagonalEntry, see DiagonalDamping.hpp) plus one small, generic addition
+// to core (NRSystem::update_trailing_feature_values) that directly pokes the
+// n reserved diagonal J_.valuePtr() positions -- bypassing
+// fill_internal_variables()/fill_J() entirely, so a rejected trial costs
+// only a numeric refactor + solve + (allocation-free) mismatch evaluation,
+// not a full O(nnz) Jacobian rebuild.
+//
+// Build/load, once compiled (see CMakeLists.txt in this directory):
+//   import lightsim2grid
+//   lightsim2grid.load_algorithm_plugin("examples/lm_algorithm/build/liblm_algorithm.so")
+//   grid.change_algorithm("NR_LM_KLU")
+
+#ifndef LM_NR_ALGO_H
+#define LM_NR_ALGO_H
+
+#include <Solvers.hpp>
+#include <powerflow_algorithm/BaseAlgo.hpp>
+#include <powerflow_algorithm/NRSystem.hpp>
+#include <linear_solvers/LinearSolverStats.hpp>
+
+#include "DiagonalDamping.hpp"
+
+namespace ls2g {
+
+template<class LinearSolver, class NRSystemT>
+class LMNRAlgo final : public BaseAlgo
+{
+public:
+    using DampedSystem = typename with_diagonal_entry<NRSystemT>::type;
+
+    LMNRAlgo() noexcept :
+        BaseAlgo(true),
+        need_factorize_(true),
+        lambda_(static_cast<real_type>(0.)),
+        lambda_init_(static_cast<real_type>(1e-6)),
+        nu_(static_cast<real_type>(2.)),
+        lambda_min_(static_cast<real_type>(0.)),
+        lambda_max_(static_cast<real_type>(1e8)),
+        lambda_eps_(static_cast<real_type>(1e-12)),
+        max_trials_(8),
+        timer_dSbus_(0.),
+        timer_fillJ_(0.) {}
+
+    ~LMNRAlgo() noexcept override = default;
+
+    // The underlying system still carries Hvdc + VoltageControl (same
+    // reasoning as NRAlgo: both SingleSlackNRSystem and MultiSlackNRSystem
+    // include them unconditionally).
+    static constexpr bool SUPPORTS_HVDC_DROOP = true;
+    bool supports_hvdc_droop() const noexcept override { return SUPPORTS_HVDC_DROOP; }
+    static constexpr bool SUPPORTS_REMOTE_VOLTAGE_CONTROL = true;
+    bool supports_remote_voltage_control() const noexcept override { return SUPPORTS_REMOTE_VOLTAGE_CONTROL; }
+
+    // ----- Jacobian / VoltageControl introspection: forward to _system, same as NRAlgo -----
+    Eigen::Ref<const Eigen::SparseMatrix<real_type>> get_J() const override { return _system.J(); }
+    IntVect get_theta_to_J_col_python() const override { return _to_intvect(_system.theta_to_J_col()); }
+    IntVect get_vm_to_J_col_python()    const override { return _to_intvect(_system.vm_to_J_col()); }
+    IntVect get_q_to_J_col_python()     const override { return _to_intvect(_system.q_to_J_col()); }
+    IntVect get_p_to_J_row_python()     const override { return _to_intvect(_system.p_to_J_row()); }
+    IntVect get_q_to_J_row_python()     const override { return _to_intvect(_system.q_to_J_row()); }
+    IntVect get_p_buses_python()        const override { return _to_intvect(_system.p_buses()); }
+    IntVect get_p_rows_python()         const override { return _to_intvect(_system.p_rows()); }
+    IntVect get_q_buses_python()        const override { return _to_intvect(_system.q_buses()); }
+    IntVect get_q_rows_python()         const override { return _to_intvect(_system.q_rows()); }
+    IntVect get_theta_buses_python()    const override { return _to_intvect(_system.theta_buses()); }
+    IntVect get_theta_cols_python()     const override { return _to_intvect(_system.theta_cols()); }
+    IntVect get_vm_buses_python()       const override { return _to_intvect(_system.vm_buses()); }
+    IntVect get_vm_cols_python()        const override { return _to_intvect(_system.vm_cols()); }
+    RealVect get_controller_q()         const override { return _system.controller_q(); }
+    IntVect  get_controller_kind()      const override { return _system.controller_kind(); }
+    IntVect  get_controller_elem_id()   const override { return _system.controller_elem_id(); }
+    IntVect  get_controller_q_col()     const override { return _system.controller_q_col(); }
+    int      get_slack_col()            const override { return _system.slack_col(); }
+    real_type get_slack_absorbed()      const override { return _system.slack_absorbed(); }
+
+    TimerJac get_timers_jacobian() const override
+    {
+        const LinearSolverStats lsstats = detail::get_stats_impl(_linear_solver, 0);
+        TimerJac res;
+        res.timer_Fx_         = timer_Fx_;
+        res.timer_solve_      = lsstats.timer_solve_;
+        res.timer_factor_     = lsstats.timer_factor_;
+        res.timer_refactor_   = lsstats.timer_refactor_;
+        res.timer_initialize_ = lsstats.timer_initialize_;
+        res.timer_check_      = timer_check_;
+        res.timer_dSbus_      = timer_dSbus_;
+        res.timer_fillJ_      = timer_fillJ_;
+        res.timer_total_nr_   = timer_total_nr_;
+        return res;
+    }
+    LinearSolverStats get_linear_solver_stats() const override {
+        return detail::get_stats_impl(_linear_solver, 0);
+    }
+
+    bool supports_bus_masking() const override { return true; }
+    void set_masked_buses(const std::vector<int>& solver_bus_ids) override {
+        _system.set_masked_buses(solver_bus_ids);
+    }
+
+    // ----- powerflow -------------------------------------------------------------
+
+    bool compute_pf(
+        const EigenRefConstCplxSpMat     & Ybus,
+        const Eigen::Ref<const CplxVect> & V,
+        const Eigen::Ref<const CplxVect> & Sbus,
+        const Eigen::Ref<const IntVect>  & slack_ids,
+        const Eigen::Ref<const RealVect> & slack_weights,
+        const Eigen::Ref<const IntVect>  & pv,
+        const Eigen::Ref<const IntVect>  & pq,
+        int                              max_iter,
+        real_type                        tol
+    ) override;
+
+    void reset() override {
+        BaseAlgo::reset();
+        _system.clear_jacobian();
+        need_factorize_ = true;
+        n_ = -1;
+        ErrorType reset_status = _linear_solver.reset();
+        if (reset_status != ErrorType::NoError) err_ = reset_status;
+    }
+
+    // ----- Levenberg-Marquardt tunables -------------------------------------------
+    real_type get_lambda_init() const { return lambda_init_; }
+    void      set_lambda_init(real_type v) { lambda_init_ = v; }
+    real_type get_nu()          const { return nu_; }
+    void      set_nu(real_type v) { nu_ = v; }
+    real_type get_lambda_min()  const { return lambda_min_; }
+    void      set_lambda_min(real_type v) { lambda_min_ = v; }
+    real_type get_lambda_max()  const { return lambda_max_; }
+    void      set_lambda_max(real_type v) { lambda_max_ = v; }
+    real_type get_lambda_eps()  const { return lambda_eps_; }
+    void      set_lambda_eps(real_type v) { lambda_eps_ = v; }
+    int       get_max_trials()  const { return max_trials_; }
+    void      set_max_trials(int v) { max_trials_ = v; }
+    // Value lambda was left at when the last compute_pf call returned
+    // (informational only -- inspect it to see how hard the last solve was).
+    real_type get_last_lambda() const { return lambda_; }
+
+    // int_params  = [max_trials_]
+    // real_params = [lambda_init_, nu_, lambda_min_, lambda_max_, lambda_eps_]
+    AlgoConfig get_config() const override {
+        AlgoConfig cfg;
+        cfg.int_params  = { max_trials_ };
+        cfg.real_params = { static_cast<double>(lambda_init_),
+                            static_cast<double>(nu_),
+                            static_cast<double>(lambda_min_),
+                            static_cast<double>(lambda_max_),
+                            static_cast<double>(lambda_eps_) };
+        return cfg;
+    }
+    void set_config(const AlgoConfig& cfg) override {
+        if (cfg.int_params.size()  < 1) throw std::runtime_error("LMNRAlgo::set_config: int_params must have at least 1 element");
+        if (cfg.real_params.size() < 5) throw std::runtime_error("LMNRAlgo::set_config: real_params must have at least 5 elements");
+        max_trials_ = cfg.int_params[0];
+        lambda_init_ = static_cast<real_type>(cfg.real_params[0]);
+        nu_          = static_cast<real_type>(cfg.real_params[1]);
+        lambda_min_  = static_cast<real_type>(cfg.real_params[2]);
+        lambda_max_  = static_cast<real_type>(cfg.real_params[3]);
+        lambda_eps_  = static_cast<real_type>(cfg.real_params[4]);
+    }
+
+protected:
+    void reset_timer() override {
+        BaseAlgo::reset_timer();
+        detail::reset_stats_timers_impl(_linear_solver, 0);
+        timer_dSbus_ = 0.;
+        timer_fillJ_ = 0.;
+        _system.reset_timers();
+    }
+
+private:
+    static IntVect _to_intvect(const std::vector<int>& v) {
+        return Eigen::Map<const IntVect>(v.data(), static_cast<Eigen::Index>(v.size()));
+    }
+
+    LinearSolver  _linear_solver;
+    DampedSystem  _system;
+
+    bool need_factorize_;
+
+    // Levenberg-Marquardt state/tunables
+    real_type lambda_;       // current damping factor, persists across outer NR iterations
+    real_type lambda_init_;  // value lambda_ is reset to at the start of each compute_pf call
+    real_type nu_;           // growth factor on rejection
+    real_type lambda_min_;   // floor applied when easing off after an accepted step
+    real_type lambda_max_;   // ceiling
+    real_type lambda_eps_;   // additive floor on rejection, so lambda_==0 is not a fixed point
+    int       max_trials_;   // per outer-iteration cap on reject-and-retry
+
+    double timer_dSbus_;
+    double timer_fillJ_;
+
+    // No copy
+    LMNRAlgo(const LMNRAlgo&) = delete;
+    LMNRAlgo(LMNRAlgo&&) = delete;
+    LMNRAlgo& operator=(LMNRAlgo&&) = delete;
+    LMNRAlgo& operator=(const LMNRAlgo&) = delete;
+};
+
+#include "LMNRAlgo.tpp"
+
+} // namespace ls2g
+
+#endif // LM_NR_ALGO_H

--- a/examples/lm_algorithm/LMNRAlgo.tpp
+++ b/examples/lm_algorithm/LMNRAlgo.tpp
@@ -1,0 +1,144 @@
+// Copyright (c) 2026
+// Experimental plugin, not part of the lightsim2grid core distribution.
+
+template<class LinearSolver, class NRSystemT>
+bool LMNRAlgo<LinearSolver, NRSystemT>::compute_pf(
+        const EigenRefConstCplxSpMat     & Ybus,
+        const Eigen::Ref<const CplxVect> & V,
+        const Eigen::Ref<const CplxVect> & Sbus,
+        const Eigen::Ref<const IntVect>  & slack_ids,
+        const Eigen::Ref<const RealVect> & slack_weights,
+        const Eigen::Ref<const IntVect>  & pv,
+        const Eigen::Ref<const IntVect>  & pq,
+        int                              max_iter,
+        real_type                        tol)
+{
+    if (!is_linear_solver_valid()) return false;
+
+    reset_timer();
+    err_ = ErrorType::NoError;
+    auto timer = CustTimer();
+
+    // Determine whether topology rebuild is required (same logic as NRAlgo).
+    const bool need_rebuild = (
+        need_factorize_ ||
+        _solver_control.need_reset_solver() ||
+        _solver_control.has_dimension_changed() ||
+        _solver_control.has_slack_participate_changed() ||
+        _solver_control.ybus_change_sparsity_pattern() ||
+        _solver_control.has_ybus_some_coeffs_zero() ||
+        _solver_control.need_recompute_ybus() ||
+        _solver_control.has_pv_changed() ||
+        _solver_control.has_pq_changed()
+    );
+
+    if (need_rebuild) {
+        ErrorType rs = _linear_solver.reset();
+        if (rs != ErrorType::NoError) err_ = rs;
+    }
+    if (!((err_ == ErrorType::NotInitError) || (err_ == ErrorType::NoError))) {
+        timer_total_nr_ += timer.duration();
+        return false;
+    }
+
+    _system.update_state(BaseAlgo::lsgrid_ptr_, Ybus, V, Sbus, slack_weights);
+    if (need_rebuild) _system.init_topology(slack_ids, slack_weights, pv, pq);
+
+    bool need_init = need_rebuild;
+    if (need_rebuild) {
+        _system.build_J_sparsity();
+        n_ = static_cast<int>(_system.J().cols());
+    }
+
+    RealVect F = _system.mismatch();
+    bool converged = _check_for_convergence(F, tol);
+    nr_iter_ = 0;
+    bool res = true;
+    lambda_ = lambda_init_;
+
+    while ((!converged) && (nr_iter_ < max_iter)) {
+        ++nr_iter_;
+
+        // Baseline (undamped) Jacobian for this outer iteration, once -- LM
+        // always rebuilds it fresh (lambda_ changes every outer iteration,
+        // so there is no stable-across-iterations J to reuse the way
+        // NRAlgo's RefactorPolicy does).
+        _system.fill_internal_variables();
+        _system.fill_J();
+
+        if (need_init) {
+            err_ = _linear_solver.analyze(_system.J());
+            if (err_ == ErrorType::NoError) err_ = _linear_solver.factorize(_system.J());
+            need_init = false;
+            need_factorize_ = false;
+        } else {
+            err_ = _linear_solver.refactorize(_system.J());
+        }
+        if (err_ != ErrorType::NoError) { res = false; break; }
+
+        const real_type F_sq = F.squaredNorm();
+        real_type lambda_applied = static_cast<real_type>(0.);  // matches the just-built undamped baseline
+        bool accepted = false;
+        int trial = 0;
+        RealVect dx;
+
+        while (!accepted && trial < max_trials_) {
+            ++trial;
+
+            const real_type delta = lambda_ - lambda_applied;
+            if (delta != static_cast<real_type>(0.)) {
+                // Fast path: only the n diagonal positions move, not the
+                // whole Jacobian -- see NRSystem::update_trailing_feature_values.
+                _system.update_trailing_feature_values(n_, RealVect::Constant(n_, delta));
+                lambda_applied = lambda_;
+                err_ = _linear_solver.refactorize(_system.J());
+                if (err_ != ErrorType::NoError) break;
+            }
+
+            dx = F;  // solve overwrites in place (mismatch, negated convention)
+            err_ = _linear_solver.solve(dx);
+            if (err_ != ErrorType::NoError) break;
+
+            // Evaluate the TRUE nonlinear residual at the trial step without
+            // mutating _system's V/Va/Vm -- only commit (apply_step) once accepted.
+            const real_type trial_sq = _system.mismatch_sq_norm_at(dx);
+
+            if (trial_sq < F_sq) {
+                _system.apply_step(dx);
+                accepted = true;
+                lambda_ = std::max(lambda_ / nu_, lambda_min_);
+            } else {
+                lambda_ = std::min(lambda_ * nu_ + lambda_eps_, lambda_max_);
+            }
+        }
+        if (err_ != ErrorType::NoError) { res = false; break; }
+        if (!accepted) {
+            // Exhausted max_trials_ without finding a step that reduces the
+            // mismatch, even at lambda_max_: treat like NRAlgo's "linear
+            // solver failed" bailout.
+            err_ = ErrorType::SingularMatrix;
+            res = false;
+            break;
+        }
+
+        F = _system.mismatch();
+        if (!F.allFinite()) { err_ = ErrorType::InifiniteValue; res = false; break; }
+        converged = _check_for_convergence(F, tol);
+    }
+
+    if (!converged && res) {
+        if (err_ == ErrorType::NoError) err_ = ErrorType::TooManyIterations;
+        res = false;
+    }
+
+    V_  = _system.V();
+    Vm_ = _system.Vm();
+    Va_ = _system.Va();
+
+    timer_dSbus_ += _system.timer_dSbus();
+    timer_fillJ_ += _system.timer_fillJ();
+    _system.reset_timers();
+    timer_total_nr_ += timer.duration();
+
+    return res;
+}

--- a/examples/lm_algorithm/LMNRAlgo_plugin.cpp
+++ b/examples/lm_algorithm/LMNRAlgo_plugin.cpp
@@ -1,0 +1,42 @@
+// LMNRAlgo plugin registration.
+//
+// Registers two names with the C++ AlgorithmRegistry at dlopen() time (via a
+// static AlgorithmRegistrar in an anonymous namespace -- same mechanism as
+// examples/dist_slack_algorithm/NRAlgoDistSlack_plugin.cpp and
+// examples/external_algorithm/DummyExternalAlgo.cpp):
+//   "NR_LM_SparseLU" -> LMNRAlgo<LinearSolverPolicy<SparseLULinearSolver>, SingleSlackNRSystem>
+//   "NR_LM_KLU"      -> LMNRAlgo<LinearSolverPolicy<KLULinearSolver>, SingleSlackNRSystem>  (only if KLU is available)
+//
+// Single-slack only for this first cut; LMNRAlgo is generic over its
+// NRSystem template parameter, so registering MultiSlackNRSystem variants
+// later is a one-line addition.
+//
+// Build (after pip install lightsim2grid, or from a source-tree checkout):
+//   LS2G_CMAKE=$(python -c "import lightsim2grid; print(lightsim2grid.get_cmake_dir())")
+//   cmake -S examples/lm_algorithm -B examples/lm_algorithm/build -DLIGHTSIM2GRID_CMAKE_DIR="$LS2G_CMAKE"
+//   cmake --build examples/lm_algorithm/build
+//
+// Python usage:
+//   import lightsim2grid
+//   lightsim2grid.load_algorithm_plugin("examples/lm_algorithm/build/liblm_algorithm.so")
+//   grid.change_algorithm("NR_LM_KLU")
+
+#include <AlgorithmRegistry.hpp>
+
+#include "LMNRAlgo.hpp"
+
+namespace {
+    ls2g::AlgorithmRegistrar _lm_sparselu_registrar(
+        "NR_LM_SparseLU",
+        []{ return std::unique_ptr<ls2g::BaseAlgo>(
+            new ls2g::LMNRAlgo<ls2g::LinearSolverPolicy<ls2g::SparseLULinearSolver>, ls2g::SingleSlackNRSystem>()); }
+    );
+
+#ifdef KLU_SOLVER_AVAILABLE
+    ls2g::AlgorithmRegistrar _lm_klu_registrar(
+        "NR_LM_KLU",
+        []{ return std::unique_ptr<ls2g::BaseAlgo>(
+            new ls2g::LMNRAlgo<ls2g::LinearSolverPolicy<ls2g::KLULinearSolver>, ls2g::SingleSlackNRSystem>()); }
+    );
+#endif
+}

--- a/examples/lm_algorithm/test_plugin.py
+++ b/examples/lm_algorithm/test_plugin.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+"""Smoke-test for the LMNRAlgo (Levenberg-Marquardt Newton-Raphson) plugin.
+
+Build the plugin first:
+    cd examples/lm_algorithm
+    mkdir build && cd build
+    cmake ..
+    make  (or: cmake --build . --config Release on Windows)
+
+The plugin's CMakeLists.txt automatically matches whatever -march=native /
+-O3 the installed lightsim2grid_core was built with (see
+examples/cmake/MatchLightsim2gridBuildFlags.cmake and
+docs/solver_plugin.rst) -- this is required, not just a performance nicety:
+lightsim2grid_core and this plugin are separate shared libraries, and a
+mismatched -march=native changes Eigen's alignment assumptions, so an Eigen
+object allocated in one and freed in the other silently corrupts the heap.
+Nothing to do here unless you're hand-rolling your own build system instead
+of the provided CMakeLists.txt.
+
+Then run:
+    python test_plugin.py
+
+This only checks that the plugin loads and registers correctly (same scope
+as examples/external_algorithm/test_plugin.py and
+lightsim2grid/tests/test_solver_registry.py::TestPluginLoading) -- it does
+NOT run a real power flow (that needs a fully configured grid: buses, lines,
+loads, generators). To actually exercise the Levenberg-Marquardt iteration on
+a real case, build a LightSimBackend on a grid2op environment and call
+grid._grid.change_algorithm("NR_LM_KLU") (or "NR_LM_SparseLU") before
+runpf().
+"""
+import platform
+import pathlib
+
+import lightsim2grid
+from lightsim2grid.lightsim2grid_cpp import LSGrid, AlgorithmType
+
+
+def find_plugin():
+    build = pathlib.Path(__file__).parent / "build"
+    if platform.system() == "Windows":
+        candidates = [
+            build / "Release" / "lm_algorithm.dll",
+            build / "lm_algorithm.dll",
+        ]
+    else:
+        candidates = [build / "liblm_algorithm.so"]
+    for p in candidates:
+        if p.exists():
+            return str(p)
+    raise FileNotFoundError(
+        f"Plugin not found (tried {[str(c) for c in candidates]}). "
+        "Build it first (see CMakeLists.txt)."
+    )
+
+
+def _make_grid():
+    """Minimal LSGrid, enough to register/switch solvers (not to run a real pf)."""
+    gm = LSGrid()
+    gm.set_sn_mva(100.0)
+    gm.set_init_vm_pu(1.0)
+    return gm
+
+
+# ------------------------------------------------------------------
+# Load the plugin
+# ------------------------------------------------------------------
+plugin_path = find_plugin()
+lightsim2grid.load_algorithm_plugin(plugin_path)
+print("Plugin loaded successfully.")
+
+# ------------------------------------------------------------------
+# Verify registration
+# ------------------------------------------------------------------
+gm = _make_grid()
+names = gm.available_solver_names()
+assert "NR_LM_SparseLU" in names, f"NR_LM_SparseLU not in {names}"
+print(f"Registered solvers: {sorted(names)}")
+
+# ------------------------------------------------------------------
+# Change to the plugin solver(s)
+# ------------------------------------------------------------------
+gm.change_algorithm("NR_LM_SparseLU")
+assert gm.get_algo_type() == AlgorithmType.Custom, \
+    f"Expected AlgorithmType.Custom, got {gm.get_algo_type()}"
+print("change_algorithm('NR_LM_SparseLU') OK — solver type is Custom as expected.")
+
+if "NR_LM_KLU" in names:
+    gm2 = _make_grid()
+    gm2.change_algorithm("NR_LM_KLU")
+    assert gm2.get_algo_type() == AlgorithmType.Custom, \
+        f"Expected AlgorithmType.Custom, got {gm2.get_algo_type()}"
+    print("change_algorithm('NR_LM_KLU') OK — solver type is Custom as expected.")
+else:
+    print("NR_LM_KLU not registered (KLU not available in this build) — skipped.")
+
+print("All checks passed.")

--- a/src/core/powerflow_algorithm/NRSystem.hpp
+++ b/src/core/powerflow_algorithm/NRSystem.hpp
@@ -904,6 +904,19 @@ public:
     void       apply_step(const Eigen::Ref<const RealVect>& dx);
     real_type  mismatch_sq_norm_at(const Eigen::Ref<const RealVect>& dx) const;
 
+    // Direct, allocation-light update of the LAST-registered extension's
+    // `count` feature entries, identified purely by count and position (the
+    // caller -- e.g. an extension whose declare_feature_entries reserved
+    // exactly `count` trailing slots -- is responsible for knowing its own
+    // count). Adds deltas[i] into the J_.valuePtr() position already
+    // resolved (in build_J_sparsity) for feature handle
+    // `sink_.size() - count + i`, bypassing fill_internal_variables()/
+    // fill_J() entirely. For extensions whose value needs to change faster
+    // than the rest of J (e.g. Levenberg-Marquardt diagonal damping; see
+    // examples/lm_algorithm/). Not diagonal- or LM-specific: it only knows
+    // "update these already-declared feature positions."
+    void update_trailing_feature_values(int count, const Eigen::Ref<const RealVect>& deltas);
+
     // ----- Housekeeping ----------------------------------------------------------
 
     void clear_jacobian() {

--- a/src/core/powerflow_algorithm/NRSystem.tpp
+++ b/src/core/powerflow_algorithm/NRSystem.tpp
@@ -177,6 +177,16 @@ inline void NRSystem<Base, Rest...>::fill_J()
 }
 
 template <typename... Rest>
+inline void NRSystem<Base, Rest...>::update_trailing_feature_values(int count, const Eigen::Ref<const RealVect>& deltas)
+{
+    assert(deltas.size() == count);
+    const int first_h = static_cast<int>(sink_.size()) - count;
+    real_type* J_values = J_.valuePtr();
+    for (int i = 0; i < count; ++i)
+        J_values[feature_pos_[first_h + i]] += deltas(i);
+}
+
+template <typename... Rest>
 inline void NRSystem<Base, Rest...>::fill_internal_variables()
 {
     auto timer = CustTimer();


### PR DESCRIPTION
## Summary

Some real grids have ill-conditioned clusters (high resistance, heavily loaded, little local generation) where plain Newton-Raphson diverges, and the existing step-scaling policies (`Iwamoto`, `MaxVoltageChange`) only rescale the same bad Newton direction rather than fixing it — they can't help when the underlying Jacobian sub-block is itself near-singular. Levenberg-Marquardt damping addresses this directly by solving `(J + λD)dx = -F` instead of `Jdx = -F`, with λ adapted via an accept/reject loop on each trial step's actual (nonlinear) mismatch reduction.

- **Core** (`src/core/powerflow_algorithm/NRSystem.hpp`/`.tpp`): one small, generic addition — `NRSystem::update_trailing_feature_values(count, deltas)`. It directly updates the last `count` already-declared Jacobian feature entries in `J_.valuePtr()`, bypassing `fill_internal_variables()`/`fill_J()` entirely. This is intentionally not diagonal- or LM-specific: any extension that reserves trailing feature slots and needs a fast partial refresh can use it.
- **`examples/lm_algorithm/`** (new, out-of-tree plugin — not wired into the main build/CI, following the same pattern as `examples/dist_slack_algorithm/` and `examples/external_algorithm/`):
  - `DiagonalDamping.hpp` — `DiagonalEntry`, a minimal `NRSystem` extension that reserves one feature slot per existing unknown (for the diagonal load) and claims no rows/cols of its own, plus `with_diagonal_entry<NRSystem>` to inject it as the last extension of an existing `SingleSlackNRSystem`/`MultiSlackNRSystem`.
  - `LMNRAlgo.hpp`/`.tpp` — the algorithm itself: a `BaseAlgo` sibling to `NRAlgo` (not built on top of it, since the inner accept/reject loop — potentially several factorize+solve+mismatch-eval cycles per outer NR iteration — doesn't fit `NRAlgo`'s single solve-per-iteration control flow, its `RefactorPolicy` (assumes stable-across-iterations J values), or its `ScalingPolicy` (only rescales an already-solved step post-hoc, can't touch the matrix being solved)). Trial evaluation uses the existing `NRSystem::mismatch_sq_norm_at(dx)` to check the true nonlinear residual without mutating internal voltage state, so a rejected trial never needs a rollback.
  - `LMNRAlgo_plugin.cpp` + `CMakeLists.txt` — registers `"NR_LM_SparseLU"` and `"NR_LM_KLU"` via the standard `AlgorithmRegistry` self-registration mechanism.
  - `test_plugin.py` — registration/load smoke test, same scope as the existing `external_algorithm` one.

## Test plan

- [x] `examples/lm_algorithm` builds cleanly (including with `-Wall -Wextra`), with only the expected core symbols left undefined for the dynamic linker (`Base`/`Hvdc`/`VoltageControl::update_state`, `SparseLULinearSolver::*`, `AlgorithmRegistry::*`) — confirming the new code only depends on symbols already compiled into `lightsim2grid_core`.
- [x] The existing `examples/dist_slack_algorithm` plugin still builds unchanged against the modified `NRSystem`, i.e. no regression from the core addition.
- [ ] End-to-end power flow run (`test_plugin.py` + a real grid via `LightSimBackend`) — not run in this environment (no compiled `lightsim2grid_cpp` extension available here).
- [ ] Validation on a real ill-conditioned case where plain NR/Iwamoto diverge and `MaxVoltageChange` lands on an unrealistic branch, compared against a PowSyBl/OpenLoadFlow reference — needs to be run against local grid data outside this repo.


---
_Generated by [Claude Code](https://claude.ai/code/session_018PXF6if9WFcunG1GrsFLm5)_