### PR TITLE
core: const-correctness and copy-elimination low-hanging fruit

### DIFF
--- a/src/core/DataConverter.cpp
+++ b/src/core/DataConverter.cpp
@@ -13,7 +13,7 @@
 namespace ls2g {
 
 
-void PandaPowerConverter::_check_init(){
+void PandaPowerConverter::_check_init() const {
     if(sn_mva_ <= 0.){
         throw std::runtime_error("PandaPowerConverter::_check_init: sn_mva has not been initialized");
     }
@@ -35,7 +35,7 @@ std::tuple<RealVect,
                                                     const Eigen::Ref<const RealVect> & trafo_vkr_percent,
                                                     const Eigen::Ref<const RealVect> & trafo_sn_trafo_mva,
                                                     const Eigen::Ref<const RealVect> & trafo_pfe_kw,
-                                                    const Eigen::Ref<const RealVect> & trafo_i0_pct)
+                                                    const Eigen::Ref<const RealVect> & trafo_i0_pct) const
 {
     //TODO consistency: move this class outside of here
     _check_init();
@@ -134,7 +134,7 @@ std::tuple<RealVect,
                                                       const Eigen::Ref<const RealVect> & branch_g,
                                                       const Eigen::Ref<const RealVect> & branch_c,
                                                       const Eigen::Ref<const RealVect> & branch_from_kv,
-                                                      const Eigen::Ref<const RealVect> & /*branch_to_kv*/)
+                                                      const Eigen::Ref<const RealVect> & /*branch_to_kv*/) const
 {
     //TODO does not use c at the moment!
     _check_init();
@@ -166,7 +166,7 @@ std::tuple<RealVect,
                                         const Eigen::Ref<const RealVect> & branch_g,
                                         const Eigen::Ref<const RealVect> & branch_c,
                                         const Eigen::Ref<const RealVect> & branch_from_kv,
-                                        const Eigen::Ref<const RealVect> & /*branch_to_kv*/)
+                                        const Eigen::Ref<const RealVect> & /*branch_to_kv*/) const
 {
     _check_init();
     const int nb_line = static_cast<int>(branch_r.size());
@@ -205,7 +205,7 @@ std::tuple<RealVect,
                                                     const Eigen::Ref<const RealVect> & trafo_sn_mva,
                                                     const Eigen::Ref<const RealVect> & trafo_pfe_kw,
                                                     const Eigen::Ref<const RealVect> & trafo_i0_pct,
-                                                    bool trafo_model_is_t)
+                                                    bool trafo_model_is_t) const
 {
     //TODO consistency: move this class outside of here
     _check_init();

--- a/src/core/DataConverter.hpp
+++ b/src/core/DataConverter.hpp
@@ -52,7 +52,7 @@ class LS2G_API PandaPowerConverter final : public BaseConstants
                                const Eigen::Ref<const RealVect> & trafo_sn_trafo_mva,
                                const Eigen::Ref<const RealVect> & trafo_pfe_kw,
                                const Eigen::Ref<const RealVect> & trafo_i0_pct,
-                               bool trafo_model_is_t);
+                               bool trafo_model_is_t) const;
 
         /**
         This converts the trafo from pandapower to r, x and h (pair unit) (for legacy (<= 2.14.somthing) pandapower)
@@ -70,7 +70,7 @@ class LS2G_API PandaPowerConverter final : public BaseConstants
                                const Eigen::Ref<const RealVect> & trafo_vkr_percent,
                                const Eigen::Ref<const RealVect> & trafo_sn_trafo_mva,
                                const Eigen::Ref<const RealVect> & trafo_pfe_kw,
-                               const Eigen::Ref<const RealVect> & trafo_i0_pct);
+                               const Eigen::Ref<const RealVect> & trafo_i0_pct) const;
 
 
         /**
@@ -84,7 +84,7 @@ class LS2G_API PandaPowerConverter final : public BaseConstants
                                  const Eigen::Ref<const RealVect> & branch_g,
                                  const Eigen::Ref<const RealVect> & branch_c,
                                  const Eigen::Ref<const RealVect> & branch_from_kv,
-                                 const Eigen::Ref<const RealVect> & branch_to_kv);
+                                 const Eigen::Ref<const RealVect> & branch_to_kv) const;
         /**
         pair unit properly the powerlines (for most recent pandapower)
         **/
@@ -97,14 +97,14 @@ class LS2G_API PandaPowerConverter final : public BaseConstants
                           const Eigen::Ref<const RealVect> & branch_g,
                           const Eigen::Ref<const RealVect> & branch_c,
                           const Eigen::Ref<const RealVect> & branch_from_kv,
-                          const Eigen::Ref<const RealVect> & branch_to_kv);
+                          const Eigen::Ref<const RealVect> & branch_to_kv) const;
 
     private:
         real_type sn_mva_;
         real_type f_hz_;
 
     private:
-        void _check_init();
+        void _check_init() const;
 };
 
 // TODO have a converter from ppc !

--- a/src/core/LSGrid.hpp
+++ b/src/core/LSGrid.hpp
@@ -782,8 +782,8 @@ class LS2G_API LSGrid final
         void change_bus2_powerline_python(int powerline_id, int new_gridmodel_bus_id) {
             change_bus2_powerline(powerline_id, GridModelBusId(new_gridmodel_bus_id));
         }
-        int get_bus1_powerline(int powerline_id) {return powerlines_.get_bus_side_1(powerline_id).cast_int();}
-        int get_bus2_powerline(int powerline_id) {return powerlines_.get_bus_side_2(powerline_id).cast_int();}
+        int get_bus1_powerline(int powerline_id) const {return powerlines_.get_bus_side_1(powerline_id).cast_int();}
+        int get_bus2_powerline(int powerline_id) const {return powerlines_.get_bus_side_2(powerline_id).cast_int();}
 
         //deactivate trafo
         void deactivate_trafo(int trafo_id) {trafos_.deactivate(trafo_id, algo_controler_); }
@@ -822,10 +822,10 @@ class LS2G_API LSGrid final
         void change_bus2_trafo_python(int trafo_id, int new_gridmodel_bus_id) {
             change_bus2_trafo(trafo_id, GridModelBusId(new_gridmodel_bus_id));
         }
-        int get_bus1_trafo(int trafo_id) {
+        int get_bus1_trafo(int trafo_id) const {
             return trafos_.get_bus_side_1(trafo_id).cast_int();
         }
-        int get_bus2_trafo(int trafo_id) {
+        int get_bus2_trafo(int trafo_id) const {
             return trafos_.get_bus_side_2(trafo_id).cast_int();
         }
         void change_ratio_trafo(int trafo_id, real_type new_ratio){
@@ -1153,7 +1153,7 @@ class LS2G_API LSGrid final
          * 
          * @return Eigen::SparseMatrix<cplx_type> 
          */
-        Eigen::SparseMatrix<cplx_type> get_Ybus_solver(){
+        Eigen::SparseMatrix<cplx_type> get_Ybus_solver() const {
             return Ybus_ac_;  // This is copied to python
         }
 
@@ -1171,7 +1171,7 @@ class LS2G_API LSGrid final
          * 
          * @return Eigen::SparseMatrix<cplx_type> 
          */
-        Eigen::SparseMatrix<real_type> get_dcYbus_solver(){
+        Eigen::SparseMatrix<real_type> get_dcYbus_solver() const {
             return Bbus_dc_;  // This is copied to python (DC admittance matrix is real)
         }
 
@@ -1227,7 +1227,7 @@ class LS2G_API LSGrid final
          * 
          * @return Eigen::Ref<const CplxVect>
          */
-        [[nodiscard]] const Eigen::SparseMatrix<cplx_type> get_Ybus() const {
+        [[nodiscard]] Eigen::SparseMatrix<cplx_type> get_Ybus() const {
             return _relabel_matrix(Ybus_ac_, id_ac_solver_to_me_);
         }
 
@@ -1247,7 +1247,7 @@ class LS2G_API LSGrid final
          * 
          * @return Eigen::Ref<const CplxVect>
          */
-        [[nodiscard]] const Eigen::SparseMatrix<real_type> get_dcYbus() const {
+        [[nodiscard]] Eigen::SparseMatrix<real_type> get_dcYbus() const {
             return _relabel_matrix(Bbus_dc_, id_dc_solver_to_me_);
         }
 
@@ -1265,7 +1265,7 @@ class LS2G_API LSGrid final
          * 
          * @return Eigen::Ref<const CplxVect>
          */
-        [[nodiscard]] const CplxVect get_Sbus() const {
+        [[nodiscard]] CplxVect get_Sbus() const {
             return _relabel_vector(acSbus_, id_ac_solver_to_me_);
         }
 
@@ -1283,7 +1283,7 @@ class LS2G_API LSGrid final
          * 
          * @return Eigen::Ref<const CplxVect>
          */
-        [[nodiscard]] const RealVect get_dcSbus() const {
+        [[nodiscard]] RealVect get_dcSbus() const {
             return _relabel_vector(dcPbus_, id_dc_solver_to_me_);
         }
 
@@ -1315,12 +1315,12 @@ class LS2G_API LSGrid final
          * 
          * @return const Eigen::VectorXi
          */
-        [[nodiscard]] const GlobalBusIdVect get_pv() const{
+        [[nodiscard]] GlobalBusIdVect get_pv() const{
             if(id_ac_solver_to_me_.size() > 0) return _relabel_vector2<SolverBusIdVect, GlobalBusIdVect>(get_pv_solver(), id_ac_solver_to_me_);
             if(id_dc_solver_to_me_.size() > 0) return _relabel_vector2<SolverBusIdVect, GlobalBusIdVect>(get_pv_solver(), id_dc_solver_to_me_);
             throw std::runtime_error("LSGrid::get_pv: impossible to retrieve the `gridmodel` bus label as it appears no powerflow has run.");
         }
-        [[nodiscard]] const IntVect get_pv_numpy() const{
+        [[nodiscard]] IntVect get_pv_numpy() const{
             return get_pv().as_eigen();  // was _to_intvect()
         }
 
@@ -1352,12 +1352,12 @@ class LS2G_API LSGrid final
          * 
          * @return const Eigen::VectorXi
          */
-        [[nodiscard]] const GlobalBusIdVect get_pq() const{
+        [[nodiscard]] GlobalBusIdVect get_pq() const{
             if(id_ac_solver_to_me_.size() > 0) return _relabel_vector2<SolverBusIdVect, GlobalBusIdVect>(get_pq_solver(), id_ac_solver_to_me_);
             if(id_dc_solver_to_me_.size() > 0) return _relabel_vector2<SolverBusIdVect, GlobalBusIdVect>(get_pq_solver(), id_dc_solver_to_me_);
             throw std::runtime_error("LSGrid::get_pq: impossible to retrieve the `gridmodel` bus label as it appears no powerflow has run.");
         }
-        [[nodiscard]] const IntVect get_pq_numpy() const{
+        [[nodiscard]] IntVect get_pq_numpy() const{
             return get_pq().as_eigen();  // was _to_intvect()
         }
 
@@ -1385,10 +1385,10 @@ class LS2G_API LSGrid final
          * 
          * @return const Eigen::VectorXi 
          */
-        [[nodiscard]] const GlobalBusIdVect get_slack_ids() const {
+        [[nodiscard]] GlobalBusIdVect get_slack_ids() const {
             return _relabel_vector2<SolverBusIdVect, GlobalBusIdVect>(slack_bus_id_ac_solver_, id_ac_solver_to_me_);
         }
-        [[nodiscard]] const IntVect get_slack_ids_numpy() const {
+        [[nodiscard]] IntVect get_slack_ids_numpy() const {
             return get_slack_ids().as_eigen();  // was _to_intvect()
         }
 
@@ -1409,9 +1409,9 @@ class LS2G_API LSGrid final
             return slack_bus_id_dc_solver_.as_eigen();  // was _to_intvect()
         }
 
-        [[nodiscard]] const GlobalBusIdVect get_slack_ids_dc() const{
+        [[nodiscard]] GlobalBusIdVect get_slack_ids_dc() const{
             return _relabel_vector2<SolverBusIdVect, GlobalBusIdVect>(
-                slack_bus_id_dc_solver_, 
+                slack_bus_id_dc_solver_,
                 id_dc_solver_to_me_);
         }
         /**
@@ -1419,7 +1419,7 @@ class LS2G_API LSGrid final
          * 
          * @return const Eigen::VectorXi 
          */
-        [[nodiscard]] const IntVect get_slack_ids_dc_numpy() const{
+        [[nodiscard]] IntVect get_slack_ids_dc_numpy() const{
             return get_slack_ids_dc().as_eigen();  // was _to_intvect()
         }
 
@@ -1441,7 +1441,7 @@ class LS2G_API LSGrid final
          * 
          * @return Eigen::Ref<const RealVect> 
          */
-        [[nodiscard]] const RealVect get_slack_weights() const{
+        [[nodiscard]] RealVect get_slack_weights() const{
             if(id_ac_solver_to_me_.size() > 0) return _relabel_vector(get_slack_weights_solver(), id_ac_solver_to_me_);
             if(id_dc_solver_to_me_.size() > 0) return _relabel_vector(get_slack_weights_solver(), id_dc_solver_to_me_);
             throw std::runtime_error("LSGrid::get_slack_weights: impossible to retrieve the `gridmodel` bus label as it appears no powerflow has run.");
@@ -1461,7 +1461,7 @@ class LS2G_API LSGrid final
          * 
          * @return CplxVect
          */
-        [[nodiscard]] const CplxVect get_V() const{
+        [[nodiscard]] CplxVect get_V() const{
             if(id_ac_solver_to_me_.size() > 0) return _relabel_vector(get_V_solver(), id_ac_solver_to_me_);
             if(id_dc_solver_to_me_.size() > 0) return _relabel_vector(get_V_solver(), id_dc_solver_to_me_);
             throw std::runtime_error("LSGrid::get_V: impossible to retrieve the `gridmodel` bus label as it appears no powerflow has run.");
@@ -1481,7 +1481,7 @@ class LS2G_API LSGrid final
          * 
          * @return const RealVect
          */
-        [[nodiscard]] const RealVect get_Va() const{
+        [[nodiscard]] RealVect get_Va() const{
             if(id_ac_solver_to_me_.size() > 0) return _relabel_vector(get_Va_solver(), id_ac_solver_to_me_);
             if(id_dc_solver_to_me_.size() > 0) return _relabel_vector(get_Va_solver(), id_dc_solver_to_me_);
             throw std::runtime_error("LSGrid::get_Va: impossible to retrieve the `gridmodel` bus label as it appears no powerflow has run.");
@@ -1501,7 +1501,7 @@ class LS2G_API LSGrid final
          * 
          * @return const RealVect
          */
-        [[nodiscard]] const RealVect get_Vm() const{
+        [[nodiscard]] RealVect get_Vm() const{
             if(id_ac_solver_to_me_.size() > 0) return _relabel_vector(get_Vm_solver(), id_ac_solver_to_me_);
             if(id_dc_solver_to_me_.size() > 0) return _relabel_vector(get_Vm_solver(), id_dc_solver_to_me_);
             throw std::runtime_error("LSGrid::get_Vm: impossible to retrieve the `gridmodel` bus label as it appears no powerflow has run.");

--- a/src/core/element_container/GeneratorContainer.hpp
+++ b/src/core/element_container/GeneratorContainer.hpp
@@ -281,7 +281,7 @@ class LS2G_API GeneratorContainer final: public OneSideContainer_PQ, public Iter
         
         void cout_v(){
             for(const auto & el : target_vm_pu_){
-                std::cout << "V " << el << std::endl;
+                std::cout << "V " << el << '\n';
             }
         }
 

--- a/src/core/powerflow_algorithm/BaseAlgo.hpp
+++ b/src/core/powerflow_algorithm/BaseAlgo.hpp
@@ -426,7 +426,7 @@ class LS2G_API BaseAlgo : public BaseConstants
             timer_total_nr_ = 0.;
         }
 
-        bool is_linear_solver_valid(){
+        bool is_linear_solver_valid() const {
             // bool res = true;
             // if((err_ == ErrorType::NotInitError) || (err_ == ErrorType::LicenseError)) res = false;  // cannot use a non intialize solver
             // return res;


### PR DESCRIPTION
Follow-up to the const / `const Eigen::Ref` sweep (#151), picking up member functions and return types that pass missed under `src/core`. Everything here is either a read-only marker or a copy-enabling change — **no behavioural change**.

### What changed

**`const` on read-only member functions** (callable through a `const` object / reference, and documents intent):
- `LSGrid`: `get_bus1_powerline`, `get_bus2_powerline`, `get_bus1_trafo`, `get_bus2_trafo`, `get_Ybus_solver`, `get_dcYbus_solver`
- `PandaPowerConverter`: `get_line_param`, `get_line_param_legacy`, `get_trafo_param_pp2`, `get_trafo_param_pp3`, `_check_init` — the whole class is read-only apart from its two setters
- `BaseAlgo::is_linear_solver_valid` (reads `err_` only)

**Drop top-level `const` on by-value return types** (`readability-const-return-type`): returning `const T` **by value** blocks move-construction / move-assignment at the call site (e.g. the pybind copy-to-Python path) and buys nothing. Applied to the freshly-computed getters in `LSGrid`: `get_Ybus`, `get_dcYbus`, `get_Sbus`, `get_dcSbus`, `get_pv[_numpy]`, `get_pq[_numpy]`, `get_slack_ids[_numpy]`, `get_slack_ids_dc[_numpy]`, `get_slack_weights`, `get_V`, `get_Va`, `get_Vm`.

**Misc**: `std::endl` → `'\n'` in `GeneratorContainer::cout_v` (drops the per-line stream flush; `performance-avoid-endl`).

### How it was found
The report-only clang-tidy config already in the tree (`performance-*`, `readability-const-return-type`, `misc-const-correctness`) run over every `src/core` translation unit, plus a manual member-function pass. Deliberately **not** touched: the `get_ptdf` / `get_lodf` chain (genuinely mutates `timer_ptdf_` and the linear-solver factorization — correctly non-const), the `performance-enum-size` findings (several enums cross the pybind / `BinaryArchive` boundary, so narrowing the width risks ABI/format breakage), and the `misc-const-correctness` const-local findings (cosmetic, no codegen effect).

### Verification
`src/core` builds and the C++ unit test suite passes (1201 assertions in 49 test cases).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01LY1xhzf8cUjqFoNNj7y2Gc)_