### PR TITLE
Fix memory-safety holes on the untrusted-input paths

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -124,6 +124,55 @@ TODO: Levenberg-Marquardt damping (a.k.a. Tikhonov-regularized Newton) : adding 
   / ``init_from_powermodels``). A well-formed but inconsistent state (e.g. an
   out-of-range bus id in a crafted binary file) now raises a clean exception instead
   of causing an out-of-bounds access during the next powerflow.
+- [FIXED] ``SubstationContainer::set_state`` performed **no** validation at all, and it
+  restores the root of the grid's index space: ``nb_bus()`` (the bound ``check_grid()``
+  validates every element bus id against), ``bus_status_`` (the vector those same ids are
+  used to index) and ``n_sub_`` / ``nmax_busbar_per_sub_`` were all read from the file
+  independently of one another. A pickle or a binary file declaring, say, 4000 buses but a
+  1-entry ``bus_status`` passed ``check_grid()`` and then corrupted the heap on the next
+  ``init_bus_status()`` (``disconnect_all_buses()`` writes ``nb_bus()`` entries into it).
+  All of these are now cross-checked on load, and re-checked by ``check_grid()``.
+- [FIXED] ``n_sub_ == 0`` restored from a state reached ``sub_id_of_bus()``, which does
+  ``gridmodel_bus_id % n_sub_`` -- an integer division by zero (SIGFPE that kills the
+  process), the same class of bug as ``refactor_every_n == 0``. A grid with buses must now
+  declare a strictly positive substation count, and ``n_sub_ * nmax_busbar_per_sub_`` is
+  rejected if it overflows the ``int`` it is stored in.
+- [FIXED] ``LSGrid::set_ls_to_orig`` accepted any value: ``set_ls_to_orig_internal`` sizes
+  the reverse mapping from ``lpNorm<Infinity>()`` (the maximum **absolute** value) and then
+  indexes it with the values themselves, so an entry of ``-5`` sized the vector from 5 and
+  wrote at index ``-5`` -- an out-of-bounds heap write, reachable from the ``_ls_to_orig``
+  python property as well as from a pickle / binary file. Entries must now be ``-1`` or a
+  sane non-negative original-grid bus id. ``_orig_to_ls`` is range-checked the same way.
+- [FIXED] ``_init_kwargs`` is serialized as two parallel vectors whose lengths are stored
+  independently; ``set_state`` walked the keys and indexed the values with the same
+  counter, so a file declaring more keys than values read past the end of the values
+  vector -- constructing ``std::string`` objects from arbitrary heap contents. The two
+  lengths must now match.
+- [FIXED] iterating ``gridmodel.get_substations()`` crashed on any grid whose substation
+  names were never set (``set_substation_names`` is optional and the pandapower / matpower
+  / powermodels loaders never call it): ``SubstationInfo`` read ``sub_names_[id]``
+  unconditionally, bounded only against the *substation count*. This needed no crafted
+  input at all.
+- [FIXED] ``update_topo`` did not check the length of the ``has_changed`` / ``new_values``
+  arrays it is given. They are indexed **by position in the topology vector** with an
+  unchecked Eigen ``operator()``: the positions are validated (``check_grid()`` proves they
+  form a permutation of ``[0, dim_topo)``), but a caller-supplied array shorter than
+  ``dim_topo`` was simply read past its end. Both must now have exactly ``dim_topo``
+  entries.
+- [FIXED] ``update_slack_weights`` did not check that its ``could_be_slack`` array had one
+  entry per generator, although it indexes it by generator id.
+- [FIXED] ``check_grid()`` now also validates the substation container's own internal
+  consistency and the bus-id mapping vectors (``_ls_to_orig`` / ``_orig_to_ls`` /
+  ``_bus_fusion_rep``), which it previously ignored entirely.
+- [FIXED] an ``AlgoConfig`` (part of the serialized grid state) carrying an out-of-range
+  ``RefactorPolicyType`` / ``ScalingPolicyType`` is now rejected instead of being cast to
+  the enum, silently falling into a ``default:`` branch and round-tripping back out of
+  ``get_config()``. ``set_config`` also validates both policies *before* touching any
+  member, so a rejected config no longer leaves a half-applied one behind.
+- [FIXED] ``LSGrid::set_orig_to_ls`` did not actually build the inverse of the mapping it
+  was given: it walked only the first *n* entries (*n* = the number of non-``-1`` ones,
+  which are not necessarily at the front) and stored the lightsim bus id where the
+  original one belonged. ``_ls_to_orig`` and ``_orig_to_ls`` are now true inverses.
 - [BREAKING] solver names are now restricted to ``[A-Za-z_][A-Za-z0-9_.]{0,63}`` (start with
   an ASCII letter or ``_``; then ASCII letters, digits, ``_`` or ``.``; at most 64
   characters). Registering any other name is refused. A solver name is written into every

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,6 +3,16 @@ Change Log
 
 [TODO]
 --------
+- ``SubstationContainer::sub_vn_kv_`` is dead state: its only writers (``init_sub()``
+  and the two-argument constructor) are called from nowhere, and nothing reads it
+  back, so it is empty on every grid every loader produces and in every binary file
+  saved so far. It is also redundant -- a substation's nominal voltage is the common
+  vn_kv of its buses, i.e. ``sub_vn_kv_[I] == bus_vn_kv_[I]`` for ``I < n_sub``, which
+  ``check_valid()`` now enforces when it is present. Decide: either drop it from
+  ``StateRes`` (needs a ``BINARY_FORMAT_VERSION`` bump) or have ``init_bus()`` fill it
+  and make it mandatory (changes what newly-saved files contain, and can only become
+  mandatory once no already-saved file needs to load). See the long note on the member
+  itself in ``SubstationContainer.hpp``.
 - [refacto] have a structure in cpp for the buses
 - [refacto] have the id_grid_to_solver and id_solver_to_grid etc. directly in the solver and NOT in the gridmodel.
 - [refacto] put some method in the DataGeneric as well as some attribute (_status for example)

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -164,6 +164,25 @@ TODO: Levenberg-Marquardt damping (a.k.a. Tikhonov-regularized Newton) : adding 
 - [FIXED] ``check_grid()`` now also validates the substation container's own internal
   consistency and the bus-id mapping vectors (``_ls_to_orig`` / ``_orig_to_ls`` /
   ``_bus_fusion_rep``), which it previously ignored entirely.
+- [FIXED] the "every bus of a substation must have the same nominal voltage" check in
+  ``init_bus`` never fired: a gridmodel bus id is ``sub_id + (local_bus_id - 1) * n_sub``
+  and ``LocalBusId`` runs ``1..nmax_busbar_per_sub``, but the loop ran local ids
+  ``[1, nmax_busbar_per_sub)`` -- so it started by comparing the reference bus with
+  *itself* and stopped one busbar short. With the usual ``nmax_busbar_per_sub == 2`` it
+  checked nothing at all, and the invariant was silently unenforced on every path. It is
+  now checked over local ids ``2..nmax_busbar_per_sub``, and re-checked by
+  ``check_grid()`` -- ``set_state`` bypasses ``init_bus``, so a pickle / binary file could
+  always carry a grid violating it.
+- [FIXED] ``SubstationContainer::init_sub`` wrote ``n_sub`` values into ``sub_vn_kv_``
+  (and into ``bus_vn_kv_``) with an unchecked ``operator[]`` without sizing them first.
+  Only the two-argument constructor sizes ``sub_vn_kv_``, and nothing uses it: the live
+  path is the default constructor followed by ``init_bus()``, which leaves ``sub_vn_kv_``
+  empty. Calling ``init_sub()`` on such a container was an out-of-bounds heap write. It is
+  currently uncalled and unbound, so this was latent rather than reachable, but it sized
+  its destinations wrongly for whoever wired it up next. ``sub_vn_kv`` is also validated
+  against ``bus_vn_kv`` by ``check_grid()`` when it is present (it stays optional: it is
+  empty on every grid produced by any loader today, and on every already-saved binary
+  file including this repo's own format-4 compatibility fixture).
 - [FIXED] an ``AlgoConfig`` (part of the serialized grid state) carrying an out-of-range
   ``RefactorPolicyType`` / ``ScalingPolicyType`` is now rejected instead of being cast to
   the enum, silently falling into a ``default:`` branch and round-tripping back out of

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -174,6 +174,31 @@ TODO: Levenberg-Marquardt damping (a.k.a. Tikhonov-regularized Newton) : adding 
 - [FIXED] ``check_grid()`` now also validates the substation container's own internal
   consistency and the bus-id mapping vectors (``_ls_to_orig`` / ``_orig_to_ls`` /
   ``_bus_fusion_rep``), which it previously ignored entirely.
+- [FIXED] whether a solver is one of lightsim2grid's own or comes from a plugin was
+  decided by ``AlgorithmType``, which cannot answer that question: it is a fixed enum of
+  *serialized* solver identities, and a built-in only appears in it if a member was added
+  for it. The ``NRRefactorRetry_KLU`` / ``_NICSLU`` / ``_CKTSO`` family never got one, so
+  ``name_to_algo_type()`` reported those three **built-in** solvers as
+  ``AlgorithmType::Custom`` exactly like a plugin -- and they were consequently paying for
+  the external-solver output check (voltage size + finiteness) on *every single solve*,
+  which built-in solvers are explicitly supposed to cost nothing. The registry now records
+  a ``SolverOrigin`` (``Builtin`` / ``External``) when a solver is registered, which is
+  where the answer is actually known; ``AlgorithmSelector::is_builtin_algo()`` caches it so
+  the hot path stays a bool read. ``SolverOrigin::External`` is the default, so a solver
+  registered without saying anything is treated as untrusted.
+- [FIXED] ``SubstationContainer`` did not check that a nominal voltage is a finite,
+  strictly positive number; 0, a negative value or NaN silently produced nonsense per-unit
+  conversions. NB this deliberately covers ``bus_vn_kv`` / ``sub_vn_kv`` only, never
+  ``bus_vmin_kv`` / ``bus_vmax_kv``, which use NaN as the documented "no limit set" sentinel.
+- [FIXED] ``n_sub * nmax_busbar_per_sub`` (the total bus count, stored in an ``int`` and
+  used in ``int`` index arithmetic) was computed without an overflow check in ``init_bus``
+  and ``init_sub``. All three entry points (those two plus ``set_state``) now go through a
+  single ``checked_nb_bus`` helper doing the multiplication in 64 bits and refusing a
+  product that does not fit, along with the positivity checks.
+- [FIXED] ``LSGrid::set_ls_to_orig_internal`` was declared ``noexcept`` although it assigns
+  one Eigen vector and allocates another, either of which throws ``std::bad_alloc`` on
+  failure -- which in a ``noexcept`` function is an immediate ``std::terminate()`` rather
+  than something the caller can handle. Nothing needed the guarantee, so it is gone.
 - [FIXED] the "every bus of a substation must have the same nominal voltage" check in
   ``init_bus`` never fired: a gridmodel bus id is ``sub_id + (local_bus_id - 1) * n_sub``
   and ``LocalBusId`` runs ``1..nmax_busbar_per_sub``, but the loop ran local ids

--- a/docs/security.rst
+++ b/docs/security.rst
@@ -83,9 +83,16 @@ the file, and it is validated at two levels:
 is internally consistent and safe to run a powerflow on. It checks that every
 index the grid carries is in range — the bus id of every element, the substation
 id and the position in the topology vector (both optional), and the generator
-slack and remote-regulated bus references. It raises ``IndexError`` (an
-out-of-range index) or ``RuntimeError`` (a structural inconsistency), and returns
-``None`` for a consistent grid.
+slack and remote-regulated bus references. It also checks the *shape* of the grid
+itself: that the substation container's own arrays agree with each other (the bus
+count, the per-bus status vector and ``n_sub × nmax_busbar_per_sub`` all describe
+the same set of buses), and that the bus-id mapping vectors carried alongside the
+grid (``_ls_to_orig`` / ``_orig_to_ls`` / ``_bus_fusion_rep``) are in range. That
+part matters as much as the per-element checks: the bus count is the *bound* the
+element checks are expressed against, so validating elements against a grid whose
+own arrays disagree would prove nothing. It raises ``IndexError`` (an out-of-range
+index) or ``RuntimeError`` (a structural inconsistency), and returns ``None`` for
+a consistent grid.
 
 You normally do not need to call it yourself:
 

--- a/lightsim2grid/tests/test_check_grid.py
+++ b/lightsim2grid/tests/test_check_grid.py
@@ -191,5 +191,165 @@ class TestCheckGrid(unittest.TestCase):
         self.assertIsNone(restored.check_grid())
 
 
+class TestSubstationAndMappingConsistency(unittest.TestCase):
+    """
+    The substation container and the bus-id mapping vectors.
+
+    ``SubstationContainer`` is the root of the grid's index space: ``nb_bus()``
+    is the bound ``check_grid()`` validates every element's bus id against, and
+    ``bus_status_`` is the vector those same ids are used to index. They used to
+    be restored from a pickle / binary file with no cross-check at all, so a file
+    whose two lengths disagreed passed ``check_grid()`` and then corrupted the
+    heap on the next ``init_bus_status()``. Same idea for ``_ls_to_orig``, whose
+    *values* are used as indices into the reverse mapping it allocates.
+
+    These are built by hand (no pandapower) so the checks are exercised directly.
+    """
+
+    def _grid(self, n_sub=3, n_busbar=2):
+        from lightsim2grid.lightsim2grid_cpp import LSGrid
+        grid = LSGrid()
+        grid.init_bus(n_sub, n_busbar,
+                      np.array([138.0] * (n_sub * n_busbar)), 0, 0)
+        grid.init_loads(np.array([1.0]), np.array([0.5]),
+                        np.array([0], dtype=np.int32))
+        grid.init_generators(np.array([1.0]), np.array([1.0]),
+                             np.array([-10.0]), np.array([10.0]),
+                             np.array([1], dtype=np.int32))
+        return grid
+
+    def test_hand_built_grid_is_consistent(self):
+        # the new substation / mapping checks must not reject a legitimate grid
+        # (sub_vn_kv and the substation names are optional and normally empty).
+        self.assertIsNone(self._grid().check_grid())
+
+    def test_substation_info_without_names(self):
+        # `sub_names_` is optional -- the pandapower / matpower / powermodels
+        # loaders never set it -- and SubstationInfo used to read sub_names_[id]
+        # unconditionally, ie read a std::string out of bounds. Iterating the
+        # substations of such a grid used to segfault.
+        grid = self._grid()
+        self.assertEqual(list(grid.get_substation_names()), [])
+        for sub in grid.get_substations():
+            self.assertEqual(sub.name, "")
+            self.assertEqual(sub.vn_kv, 138.0)
+
+    def test_negative_ls_to_orig_is_rejected(self):
+        # the reverse mapping is sized from max(abs(values)) and then indexed with
+        # the values themselves: -5 sizes it from 5 and writes at index -5.
+        grid = self._grid()
+        bad = np.full(grid.total_bus(), -1, dtype=np.int32)
+        bad[0] = -5
+        with self.assertRaises(IndexError):
+            grid._ls_to_orig = bad
+
+    def test_absurd_ls_to_orig_is_rejected(self):
+        grid = self._grid()
+        bad = np.full(grid.total_bus(), -1, dtype=np.int32)
+        bad[0] = np.iinfo(np.int32).max
+        with self.assertRaises(IndexError):
+            grid._ls_to_orig = bad
+
+    def test_valid_ls_to_orig_is_accepted(self):
+        grid = self._grid()
+        ok = np.arange(grid.total_bus(), dtype=np.int32)
+        grid._ls_to_orig = ok
+        np.testing.assert_array_equal(np.asarray(grid._ls_to_orig), ok)
+        self.assertIsNone(grid.check_grid())
+
+    def test_orig_to_ls_is_the_inverse_of_ls_to_orig(self):
+        # orig bus 0 has no lightsim counterpart; orig 1..6 map to ls 0..5.
+        grid = self._grid()
+        orig_to_ls = np.array([-1, 0, 1, 2, 3, 4, 5], dtype=np.int32)
+        grid._orig_to_ls = orig_to_ls
+        # the inverse: lightsim bus i corresponds to original bus i + 1
+        np.testing.assert_array_equal(np.asarray(grid._ls_to_orig),
+                                      np.arange(1, 7, dtype=np.int32))
+
+    def test_out_of_range_orig_to_ls_is_rejected(self):
+        grid = self._grid()
+        bad = np.arange(grid.total_bus(), dtype=np.int32)
+        bad[0] = BIG  # used to index a total_bus()-long _ls_to_orig
+        with self.assertRaises(IndexError):
+            grid._orig_to_ls = bad
+
+    def test_update_topo_rejects_short_arrays(self):
+        # each container indexes has_changed / new_values by position in the
+        # topology vector with an unchecked Eigen operator(): a short array was
+        # simply read past its end.
+        grid = self._grid()
+        grid.set_load_pos_topo_vect(np.array([0], dtype=np.int32))
+        grid.set_gen_pos_topo_vect(np.array([1], dtype=np.int32))
+        with self.assertRaises(RuntimeError):
+            grid.update_topo(np.zeros(0, dtype=bool), np.zeros(0, dtype=np.int32))
+        # correctly-sized (dim_topo == 2 here: one load + one gen), no-op call
+        grid.update_topo(np.zeros(2, dtype=bool), np.ones(2, dtype=np.int32))
+
+    def test_update_slack_weights_rejects_short_array(self):
+        grid = self._grid()  # exactly one generator
+        with self.assertRaises(RuntimeError):
+            grid.update_slack_weights(np.zeros(0, dtype=bool))
+        grid.update_slack_weights(np.ones(1, dtype=bool))
+
+    def test_poisoned_substation_state_is_rejected(self):
+        # go through the real pickle path: tamper with the substation block of a
+        # grid's state, then load it. Every case must raise, never corrupt memory.
+        import copyreg
+        import io
+        import pickle
+        from lightsim2grid.lightsim2grid_cpp import LSGrid
+
+        SUBSTATION_ID = 7
+        # SubstationContainer::StateRes = (n_sub, nmax_busbar, sub_vn_kv,
+        #                                  bus_status, bus_vn_kv, sub_names,
+        #                                  bus_vmin_kv, bus_vmax_kv)
+        def dump_with(grid, mutate):
+            outer = grid.__getstate__()
+            inner = list(outer[3])
+            sub = list(inner[SUBSTATION_ID])
+            mutate(sub)
+            inner[SUBSTATION_ID] = tuple(sub)
+            state = (outer[0], outer[1], outer[2], tuple(inner))
+
+            class _P(pickle.Pickler):
+                def reducer_override(self, obj):
+                    if isinstance(obj, LSGrid):
+                        return (copyreg.__newobj__, (LSGrid,), state)
+                    return NotImplemented
+
+            buf = io.BytesIO()
+            _P(buf, protocol=4).dump(grid)
+            return buf.getvalue()
+
+        def set_bus_status_short(sub):
+            sub[3] = [True]
+
+        def set_nsub_zero(sub):
+            sub[0] = 0
+
+        def set_nsub_overflow(sub):
+            sub[0] = 100000
+            sub[1] = 100000
+
+        def set_bus_vn_kv_short(sub):
+            sub[4] = [138.0]
+
+        for name, mutate in [("bus_status too short", set_bus_status_short),
+                             ("n_sub == 0", set_nsub_zero),
+                             ("n_sub * nmax overflows", set_nsub_overflow),
+                             ("bus_vn_kv too short", set_bus_vn_kv_short)]:
+            with self.subTest(name):
+                blob = dump_with(self._grid(), mutate)
+                with self.assertRaises(RuntimeError):
+                    pickle.loads(blob)
+
+    def test_pickle_roundtrip_of_hand_built_grid(self):
+        import pickle
+        grid = self._grid()
+        restored = pickle.loads(pickle.dumps(grid))
+        self.assertIsNone(restored.check_grid())
+        self.assertEqual(restored.total_bus(), grid.total_bus())
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/src/core/AlgorithmRegistry.cpp
+++ b/src/core/AlgorithmRegistry.cpp
@@ -15,7 +15,8 @@ AlgorithmRegistry& AlgorithmRegistry::instance() {
     return reg;
 }
 
-void AlgorithmRegistry::register_solver(const std::string& name, Factory f, Ls2gAbiTag caller_tag) {
+void AlgorithmRegistry::register_solver(const std::string& name, Factory f, Ls2gAbiTag caller_tag,
+                                        SolverOrigin origin) {
     const Ls2gAbiTag& this_core_tag = core_abi_tag();
     if (caller_tag != this_core_tag) {
         throw std::runtime_error(
@@ -37,9 +38,10 @@ void AlgorithmRegistry::register_solver(const std::string& name, Factory f, Ls2g
         throw std::invalid_argument("AlgorithmRegistry: a solver named '" + printable(name) + "' is already registered.");
     }
     _factories[name] = std::move(f);
+    _origins[name] = origin;
 }
 
-void AlgorithmRegistry::register_all(FactoryMap batch, Ls2gAbiTag caller_tag) {
+void AlgorithmRegistry::register_all(FactoryMap batch, Ls2gAbiTag caller_tag, SolverOrigin origin) {
     const Ls2gAbiTag& this_core_tag = core_abi_tag();
     if (caller_tag != this_core_tag) {
         throw std::runtime_error(
@@ -70,10 +72,14 @@ void AlgorithmRegistry::register_all(FactoryMap batch, Ls2gAbiTag caller_tag) {
     // throws (e.g. std::bad_alloc), _factories is left exactly as it was.
     FactoryMap merged = _factories;
     merged.reserve(_factories.size() + batch.size());
+    std::unordered_map<std::string, SolverOrigin> merged_origins = _origins;
+    merged_origins.reserve(_origins.size() + batch.size());
     for (auto& kv : batch) {
+        merged_origins.emplace(kv.first, origin);
         merged.emplace(kv.first, std::move(kv.second));
     }
     _factories.swap(merged);
+    _origins.swap(merged_origins);
 }
 
 std::unique_ptr<BaseAlgo> AlgorithmRegistry::make(const std::string& name) const {
@@ -87,6 +93,21 @@ std::unique_ptr<BaseAlgo> AlgorithmRegistry::make(const std::string& name) const
 
 bool AlgorithmRegistry::is_registered(const std::string& name) const {
     return _factories.find(name) != _factories.end();
+}
+
+SolverOrigin AlgorithmRegistry::origin_of(const std::string& name) const {
+    auto it = _origins.find(name);
+    // an unknown name is reported External: the cautious answer (see the header)
+    if (it == _origins.end()) return SolverOrigin::External;
+    return it->second;
+}
+
+std::vector<std::string> AlgorithmRegistry::builtin_algorithm_names() const {
+    std::vector<std::string> names;
+    for (auto it = _origins.begin(); it != _origins.end(); ++it) {
+        if (it->second == SolverOrigin::Builtin) names.push_back(it->first);
+    }
+    return names;
 }
 
 std::vector<std::string> AlgorithmRegistry::available_algorithm_names() const {

--- a/src/core/AlgorithmRegistry.hpp
+++ b/src/core/AlgorithmRegistry.hpp
@@ -83,6 +83,25 @@ inline std::string solver_name_rule() {
            "letters, digits, '_' or '.'";
 }
 
+/**
+ * Where a registered solver comes from: shipped with lightsim2grid, or brought in
+ * from outside (a plugin).
+ *
+ * This is the ONLY trustworthy answer to "is this solver ours?". `AlgorithmType`
+ * cannot answer it: it is a fixed enum of *serialized* solver identities, and a
+ * built-in solver only has a member there if someone added one -- the
+ * `NRRefactorRetry_*` family never got one, so `name_to_algo_type()` returns
+ * `AlgorithmType::Custom` for them exactly as it does for a plugin. Anything
+ * gating on `== Custom` therefore silently mistreats those built-ins (see
+ * LSGrid::process_results, which used to run the external-solver output check on
+ * them). Origin is recorded at registration time, where the truth is actually
+ * known, and cannot drift out of sync with the enum.
+ */
+enum class SolverOrigin {
+    Builtin,   // registered by BuiltinSolversRegistration.cpp, ie shipped in-tree
+    External   // registered by a plugin (or anything else at run time)
+};
+
 class LS2G_API AlgorithmRegistry {
 public:
     using Factory = std::function<std::unique_ptr<BaseAlgo>()>;
@@ -95,8 +114,14 @@ public:
     // this, the default captures that TU's own Eigen SIMD/alignment settings.
     // Throws if it disagrees with lightsim2grid_core's own tag -- see
     // Ls2gAbiTag.hpp. Used for the built-in solvers (BuiltinSolversRegistration).
+    //
+    // `origin` defaults to External on purpose: External is the *cautious*
+    // answer (it is what makes a solver's output validated before use), so a
+    // caller that does not say anything is treated as untrusted. Only
+    // BuiltinSolversRegistration.cpp passes SolverOrigin::Builtin.
     void register_solver(const std::string& name, Factory f,
-                          Ls2gAbiTag caller_tag = ls2g_current_abi_tag());
+                          Ls2gAbiTag caller_tag = ls2g_current_abi_tag(),
+                          SolverOrigin origin = SolverOrigin::External);
 
     // Register a whole batch of solvers atomically: either every name in
     // `batch` is added, or none is and the registry is left exactly as it was.
@@ -104,15 +129,27 @@ public:
     // that a plugin exposing several solvers can never half-register when a
     // later name collides with an already-registered one. Throws (leaving the
     // registry unchanged) on an ABI-tag mismatch or a name already present.
-    void register_all(FactoryMap batch, Ls2gAbiTag caller_tag = ls2g_current_abi_tag());
+    void register_all(FactoryMap batch, Ls2gAbiTag caller_tag = ls2g_current_abi_tag(),
+                      SolverOrigin origin = SolverOrigin::External);
 
     std::unique_ptr<BaseAlgo> make(const std::string& name) const;
     bool is_registered(const std::string& name) const;
     std::vector<std::string> available_algorithm_names() const;
 
+    // Origin of an already-registered solver. An unknown name is reported as
+    // External -- again the cautious answer, and it keeps callers from having to
+    // handle a third "not registered" case.
+    SolverOrigin origin_of(const std::string& name) const;
+    bool is_builtin(const std::string& name) const {
+        return origin_of(name) == SolverOrigin::Builtin;
+    }
+    // Names registered with SolverOrigin::Builtin, ie the solvers shipped in-tree.
+    std::vector<std::string> builtin_algorithm_names() const;
+
 private:
     AlgorithmRegistry() = default;
     FactoryMap _factories;
+    std::unordered_map<std::string, SolverOrigin> _origins;
 };
 
 // Staging area a plugin fills in with its solvers before they are committed to

--- a/src/core/AlgorithmSelector.cpp
+++ b/src/core/AlgorithmSelector.cpp
@@ -35,6 +35,7 @@ FDPF_BX_SparseLU& AlgorithmSelector::get_fdpf_bx_lu() {
 AlgorithmSelector::AlgorithmSelector()
     : _algo_type(AlgorithmType::NR_SparseLU),
       _algo_name("NR_SparseLU"),
+      _algo_is_builtin(true),  // NR_SparseLU is shipped in-tree
       _algo_type_used_for_nr(AlgorithmType::NR_SparseLU),
       _gridmodel_ptr(nullptr)
 {
@@ -102,6 +103,9 @@ void AlgorithmSelector::change_algorithm(const std::string& name)
     _algo = std::move(new_algo);
     _algo_type = type;
     _algo_name = name;  // keeps the plugin name, which `type` (Custom) loses
+    // Ask the registry, not the enum: NRRefactorRetry_* are built-ins with no
+    // AlgorithmType member, so `type` is Custom for them just as for a plugin.
+    _algo_is_builtin = AlgorithmRegistry::instance().is_builtin(name);
     _algo_type_used_for_nr = type;
 
     if (_gridmodel_ptr) _algo->set_lsgrid(_gridmodel_ptr);

--- a/src/core/AlgorithmSelector.hpp
+++ b/src/core/AlgorithmSelector.hpp
@@ -119,6 +119,18 @@ class LS2G_API AlgorithmSelector final
         // using a plugin can be restored (see LSGrid::get_state/set_state).
         const std::string& get_name() const { return _algo_name; }
 
+        // Is the currently selected algorithm one shipped with lightsim2grid?
+        //
+        // Use THIS, never `get_type() == AlgorithmType::Custom`, to tell an
+        // in-tree solver from a plugin. AlgorithmType is a fixed enum of
+        // *serialized* solver identities, and a built-in only appears in it if a
+        // member was added for it: the NRRefactorRetry_* family never got one, so
+        // name_to_algo_type() reports those built-ins as Custom exactly like a
+        // plugin. The registry records the real answer at registration time (see
+        // SolverOrigin), and it is cached here at change_algorithm() time so
+        // asking costs nothing on the per-solve path.
+        bool is_builtin_algo() const { return _algo_is_builtin; }
+
         // Polymorphic (instance-level) capability queries: unlike the
         // type-keyed overloads above (needed by LSGrid::change_algorithm to
         // route BEFORE a solver is constructed), these ask the CURRENTLY
@@ -390,6 +402,8 @@ class LS2G_API AlgorithmSelector final
         std::unique_ptr<BaseAlgo> _algo;
         AlgorithmType _algo_type;
         std::string _algo_name;  // registry name; survives for plugin solvers
+        // cached SolverOrigin of _algo_name, see is_builtin_algo()
+        bool _algo_is_builtin;
         AlgorithmType _algo_type_used_for_nr;
         const LSGrid* _gridmodel_ptr;
 };

--- a/src/core/BuiltinSolversRegistration.cpp
+++ b/src/core/BuiltinSolversRegistration.cpp
@@ -13,63 +13,73 @@
 namespace ls2g {
 
 void register_builtin_solvers(AlgorithmRegistry& reg) {
-    reg.register_solver("NR_SparseLU",
+    // Every solver registered here is shipped in-tree, so it is tagged
+    // SolverOrigin::Builtin. That tag -- NOT AlgorithmType -- is what tells
+    // lightsim2grid apart from a plugin at run time: AlgorithmType is a fixed enum
+    // of serialized solver identities and the NRRefactorRetry_* family has no
+    // member there, so name_to_algo_type() reports them as AlgorithmType::Custom
+    // exactly like a plugin. Going through this helper means a built-in added later
+    // cannot silently be treated as external by forgetting the tag.
+    const auto add_builtin = [&reg](const std::string& name, AlgorithmRegistry::Factory f) {
+        reg.register_solver(name, std::move(f), ls2g_current_abi_tag(), SolverOrigin::Builtin);
+    };
+    add_builtin("NR_SparseLU",
         []{ return std::make_unique<NR_SparseLU>(); });
-    reg.register_solver("NRSing_SparseLU",
+    add_builtin("NRSing_SparseLU",
         []{ return std::make_unique<NRSing_SparseLU>(); });
-    reg.register_solver("DC_SparseLU",
+    add_builtin("DC_SparseLU",
         []{ return std::make_unique<DC_SparseLU>(); });
-    reg.register_solver("GaussSeidel",
+    add_builtin("GaussSeidel",
         []{ return std::make_unique<GaussSeidelAlgo>(); });
-    reg.register_solver("GaussSeidelSynch",
+    add_builtin("GaussSeidelSynch",
         []{ return std::make_unique<GaussSeidelSynchAlgo>(); });
-    reg.register_solver("FDPF_XB_SparseLU",
+    add_builtin("FDPF_XB_SparseLU",
         []{ return std::make_unique<FDPF_XB_SparseLU>(); });
-    reg.register_solver("FDPF_BX_SparseLU",
+    add_builtin("FDPF_BX_SparseLU",
         []{ return std::make_unique<FDPF_BX_SparseLU>(); });
 
 #ifdef KLU_SOLVER_AVAILABLE
-    reg.register_solver("NR_KLU",
+    add_builtin("NR_KLU",
         []{ return std::make_unique<NR_KLU>(); });
-    reg.register_solver("NRSing_KLU",
+    add_builtin("NRSing_KLU",
         []{ return std::make_unique<NRSing_KLU>(); });
-    reg.register_solver("DC_KLU",
+    add_builtin("DC_KLU",
         []{ return std::make_unique<DC_KLU>(); });
-    reg.register_solver("FDPF_XB_KLU",
+    add_builtin("FDPF_XB_KLU",
         []{ return std::make_unique<FDPF_XB_KLU>(); });
-    reg.register_solver("FDPF_BX_KLU",
+    add_builtin("FDPF_BX_KLU",
         []{ return std::make_unique<FDPF_BX_KLU>(); });
-    reg.register_solver("NRRefactorRetry_KLU",
+    add_builtin("NRRefactorRetry_KLU",
         []{ return std::make_unique<NRRefactorRetry_KLU>(); });
 #endif // KLU_SOLVER_AVAILABLE
 
 #ifdef NICSLU_SOLVER_AVAILABLE
-    reg.register_solver("NR_NICSLU",
+    add_builtin("NR_NICSLU",
         []{ return std::make_unique<NR_NICSLU>(); });
-    reg.register_solver("NRSing_NICSLU",
+    add_builtin("NRSing_NICSLU",
         []{ return std::make_unique<NRSing_NICSLU>(); });
-    reg.register_solver("DC_NICSLU",
+    add_builtin("DC_NICSLU",
         []{ return std::make_unique<DC_NICSLU>(); });
-    reg.register_solver("FDPF_XB_NICSLU",
+    add_builtin("FDPF_XB_NICSLU",
         []{ return std::make_unique<FDPF_XB_NICSLU>(); });
-    reg.register_solver("FDPF_BX_NICSLU",
+    add_builtin("FDPF_BX_NICSLU",
         []{ return std::make_unique<FDPF_BX_NICSLU>(); });
-    reg.register_solver("NRRefactorRetry_NICSLU",
+    add_builtin("NRRefactorRetry_NICSLU",
         []{ return std::make_unique<NRRefactorRetry_NICSLU>(); });
 #endif // NICSLU_SOLVER_AVAILABLE
 
 #ifdef CKTSO_SOLVER_AVAILABLE
-    reg.register_solver("NR_CKTSO",
+    add_builtin("NR_CKTSO",
         []{ return std::make_unique<NR_CKTSO>(); });
-    reg.register_solver("NRSing_CKTSO",
+    add_builtin("NRSing_CKTSO",
         []{ return std::make_unique<NRSing_CKTSO>(); });
-    reg.register_solver("DC_CKTSO",
+    add_builtin("DC_CKTSO",
         []{ return std::make_unique<DC_CKTSO>(); });
-    reg.register_solver("FDPF_XB_CKTSO",
+    add_builtin("FDPF_XB_CKTSO",
         []{ return std::make_unique<FDPF_XB_CKTSO>(); });
-    reg.register_solver("FDPF_BX_CKTSO",
+    add_builtin("FDPF_BX_CKTSO",
         []{ return std::make_unique<FDPF_BX_CKTSO>(); });
-    reg.register_solver("NRRefactorRetry_CKTSO",
+    add_builtin("NRRefactorRetry_CKTSO",
         []{ return std::make_unique<NRRefactorRetry_CKTSO>(); });
 #endif // CKTSO_SOLVER_AVAILABLE
 }

--- a/src/core/LSGrid.cpp
+++ b/src/core/LSGrid.cpp
@@ -246,7 +246,19 @@ void LSGrid::set_state(LSGrid::StateRes & my_state, bool restore_algorithm)
         set_dc_algo_config(dc_algo_cfg);
     }
 
-    // relevant kwargs the grid was built with (eg by init_from_pypowsybl)
+    // relevant kwargs the grid was built with (eg by init_from_pypowsybl).
+    // The map is serialized as two parallel vectors, whose lengths are stored
+    // independently (both in a pickle and in the binary format): a file declaring
+    // more keys than values makes the loop below read past the end of
+    // init_kwargs_values -- an out-of-bounds read over std::string objects, ie
+    // constructing a std::string from whatever the heap holds there. Check first.
+    if (init_kwargs_keys.size() != init_kwargs_values.size()) {
+        std::ostringstream exc_;
+        exc_ << "LSGrid::set_state: the serialized `_init_kwargs` is inconsistent: "
+             << init_kwargs_keys.size() << " keys but " << init_kwargs_values.size()
+             << " values. They are two parallel vectors and must have the same length.";
+        throw std::runtime_error(exc_.str());
+    }
     init_kwargs_.clear();
     for (std::size_t i = 0; i < init_kwargs_keys.size(); ++i) {
         init_kwargs_[init_kwargs_keys[i]] = init_kwargs_values[i];
@@ -316,6 +328,12 @@ void LSGrid::_restore_algorithm(AlgorithmSelector & algo_selector,
 
 void LSGrid::check_grid() const
 {
+    // The substation container FIRST: it defines nb_bus / nb_sub, the bounds every
+    // per-element check below is expressed against, and it carries the vector
+    // (bus_status_) those very ids are used to index. Validating elements against a
+    // self-inconsistent substation container would prove nothing.
+    substations_.check_valid();
+
     const int nb_bus = static_cast<int>(substations_.nb_bus());
     const int nb_sub = substations_.nb_sub();
 
@@ -362,6 +380,65 @@ void LSGrid::check_grid() const
             seen[pos] = 1;
         }
     }
+
+    // Bus-id mapping vectors carried alongside the grid. They are never read by the
+    // C++ powerflow itself (only by downstream python result views), but they are
+    // part of the serialized state, they are sized against the grid, and
+    // set_ls_to_orig_internal() indexes _orig_to_ls with the *values* of
+    // _ls_to_orig -- so an inconsistent pair is exactly the kind of thing this
+    // function exists to reject rather than discover later.
+    if(_ls_to_orig.size() != 0)
+    {
+        if(static_cast<size_t>(_ls_to_orig.size()) != substations_.nb_bus())
+        {
+            std::ostringstream exc_;
+            exc_ << "LSGrid::check_grid: _ls_to_orig has " << _ls_to_orig.size()
+                 << " entries while the grid has " << substations_.nb_bus()
+                 << " buses (it is indexed by lightsim bus id).";
+            throw std::runtime_error(exc_.str());
+        }
+        check_ls_to_orig_values(_ls_to_orig);
+    }
+    if(_orig_to_ls.size() != 0)
+    {
+        const int nb_bus_ls = static_cast<int>(substations_.nb_bus());
+        for(Eigen::Index i = 0; i < _orig_to_ls.size(); ++i)
+        {
+            const int ls_id = _orig_to_ls(i);
+            if(ls_id == GenericContainer::_deactivated_bus_id) continue;
+            if((ls_id < 0) || (ls_id >= nb_bus_ls))
+            {
+                std::ostringstream exc_;
+                exc_ << "LSGrid::check_grid: _orig_to_ls[" << i << "] = " << ls_id
+                     << " is out of range: it must be -1 or a lightsim bus id in [0, "
+                     << nb_bus_ls << ").";
+                throw std::out_of_range(exc_.str());
+            }
+        }
+    }
+    if(_bus_fusion_rep.size() != 0)
+    {
+        const int nb_bus_ls = static_cast<int>(substations_.nb_bus());
+        if(static_cast<size_t>(_bus_fusion_rep.size()) != substations_.nb_bus())
+        {
+            std::ostringstream exc_;
+            exc_ << "LSGrid::check_grid: _bus_fusion_rep has " << _bus_fusion_rep.size()
+                 << " entries while the grid has " << substations_.nb_bus() << " buses.";
+            throw std::runtime_error(exc_.str());
+        }
+        for(Eigen::Index i = 0; i < _bus_fusion_rep.size(); ++i)
+        {
+            const int rep = _bus_fusion_rep(i);
+            if((rep < 0) || (rep >= nb_bus_ls))
+            {
+                std::ostringstream exc_;
+                exc_ << "LSGrid::check_grid: _bus_fusion_rep[" << i << "] = " << rep
+                     << " is out of range [0, " << nb_bus_ls << "): every bus must be merged into "
+                     << "an existing bus (identity for a bus involved in no fusion).";
+                throw std::out_of_range(exc_.str());
+            }
+        }
+    }
 }
 
 void LSGrid::save_binary(const std::string & path, bool atomic) const {
@@ -390,7 +467,45 @@ void LSGrid::set_ls_to_orig(const Eigen::Ref<const IntVect> & ls_to_orig){
 
     if(static_cast<size_t>(ls_to_orig.size()) != substations_.nb_bus())
         throw std::runtime_error("Impossible to set the converter ls_to_orig: the provided vector has not the same size as the number of bus on the grid.");
+    check_ls_to_orig_values(ls_to_orig);
     set_ls_to_orig_internal(ls_to_orig);
+}
+
+// Every entry of _ls_to_orig is either -1 ("this lightsim bus has no counterpart in
+// the original grid") or an original-grid bus id, which set_ls_to_orig_internal uses
+// *as an index* into the _orig_to_ls it allocates. That allocation is sized from
+// `lpNorm<Infinity>()`, ie the max ABSOLUTE value, so a negative entry other than -1
+// (say -5) sizes the vector from |−5| and then writes at index −5: an out-of-bounds
+// heap write. A huge positive entry is the other end of the same problem (`size + 1`
+// overflows int for INT_MAX, and even short of that it asks for a multi-gigabyte
+// allocation for a handful of buses). Both are rejected here, before any allocation.
+// This runs on the python property setter AND on set_state(), ie on every pickle and
+// every binary file.
+void LSGrid::check_ls_to_orig_values(const Eigen::Ref<const IntVect> & ls_to_orig)
+{
+    // an original grid can never have more buses than the biggest vector we could
+    // possibly want to allocate for it; keep the bound generous but finite.
+    constexpr int max_orig_bus_id = 100000000;  // 100M buses, ~400 MB for _orig_to_ls
+    for(Eigen::Index i = 0; i < ls_to_orig.size(); ++i){
+        const int el = ls_to_orig(i);
+        if(el == GenericContainer::_deactivated_bus_id) continue;  // -1: no counterpart, legal
+        if(el < 0){
+            std::ostringstream exc_;
+            exc_ << "LSGrid::set_ls_to_orig: ls_to_orig[" << i << "] = " << el
+                 << " is negative. Entries must be either -1 (this bus has no counterpart in the "
+                 << "original grid) or a valid original-grid bus id >= 0 (it is used as an index "
+                 << "into the reverse mapping).";
+            throw std::out_of_range(exc_.str());
+        }
+        if(el > max_orig_bus_id){
+            std::ostringstream exc_;
+            exc_ << "LSGrid::set_ls_to_orig: ls_to_orig[" << i << "] = " << el
+                 << " exceeds the maximum supported original-grid bus id (" << max_orig_bus_id
+                 << "). The reverse mapping is sized from the largest id, so this would ask for "
+                 << "an unreasonable allocation.";
+            throw std::out_of_range(exc_.str());
+        }
+    }
 }
 
 void LSGrid::set_orig_to_ls(const Eigen::Ref<const IntVect> & orig_to_ls){
@@ -399,21 +514,35 @@ void LSGrid::set_orig_to_ls(const Eigen::Ref<const IntVect> & orig_to_ls){
         _orig_to_ls = IntVect();
         return;
     }
-    _orig_to_ls = orig_to_ls;
     size_t nb_bus_ls = 0;
     for(const auto el : orig_to_ls){
         if (el != -1) nb_bus_ls += 1;
     }
-    if(nb_bus_ls != substations_.nb_bus()) 
+    if(nb_bus_ls != substations_.nb_bus())
         throw std::runtime_error("Impossible to set the converter orig_to_ls: the number of 'non -1' component in the provided vector does not match the number of buses on the grid.");
-    _ls_to_orig = IntVect::Constant(nb_bus_ls, -1);
-    size_t ls2or_ind = 0;
-    for(size_t or2ls_ind = 0; or2ls_ind < nb_bus_ls; ++or2ls_ind){
-        const auto my_ind = _orig_to_ls[or2ls_ind];
-        if(my_ind >= 0){
-            _ls_to_orig[ls2or_ind] = my_ind;
-            ls2or_ind++;
+    // orig_to_ls[orig_bus_id] is a LIGHTSIM bus id, used below as an index into
+    // _ls_to_orig (which has one slot per lightsim bus): validate the range before
+    // writing anything, an unchecked entry here is an out-of-bounds heap write.
+    for(Eigen::Index i = 0; i < orig_to_ls.size(); ++i){
+        const int ls_id = orig_to_ls(i);
+        if(ls_id == GenericContainer::_deactivated_bus_id) continue;  // -1: this original bus has no lightsim bus
+        if((ls_id < 0) || (static_cast<size_t>(ls_id) >= nb_bus_ls)){
+            std::ostringstream exc_;
+            exc_ << "LSGrid::set_orig_to_ls: orig_to_ls[" << i << "] = " << ls_id
+                 << " is out of range: entries must be either -1 (this original bus has no "
+                 << "counterpart in lightsim2grid) or a lightsim bus id in [0, " << nb_bus_ls << ").";
+            throw std::out_of_range(exc_.str());
         }
+    }
+    // _ls_to_orig is the INVERSE of _orig_to_ls: _ls_to_orig[ls_id] == orig_id iff
+    // _orig_to_ls[orig_id] == ls_id. Walk the whole input (not just its first
+    // nb_bus_ls entries -- the non -1 ones are not necessarily at the front) and
+    // index the result by the lightsim id, so the two arrays really are inverses.
+    _orig_to_ls = orig_to_ls;
+    _ls_to_orig = IntVect::Constant(nb_bus_ls, -1);
+    for(Eigen::Index orig_id = 0; orig_id < _orig_to_ls.size(); ++orig_id){
+        const int ls_id = _orig_to_ls(orig_id);
+        if(ls_id >= 0) _ls_to_orig[ls_id] = static_cast<int>(orig_id);
     }
 }
 
@@ -1799,6 +1928,29 @@ void LSGrid::update_storages_p(const Eigen::Ref<const Eigen::Array<bool, Eigen::
 void LSGrid::update_topo(const Eigen::Ref<const Eigen::Array<bool, Eigen::Dynamic, Eigen::RowMajor> > & has_changed,
                             const Eigen::Ref<const Eigen::Array<int,  Eigen::Dynamic, Eigen::RowMajor> > & new_values)
 {
+    // Both arrays come straight from python and are indexed BY POSITION IN THE
+    // TOPOLOGY VECTOR: each container does `has_changed(pos_topo_vect_(el_id))` /
+    // `new_values(pos_topo_vect_(el_id))` with an unchecked Eigen operator(). The
+    // positions themselves are validated (check_grid() proves they form a
+    // permutation of [0, dim_topo)), but nothing checked that the caller's arrays
+    // are dim_topo long -- a shorter one reads past its end. dim_topo is exactly
+    // the number of topology-participating element sides, so compute it and demand
+    // both arrays match it.
+    const Eigen::Index dim_topo =
+        static_cast<Eigen::Index>(loads_.nb()) +
+        static_cast<Eigen::Index>(generators_.nb()) +
+        static_cast<Eigen::Index>(storages_.nb()) +
+        2 * static_cast<Eigen::Index>(powerlines_.nb()) +
+        2 * static_cast<Eigen::Index>(trafos_.nb());
+    if((has_changed.rows() != dim_topo) || (new_values.rows() != dim_topo)){
+        std::ostringstream exc_;
+        exc_ << "LSGrid::update_topo: 'has_changed' (size " << has_changed.rows()
+             << ") and 'new_values' (size " << new_values.rows() << ") must both have the size of "
+             << "the topology vector (" << dim_topo << " = nb loads + nb gens + nb storages + "
+             << "2 * nb lines + 2 * nb trafos). They are indexed by position in the topology "
+             << "vector, so a shorter array would be read out of bounds.";
+        throw std::runtime_error(exc_.str());
+    }
     loads_.update_topo(has_changed, new_values, algo_controler_, substations_);
     generators_.update_topo(has_changed, new_values, algo_controler_, substations_);
     storages_.update_topo(has_changed, new_values, algo_controler_, substations_);

--- a/src/core/LSGrid.cpp
+++ b/src/core/LSGrid.cpp
@@ -546,7 +546,8 @@ void LSGrid::set_orig_to_ls(const Eigen::Ref<const IntVect> & orig_to_ls){
     }
 }
 
-void LSGrid::set_ls_to_orig_internal(const Eigen::Ref<const IntVect> & ls_to_orig) noexcept{
+// NB deliberately NOT noexcept -- it allocates, see the declaration in LSGrid.hpp.
+void LSGrid::set_ls_to_orig_internal(const Eigen::Ref<const IntVect> & ls_to_orig){
     if(ls_to_orig.size() == 0){
         _ls_to_orig = IntVect();
         _orig_to_ls = IntVect();
@@ -1388,11 +1389,20 @@ void LSGrid::process_results(bool conv,
         // voltages. Validate their size/finiteness before we index them below
         // (compute_results / _get_results_back_to_orig_nodes both index the solver
         // vectors with an unchecked operator()).
-        // Only external solvers are checked: AlgorithmType::Custom is precisely
-        // "not one of the built-in solvers" (see name_to_algo_type), and the
-        // built-in ones are covered by the test suite, so they pay nothing here.
+        // Only external solvers are checked: the built-in ones are covered by the
+        // test suite, so they pay nothing here.
+        //
+        // "Is it built-in?" is asked of the REGISTRY, which records it at
+        // registration time (SolverOrigin), not of AlgorithmType. Gating on
+        // `get_type() == AlgorithmType::Custom` was wrong: AlgorithmType is a fixed
+        // enum of serialized solver identities, and a built-in only has a member
+        // there if one was added for it -- the NRRefactorRetry_* family never got
+        // one, so name_to_algo_type() reports those three built-ins as Custom
+        // exactly like a plugin, and they were paying for this check on every
+        // single solve. The flag is cached by AlgorithmSelector::change_algorithm,
+        // so this stays a bool read on the hot path.
         const bool is_external_algo =
-            (ac ? _algo.get_type() : _dc_algo.get_type()) == AlgorithmType::Custom;
+            !(ac ? _algo.is_builtin_algo() : _dc_algo.is_builtin_algo());
         if (is_external_algo) conv = _check_solver_output(ac);
     }
     if (conv){

--- a/src/core/LSGrid.hpp
+++ b/src/core/LSGrid.hpp
@@ -1824,7 +1824,13 @@ class LS2G_API LSGrid final
         }
 
     protected:
-        void set_ls_to_orig_internal(const Eigen::Ref<const IntVect> & ls_to_orig) noexcept;  // set both _ls_to_orig and _orig_to_ls
+        // set both _ls_to_orig and _orig_to_ls. `noexcept`, and it indexes
+        // _orig_to_ls with the values of `ls_to_orig`: only ever call it on a vector
+        // that check_ls_to_orig_values() has already accepted (set_ls_to_orig does).
+        void set_ls_to_orig_internal(const Eigen::Ref<const IntVect> & ls_to_orig) noexcept;
+        // throws std::out_of_range unless every entry is -1 or a sane, non-negative
+        // original-grid bus id -- see the definition in LSGrid.cpp for why.
+        static void check_ls_to_orig_values(const Eigen::Ref<const IntVect> & ls_to_orig);
 
         // init the Ybus matrix (its size, it is filled up elsewhere) and also the 
         // converter from "my bus id" to the "solver bus id" (id_me_to_solver and id_solver_to_me)

--- a/src/core/LSGrid.hpp
+++ b/src/core/LSGrid.hpp
@@ -1824,10 +1824,19 @@ class LS2G_API LSGrid final
         }
 
     protected:
-        // set both _ls_to_orig and _orig_to_ls. `noexcept`, and it indexes
-        // _orig_to_ls with the values of `ls_to_orig`: only ever call it on a vector
-        // that check_ls_to_orig_values() has already accepted (set_ls_to_orig does).
-        void set_ls_to_orig_internal(const Eigen::Ref<const IntVect> & ls_to_orig) noexcept;
+        // Set both _ls_to_orig and _orig_to_ls.
+        //
+        // NOT noexcept (it used to be declared so, wrongly): it assigns one Eigen
+        // vector and allocates another, either of which throws std::bad_alloc on
+        // failure -- and a throw out of a noexcept function is not an error the
+        // caller can handle, it is an immediate std::terminate(). Nothing needs the
+        // guarantee (the only callers are the copy constructor and set_ls_to_orig,
+        // neither of them noexcept), so the honest declaration is the plain one.
+        //
+        // It indexes _orig_to_ls with the *values* of `ls_to_orig`: only ever call
+        // it on a vector check_ls_to_orig_values() has already accepted, as
+        // set_ls_to_orig does.
+        void set_ls_to_orig_internal(const Eigen::Ref<const IntVect> & ls_to_orig);
         // throws std::out_of_range unless every entry is -1 or a sane, non-negative
         // original-grid bus id -- see the definition in LSGrid.cpp for why.
         static void check_ls_to_orig_values(const Eigen::Ref<const IntVect> & ls_to_orig);

--- a/src/core/SubstationContainer.cpp
+++ b/src/core/SubstationContainer.cpp
@@ -9,7 +9,9 @@
 #include "SubstationContainer.hpp"
 #include "BinaryArchive.hpp"
 
+#include <cstdint>
 #include <iostream>
+#include <limits>
 #include <sstream>
 
 namespace ls2g {
@@ -34,28 +36,156 @@ SubstationContainer::StateRes SubstationContainer::get_state() const
 
 void SubstationContainer::set_state(SubstationContainer::StateRes & my_state)
 {
-    n_sub_ = std::get<0>(my_state);
-    nmax_busbar_per_sub_ = std::get<1>(my_state);
-    n_bus_max_ = n_sub_ * nmax_busbar_per_sub_;
-
-    // the generators themelves
+    // NB every field below comes straight from a pickle or a binary file, ie from
+    // outside the C++ core. This container is the *root* of the grid's index space:
+    // `nb_bus()` (= bus_vn_kv_.size()) is the upper bound LSGrid::check_grid()
+    // validates every element's bus id against, while `bus_status_` is what
+    // `is_bus_connected()` / `disconnect_all_buses()` actually index with those same
+    // ids, and `n_sub_` is both the substation-id bound and a modulo divisor
+    // (sub_id_of_bus). Nothing downstream re-derives these from each other, so if
+    // they are allowed to disagree here, a *validated* bus id still reads and writes
+    // past the end of bus_status_ -- release wheels are built -O3 -DNDEBUG, so
+    // neither Eigen nor the standard library catches it. Validate them all now,
+    // before anything is assigned.
+    const int n_sub = std::get<0>(my_state);
+    const int nmax_busbar_per_sub = std::get<1>(my_state);
     std::vector<real_type> & sub_vn_kv = std::get<2>(my_state);
     std::vector<bool> & bus_status = std::get<3>(my_state);
     std::vector<real_type> & bus_vn_kv = std::get<4>(my_state);
+    const std::vector<std::string> & sub_names = std::get<5>(my_state);
+    std::vector<real_type> & bus_vmin_kv = std::get<6>(my_state);
+    std::vector<real_type> & bus_vmax_kv = std::get<7>(my_state);
 
-    // check sizes
-    // TODO dev switches
+    // a default-constructed container has n_sub_ == nmax_busbar_per_sub_ == -1 and
+    // no bus at all: that state must still round-trip, so it is the one case where
+    // negative counts are legal.
+    const bool is_empty = bus_vn_kv.empty() && bus_status.empty();
+    if(!(is_empty && (n_sub <= 0) && (nmax_busbar_per_sub <= 0)))
+    {
+        if(n_sub <= 0){
+            std::ostringstream exc_;
+            exc_ << "SubstationContainer::set_state: the number of substations must be strictly "
+                 << "positive on a grid that has buses, got " << n_sub << " (it is also used as a "
+                 << "modulo divisor in sub_id_of_bus, so 0 would be a division by zero).";
+            throw std::runtime_error(exc_.str());
+        }
+        if(nmax_busbar_per_sub <= 0){
+            std::ostringstream exc_;
+            exc_ << "SubstationContainer::set_state: the maximum number of busbars per substation "
+                 << "must be strictly positive, got " << nmax_busbar_per_sub << ".";
+            throw std::runtime_error(exc_.str());
+        }
+        // n_sub_ * nmax_busbar_per_sub_ is stored in an int: reject a product that
+        // does not fit rather than letting it overflow (UB, and a negative bus count).
+        if(nmax_busbar_per_sub > std::numeric_limits<int>::max() / n_sub){
+            std::ostringstream exc_;
+            exc_ << "SubstationContainer::set_state: n_sub (" << n_sub << ") * nmax_busbar_per_sub ("
+                 << nmax_busbar_per_sub << ") overflows the maximum number of buses representable.";
+            throw std::runtime_error(exc_.str());
+        }
+    }
+    const std::int64_t n_bus_max = static_cast<std::int64_t>(n_sub) * static_cast<std::int64_t>(nmax_busbar_per_sub);
 
-    // assign data
+    // bus_vn_kv_ defines nb_bus(), the bound every other index is checked against;
+    // bus_status_ is indexed with those same ids and MUST match it exactly.
+    const auto check_len = [](std::size_t actual, std::int64_t expected, const char * name){
+        if(static_cast<std::int64_t>(actual) != expected){
+            std::ostringstream exc_;
+            exc_ << "SubstationContainer::set_state: '" << name << "' has " << actual
+                 << " elements but " << expected << " were expected. The grid state is inconsistent "
+                 << "(this field is indexed with ids validated against another one, so a mismatch "
+                 << "would cause an out-of-bounds access).";
+            throw std::runtime_error(exc_.str());
+        }
+    };
+    if(!is_empty) check_len(bus_vn_kv.size(), n_bus_max, "bus_vn_kv");
+    check_len(bus_status.size(), static_cast<std::int64_t>(bus_vn_kv.size()), "bus_status");
+    // Optional fields: either absent, or fully sized. sub_vn_kv_ and sub_names_ are
+    // only filled by init_sub() / init_sub_names(), which the usual init_bus() path
+    // does not call -- so "empty" is the normal state for most grids, NOT a defect.
+    if(!sub_vn_kv.empty()) check_len(sub_vn_kv.size(), n_sub, "sub_vn_kv");
+    if(!sub_names.empty()) check_len(sub_names.size(), n_sub, "sub_names");
+    if(!bus_vmin_kv.empty()) check_len(bus_vmin_kv.size(), static_cast<std::int64_t>(bus_vn_kv.size()), "bus_vmin_kv");
+    if(!bus_vmax_kv.empty()) check_len(bus_vmax_kv.size(), static_cast<std::int64_t>(bus_vn_kv.size()), "bus_vmax_kv");
+
+    // assign data (nothing above has modified `this`, so a rejected state leaves
+    // the container untouched)
+    n_sub_ = n_sub;
+    nmax_busbar_per_sub_ = nmax_busbar_per_sub;
+    n_bus_max_ = static_cast<int>(n_bus_max);
     sub_vn_kv_ = RealVect::Map(sub_vn_kv.data(), sub_vn_kv.size());
     bus_status_ = bus_status;
     bus_vn_kv_ = RealVect::Map(bus_vn_kv.data(), bus_vn_kv.size());
-    sub_names_ = std::get<5>(my_state);
-
-    std::vector<real_type> & bus_vmin_kv = std::get<6>(my_state);
-    std::vector<real_type> & bus_vmax_kv = std::get<7>(my_state);
+    sub_names_ = sub_names;
     bus_vmin_kv_ = bus_vmin_kv.empty() ? RealVect() : RealVect::Map(bus_vmin_kv.data(), bus_vmin_kv.size());
     bus_vmax_kv_ = bus_vmax_kv.empty() ? RealVect() : RealVect::Map(bus_vmax_kv.data(), bus_vmax_kv.size());
+}
+
+void SubstationContainer::check_valid() const
+{
+    // a default-constructed / never-initialized container is consistent by
+    // definition: it has no bus at all, so nothing can index into it.
+    if((bus_vn_kv_.size() == 0) && bus_status_.empty()) return;
+
+    if(n_sub_ <= 0){
+        std::ostringstream exc_;
+        exc_ << "LSGrid::check_grid: the grid declares " << n_sub_ << " substation(s) but has "
+             << bus_vn_kv_.size() << " buses. The number of substations must be strictly positive "
+             << "(it is also used as a modulo divisor in sub_id_of_bus).";
+        throw std::runtime_error(exc_.str());
+    }
+    if(nmax_busbar_per_sub_ <= 0){
+        std::ostringstream exc_;
+        exc_ << "LSGrid::check_grid: the grid declares " << nmax_busbar_per_sub_
+             << " busbar(s) per substation; it must be strictly positive.";
+        throw std::runtime_error(exc_.str());
+    }
+    // bus_status_ is indexed with the very bus ids check_grid() validates against
+    // nb_bus() (= bus_vn_kv_.size()), and disconnect_all_buses() writes nb_bus()
+    // entries into it: the two must have exactly the same length.
+    if(bus_status_.size() != static_cast<std::size_t>(bus_vn_kv_.size())){
+        std::ostringstream exc_;
+        exc_ << "LSGrid::check_grid: the bus status vector has " << bus_status_.size()
+             << " entries while the grid has " << bus_vn_kv_.size() << " buses. Both are indexed "
+             << "by bus id and must have the same length.";
+        throw std::runtime_error(exc_.str());
+    }
+    if(static_cast<std::int64_t>(bus_vn_kv_.size()) !=
+       static_cast<std::int64_t>(n_sub_) * static_cast<std::int64_t>(nmax_busbar_per_sub_)){
+        std::ostringstream exc_;
+        exc_ << "LSGrid::check_grid: the grid has " << bus_vn_kv_.size() << " buses but declares "
+             << n_sub_ << " substations of at most " << nmax_busbar_per_sub_ << " busbars ("
+             << static_cast<std::int64_t>(n_sub_) * static_cast<std::int64_t>(nmax_busbar_per_sub_)
+             << " buses). Bus ids are laid out as `sub_id + (busbar - 1) * n_sub`, so both must match.";
+        throw std::runtime_error(exc_.str());
+    }
+    // optional fields: either absent, or one entry per substation / per bus.
+    // sub_vn_kv_ / sub_names_ are only filled by init_sub() / init_sub_names(),
+    // which the usual init_bus() path does not call: empty is the normal state.
+    if((sub_vn_kv_.size() != 0) && (sub_vn_kv_.size() != n_sub_)){
+        std::ostringstream exc_;
+        exc_ << "LSGrid::check_grid: the substation nominal-voltage vector has " << sub_vn_kv_.size()
+             << " entries for " << n_sub_ << " substations (it must be either empty or complete).";
+        throw std::runtime_error(exc_.str());
+    }
+    if(!sub_names_.empty() && (sub_names_.size() != static_cast<std::size_t>(n_sub_))){
+        std::ostringstream exc_;
+        exc_ << "LSGrid::check_grid: the substation names vector has " << sub_names_.size()
+             << " entries for " << n_sub_ << " substations (it must be either empty or complete).";
+        throw std::runtime_error(exc_.str());
+    }
+    if((bus_vmin_kv_.size() != 0) && (bus_vmin_kv_.size() != bus_vn_kv_.size())){
+        std::ostringstream exc_;
+        exc_ << "LSGrid::check_grid: the per-bus min voltage vector has " << bus_vmin_kv_.size()
+             << " entries for " << bus_vn_kv_.size() << " buses (it must be either empty or complete).";
+        throw std::runtime_error(exc_.str());
+    }
+    if((bus_vmax_kv_.size() != 0) && (bus_vmax_kv_.size() != bus_vn_kv_.size())){
+        std::ostringstream exc_;
+        exc_ << "LSGrid::check_grid: the per-bus max voltage vector has " << bus_vmax_kv_.size()
+             << " entries for " << bus_vn_kv_.size() << " buses (it must be either empty or complete).";
+        throw std::runtime_error(exc_.str());
+    }
 }
 
 void SubstationContainer::save_binary(const std::string & path, bool atomic) const {

--- a/src/core/SubstationContainer.cpp
+++ b/src/core/SubstationContainer.cpp
@@ -60,32 +60,15 @@ void SubstationContainer::set_state(SubstationContainer::StateRes & my_state)
     // no bus at all: that state must still round-trip, so it is the one case where
     // negative counts are legal.
     const bool is_empty = bus_vn_kv.empty() && bus_status.empty();
-    if(!(is_empty && (n_sub <= 0) && (nmax_busbar_per_sub <= 0)))
-    {
-        if(n_sub <= 0){
-            std::ostringstream exc_;
-            exc_ << "SubstationContainer::set_state: the number of substations must be strictly "
-                 << "positive on a grid that has buses, got " << n_sub << " (it is also used as a "
-                 << "modulo divisor in sub_id_of_bus, so 0 would be a division by zero).";
-            throw std::runtime_error(exc_.str());
-        }
-        if(nmax_busbar_per_sub <= 0){
-            std::ostringstream exc_;
-            exc_ << "SubstationContainer::set_state: the maximum number of busbars per substation "
-                 << "must be strictly positive, got " << nmax_busbar_per_sub << ".";
-            throw std::runtime_error(exc_.str());
-        }
-        // n_sub_ * nmax_busbar_per_sub_ is stored in an int: reject a product that
-        // does not fit rather than letting it overflow (UB, and a negative bus count).
-        if(nmax_busbar_per_sub > std::numeric_limits<int>::max() / n_sub){
-            std::ostringstream exc_;
-            exc_ << "SubstationContainer::set_state: n_sub (" << n_sub << ") * nmax_busbar_per_sub ("
-                 << nmax_busbar_per_sub << ") overflows the maximum number of buses representable.";
-            throw std::runtime_error(exc_.str());
-        }
-    }
-    const std::int64_t n_bus_max = static_cast<std::int64_t>(n_sub) * static_cast<std::int64_t>(nmax_busbar_per_sub);
+    // positivity + no int overflow on n_sub * nmax_busbar_per_sub, the same guarantee
+    // init_bus() / init_sub() get from the same helper.
+    const std::int64_t n_bus_max = is_empty
+        ? std::int64_t{0}
+        : static_cast<std::int64_t>(checked_nb_bus(n_sub, nmax_busbar_per_sub,
+                                                   "SubstationContainer::set_state"));
 
+    // check sizes
+    // TODO dev switches
     // bus_vn_kv_ defines nb_bus(), the bound every other index is checked against;
     // bus_status_ is indexed with those same ids and MUST match it exactly.
     const auto check_len = [](std::size_t actual, std::int64_t expected, const char * name){
@@ -186,6 +169,9 @@ void SubstationContainer::check_valid() const
              << " entries for " << bus_vn_kv_.size() << " buses (it must be either empty or complete).";
         throw std::runtime_error(exc_.str());
     }
+
+    // every nominal voltage must be a finite, strictly positive number
+    check_vn_kv_positive();
 
     // All busbars of a substation share its nominal voltage. init_bus() is supposed
     // to enforce this at build time, but set_state() bypasses init_bus() entirely,

--- a/src/core/SubstationContainer.cpp
+++ b/src/core/SubstationContainer.cpp
@@ -186,6 +186,28 @@ void SubstationContainer::check_valid() const
              << " entries for " << bus_vn_kv_.size() << " buses (it must be either empty or complete).";
         throw std::runtime_error(exc_.str());
     }
+
+    // All busbars of a substation share its nominal voltage. init_bus() is supposed
+    // to enforce this at build time, but set_state() bypasses init_bus() entirely,
+    // so a pickle / binary file could always carry a grid violating it. Re-check
+    // here, which is the point of check_grid().
+    check_bus_vn_kv_uniform_per_sub();
+
+    // sub_vn_kv_ is optional (see the note on StateRes), but when it IS present it
+    // is by definition the common nominal voltage of each substation's busbars,
+    // i.e. bus_vn_kv_ restricted to the first n_sub_ bus ids (busbar 1 of each
+    // substation). A stored value disagreeing with that is an inconsistent state.
+    if(sub_vn_kv_.size() != 0){
+        for(int sub_id = 0; sub_id < n_sub_; ++sub_id){
+            if(std::abs(sub_vn_kv_(sub_id) - bus_vn_kv_(sub_id)) > BaseConstants::_tol_equal_float){
+                std::ostringstream exc_;
+                exc_ << "LSGrid::check_grid: substation " << sub_id << " declares a nominal voltage of "
+                     << sub_vn_kv_(sub_id) << " kV but its buses carry " << bus_vn_kv_(sub_id)
+                     << " kV. Both must agree.";
+                throw std::runtime_error(exc_.str());
+            }
+        }
+    }
 }
 
 void SubstationContainer::save_binary(const std::string & path, bool atomic) const {

--- a/src/core/SubstationContainer.hpp
+++ b/src/core/SubstationContainer.hpp
@@ -15,7 +15,9 @@
 #include <stdio.h>
 #include <cstdint> // for int32
 #include <chrono>
-#include <cmath>  // for PI
+#include <cmath>  // for PI, std::abs
+#include <sstream>
+#include <stdexcept>
 
 #include "Utils.hpp"
 #include "BaseConstants.hpp"
@@ -58,7 +60,16 @@ class LS2G_API SubstationContainer final : public IteratorAdder<SubstationContai
         using StateRes = std::tuple<
             int,  // n_sub_
             int,  // nmax_busbar_per_sub
-            std::vector<real_type>, // sub_vn_kv_;
+            // sub_vn_kv_: OPTIONAL, and empty in practice on every grid produced
+            // today. It is only ever filled by init_sub() / the two-argument
+            // constructor, neither of which is called anywhere (the live path is
+            // the default constructor + init_bus(), which fills bus_vn_kv_ only),
+            // and nothing reads it back. It is therefore NOT valid to require it
+            // whenever bus_vn_kv_ is set: doing so rejects every grid built by
+            // init_from_pandapower / _pypowsybl / _matpower / _powermodels, and
+            // every already-saved binary file -- including this repo's own
+            // format-4 compatibility fixture (tests/binary_format_fixture).
+            std::vector<real_type>, // sub_vn_kv_ (optional, see above)
             std::vector<bool>,  // bus_status_;
             std::vector<real_type>,  // bus_vn_kv_;
             std::vector<std::string>,  // sub_names_
@@ -102,13 +113,31 @@ class LS2G_API SubstationContainer final : public IteratorAdder<SubstationContai
         ~SubstationContainer() noexcept = default;
 
         void reset_bus_status(){
-            for(auto i = 0; i < n_bus_max_; ++ i) bus_status_[i] = false;
+            // iterate the vector actually being written, not n_bus_max_ (a separate
+            // field): set_state() now guarantees they agree, but not depending on
+            // that invariant costs nothing and cannot go wrong if it is ever broken.
+            const std::size_t nb_bus_total = bus_status_.size();
+            for(std::size_t i = 0; i < nb_bus_total; ++ i) bus_status_[i] = false;
         }
 
         void init_sub(const Eigen::Ref<const RealVect> & sub_vn_kv){
+            if((n_sub_ <= 0) || (nmax_busbar_per_sub_ <= 0)){
+                throw std::runtime_error("SubstationContainer::init_sub: the substations must be declared "
+                                         "first (see init_bus / the two-argument constructor).");
+            }
             if(sub_vn_kv.size() != n_sub_){
                 throw std::range_error("SubstationContainer::init_sub: sub_vn_kv should have the size of the number of substations on the grid.");
             }
+            // Both destinations are written with an unchecked operator[] below, and
+            // neither is guaranteed to be sized yet: only the two-argument
+            // constructor sizes sub_vn_kv_, and the live construction path is the
+            // default constructor followed by init_bus(), which leaves sub_vn_kv_
+            // EMPTY. Writing n_sub_ doubles into it would be an out-of-bounds heap
+            // write. Size both here instead of assuming.
+            const Eigen::Index nb_bus_total =
+                static_cast<Eigen::Index>(n_sub_) * static_cast<Eigen::Index>(nmax_busbar_per_sub_);
+            if(sub_vn_kv_.size() != n_sub_) sub_vn_kv_ = RealVect::Zero(n_sub_);
+            if(bus_vn_kv_.size() != nb_bus_total) bus_vn_kv_ = RealVect::Zero(nb_bus_total);
             for(int i = 0; i < n_sub_; ++i){
                 // store substation vn kv
                 sub_vn_kv_[i] = sub_vn_kv[i];
@@ -193,20 +222,40 @@ class LS2G_API SubstationContainer final : public IteratorAdder<SubstationContai
             bus_status_ = std::vector<bool>(nb_bus(), true); // by default everything is connected
 
             // check that a "substation" always has the same vn_kv for all of its buses
-            for(int sub_id=0; sub_id < n_sub; sub_id++){
-                real_type ref_vn_kv = bus_vn_kv(sub_id);
-                for(int bus_id=1; bus_id < nmax_busbar_per_sub; bus_id++)
-                {
-                    real_type this_bus_vn_kv = bus_vn_kv(local_to_gridmodel(sub_id, LocalBusId(bus_id)).cast_int());
-                    if(abs(this_bus_vn_kv - ref_vn_kv) > BaseConstants::_tol_equal_float){
-                        const std::string msg = R"mydelimiter(
-                        Each bus of each substation must have the same nominal voltage. 
-                        Check substation )mydelimiter" + 
-                        std::to_string(sub_id) + 
-                        " and buses 0 and " + 
-                        std::to_string(bus_id)+".";
+            check_bus_vn_kv_uniform_per_sub();
+        }
 
-                        throw std::runtime_error(msg);
+        /**
+         * Every busbar of a substation must carry the same nominal voltage.
+         *
+         * A gridmodel bus id is laid out as `sub_id + (local_bus_id - 1) * n_sub_`
+         * (see local_to_gridmodel), so the buses of one substation are strided by
+         * **n_sub_**, not by nmax_busbar_per_sub_, and LocalBusId is 1-BASED:
+         * local id 1 is the first busbar (gridmodel id == sub_id), local id
+         * nmax_busbar_per_sub_ is the last one.
+         *
+         * That 1-based convention is what made the original loop here a no-op: it
+         * ran local ids `[1, nmax_busbar_per_sub_)`, so it started by comparing the
+         * reference bus with itself and stopped one busbar short -- with the usual
+         * nmax_busbar_per_sub_ == 2 it compared bus `sub_id` to bus `sub_id` and
+         * checked nothing at all. Hence the range below: local ids 2 .. nmax
+         * inclusive, i.e. every busbar *after* the reference one.
+         */
+        void check_bus_vn_kv_uniform_per_sub() const
+        {
+            for(int sub_id = 0; sub_id < n_sub_; sub_id++){
+                const real_type ref_vn_kv = bus_vn_kv_(sub_id);
+                for(int local_bus_id = 2; local_bus_id <= nmax_busbar_per_sub_; local_bus_id++)
+                {
+                    const int bus_id = local_to_gridmodel(sub_id, LocalBusId(local_bus_id)).cast_int();
+                    const real_type this_bus_vn_kv = bus_vn_kv_(bus_id);
+                    if(std::abs(this_bus_vn_kv - ref_vn_kv) > BaseConstants::_tol_equal_float){
+                        std::ostringstream exc_;
+                        exc_ << "SubstationContainer: each bus of a substation must have the same nominal "
+                             << "voltage. Substation " << sub_id << " has " << ref_vn_kv
+                             << " kV on its busbar 1 (bus id " << sub_id << ") but " << this_bus_vn_kv
+                             << " kV on its busbar " << local_bus_id << " (bus id " << bus_id << ").";
+                        throw std::runtime_error(exc_.str());
                     }
                 }
             }

--- a/src/core/SubstationContainer.hpp
+++ b/src/core/SubstationContainer.hpp
@@ -13,7 +13,8 @@
 #include <vector>
 // #include <set>
 #include <stdio.h>
-#include <cstdint> // for int32
+#include <cstdint> // for int32, int64
+#include <limits>
 #include <chrono>
 #include <cmath>  // for PI, std::abs
 #include <sstream>
@@ -128,16 +129,17 @@ class LS2G_API SubstationContainer final : public IteratorAdder<SubstationContai
             if(sub_vn_kv.size() != n_sub_){
                 throw std::range_error("SubstationContainer::init_sub: sub_vn_kv should have the size of the number of substations on the grid.");
             }
+            // positivity + no int overflow, same guarantee as init_bus: `i + j * n_sub_`
+            // below is int arithmetic
+            const int nb_bus_checked = checked_nb_bus(n_sub_, nmax_busbar_per_sub_, "SubstationContainer::init_sub");
             // Both destinations are written with an unchecked operator[] below, and
             // neither is guaranteed to be sized yet: only the two-argument
             // constructor sizes sub_vn_kv_, and the live construction path is the
             // default constructor followed by init_bus(), which leaves sub_vn_kv_
             // EMPTY. Writing n_sub_ doubles into it would be an out-of-bounds heap
             // write. Size both here instead of assuming.
-            const Eigen::Index nb_bus_total =
-                static_cast<Eigen::Index>(n_sub_) * static_cast<Eigen::Index>(nmax_busbar_per_sub_);
             if(sub_vn_kv_.size() != n_sub_) sub_vn_kv_ = RealVect::Zero(n_sub_);
-            if(bus_vn_kv_.size() != nb_bus_total) bus_vn_kv_ = RealVect::Zero(nb_bus_total);
+            if(bus_vn_kv_.size() != nb_bus_checked) bus_vn_kv_ = RealVect::Zero(nb_bus_checked);
             for(int i = 0; i < n_sub_; ++i){
                 // store substation vn kv
                 sub_vn_kv_[i] = sub_vn_kv[i];
@@ -202,9 +204,74 @@ class LS2G_API SubstationContainer final : public IteratorAdder<SubstationContai
             return bus_status_[local_to_gridmodel(sub_id, local_bus_id).cast_int()];
         }
 
+        /**
+         * `n_sub * nmax_busbar_per_sub` -- the total bus count -- computed safely.
+         *
+         * Both factors reach us from outside the C++ core (init_bus / init_sub
+         * arguments, or a pickle / binary file via set_state), and the product is
+         * stored in an `int` (n_bus_max_) and used in `int` index arithmetic
+         * (`i + j * n_sub`). Computing it directly overflows for large inputs, which
+         * is UB and yields a negative bus count. Do the multiplication in 64 bits and
+         * refuse anything that does not fit, so no caller has to remember to.
+         * `caller` only names the function in the error message.
+         */
+        static int checked_nb_bus(int n_sub, int nmax_busbar_per_sub, const char * caller)
+        {
+            if(n_sub <= 0){
+                std::ostringstream exc_;
+                exc_ << caller << ": the number of substations must be strictly positive, got "
+                     << n_sub << " (it is also used as a modulo divisor in sub_id_of_bus, so 0 "
+                     << "would be a division by zero).";
+                throw std::runtime_error(exc_.str());
+            }
+            if(nmax_busbar_per_sub <= 0){
+                std::ostringstream exc_;
+                exc_ << caller << ": the maximum number of busbars per substation must be strictly "
+                     << "positive, got " << nmax_busbar_per_sub << ".";
+                throw std::runtime_error(exc_.str());
+            }
+            const std::int64_t total = static_cast<std::int64_t>(n_sub) *
+                                       static_cast<std::int64_t>(nmax_busbar_per_sub);
+            if(total > static_cast<std::int64_t>(std::numeric_limits<int>::max())){
+                std::ostringstream exc_;
+                exc_ << caller << ": n_sub (" << n_sub << ") * nmax_busbar_per_sub ("
+                     << nmax_busbar_per_sub << ") = " << total << " buses, which does not fit in the "
+                     << "int used to index them.";
+                throw std::runtime_error(exc_.str());
+            }
+            return static_cast<int>(total);
+        }
+
+        /**
+         * Every bus nominal voltage must be a finite, strictly positive number.
+         *
+         * NB this is deliberately only about `bus_vn_kv_` / `sub_vn_kv_`, never about
+         * bus_vmin_kv_ / bus_vmax_kv_: those use NaN as the documented "no limit set
+         * for this bus" sentinel. Same reason the element-level finiteness checks were
+         * dropped earlier (non-finite thermal limits / reactive bounds are legitimate
+         * sentinels on real grids) -- a NOMINAL voltage has no such convention, 0 or a
+         * negative value is simply meaningless and would silently produce nonsense
+         * per-unit conversions (v_kv_from_vpu multiplies by it).
+         */
+        void check_vn_kv_positive() const
+        {
+            const auto check_one = [](real_type v, int id, const char * what){
+                if(!std::isfinite(v) || (v <= 0.)){
+                    std::ostringstream exc_;
+                    exc_ << "SubstationContainer: " << what << " " << id << " has a nominal voltage of "
+                         << v << " kV; it must be a finite, strictly positive number.";
+                    throw std::runtime_error(exc_.str());
+                }
+            };
+            for(Eigen::Index i = 0; i < bus_vn_kv_.size(); ++i) check_one(bus_vn_kv_(i), static_cast<int>(i), "bus");
+            for(Eigen::Index i = 0; i < sub_vn_kv_.size(); ++i) check_one(sub_vn_kv_(i), static_cast<int>(i), "substation");
+        }
+
         void init_bus(int n_sub, int nmax_busbar_per_sub, const Eigen::Ref<const RealVect> & bus_vn_kv)
         {
-            if(bus_vn_kv.size() != n_sub * nmax_busbar_per_sub){
+            // positivity + no int overflow on n_sub * nmax_busbar_per_sub
+            const int nb_bus_total = checked_nb_bus(n_sub, nmax_busbar_per_sub, "Substation::init_bus");
+            if(bus_vn_kv.size() != nb_bus_total){
                 std::ostringstream exc_;
                 exc_ << "Substation::init_bus: ";
                 exc_ << "your model counts ";
@@ -223,6 +290,7 @@ class LS2G_API SubstationContainer final : public IteratorAdder<SubstationContai
 
             // check that a "substation" always has the same vn_kv for all of its buses
             check_bus_vn_kv_uniform_per_sub();
+            check_vn_kv_positive();
         }
 
         /**
@@ -231,7 +299,7 @@ class LS2G_API SubstationContainer final : public IteratorAdder<SubstationContai
          * With `n` = n_sub_ and `k` = nmax_busbar_per_sub_, the buses of substation
          * `I` are the ids `I, I + n, I + 2n, ..., I + (k-1)n` -- so the invariant is
          *
-         *     for all 0 <= I < n, for all 0 <= j < k:  bus_vn_kv[I] == bus_vn_kv[I + j*n]
+         *     for all 0 <= i < n, for all 0 <= j < k:  bus_vn_kv[i] == bus_vn_kv[i + j*n]
          *
          * and that is exactly the loop below, written as plain index arithmetic on
          * bus_vn_kv_ (the stride is `n`, NOT 1 and not `k`: consecutive entries of
@@ -241,25 +309,25 @@ class LS2G_API SubstationContainer final : public IteratorAdder<SubstationContai
          * NB this used to be expressed via local_to_gridmodel(sub_id, LocalBusId(..)),
          * which is where it went wrong: LocalBusId is 1-based (bus id ==
          * `sub_id + (local_bus_id - 1) * n`), and the loop ran local ids `[1, k)`, so
-         * it opened by comparing bus `I` with itself and stopped one busbar short.
-         * At the usual k == 2 that compared bus `I` to bus `I` and checked nothing at
+         * it opened by comparing bus `i` with itself and stopped one busbar short.
+         * At the usual k == 2 that compared bus `i` to bus `i` and checked nothing at
          * all -- the invariant was silently unenforced on every path.
          */
         void check_bus_vn_kv_uniform_per_sub() const
         {
             const int n = n_sub_;
             const int k = nmax_busbar_per_sub_;
-            for(int I = 0; I < n; ++I){
-                const real_type ref_vn_kv = bus_vn_kv_(I);
+            for(int i = 0; i < n; ++i){
+                const real_type ref_vn_kv = bus_vn_kv_(i);
                 for(int j = 1; j < k; ++j)
                 {
-                    const int bus_id = I + j * n;
+                    const int bus_id = i + j * n;
                     const real_type this_bus_vn_kv = bus_vn_kv_(bus_id);
                     if(std::abs(this_bus_vn_kv - ref_vn_kv) > BaseConstants::_tol_equal_float){
                         std::ostringstream exc_;
                         exc_ << "SubstationContainer: each bus of a substation must have the same nominal "
-                             << "voltage. Substation " << I << " has " << ref_vn_kv
-                             << " kV on bus id " << I << " but " << this_bus_vn_kv
+                             << "voltage. Substation " << i << " has " << ref_vn_kv
+                             << " kV on bus id " << i << " but " << this_bus_vn_kv
                              << " kV on bus id " << bus_id << " (its busbar " << (j + 1) << ").";
                         throw std::runtime_error(exc_.str());
                     }

--- a/src/core/SubstationContainer.hpp
+++ b/src/core/SubstationContainer.hpp
@@ -71,6 +71,16 @@ class LS2G_API SubstationContainer final : public IteratorAdder<SubstationContai
         SubstationContainer::StateRes get_state() const;
         void set_state(SubstationContainer::StateRes & my_state);
 
+        /**
+         * Whole-container consistency validation, the substation half of
+         * LSGrid::check_grid() (see there). set_state() already enforces this on
+         * anything coming from a pickle / a binary file; this is what covers a
+         * container reached the other way -- built element by element through the
+         * python API, or mutated afterwards. Throws std::runtime_error, returns
+         * normally for a consistent container.
+         */
+        void check_valid() const;
+
         // fast binary serialization (additive alternative to pickle, see BinaryArchive.hpp)
         void save_binary(const std::string & path, bool atomic = true) const;
         static SubstationContainer load_binary(const std::string & path);
@@ -271,9 +281,15 @@ inline SubstationInfo::SubstationInfo(const SubstationContainer & r_data, int my
 {
     if(my_id < 0) return;
     if(my_id >= r_data.nb()) return;
-    name = r_data.sub_names_[my_id];
+    // sub_names_ is OPTIONAL (empty unless set_substation_names() was called, which
+    // eg the pandapower / matpower / powermodels loaders never do) and bus_vn_kv_ is
+    // empty on a substation container that was declared but never given its buses:
+    // both must be bounds-checked here, `my_id < nb()` only bounds them against
+    // n_sub_. Same reason as everywhere else: -O3 -DNDEBUG release wheels have no
+    // std::vector / Eigen bounds check to fall back on.
+    if(my_id < static_cast<int>(r_data.sub_names_.size())) name = r_data.sub_names_[my_id];
     nb_max_busbars = r_data.nmax_busbar_per_sub_;
-    vn_kv = r_data.bus_vn_kv_[my_id];
+    if(my_id < static_cast<int>(r_data.bus_vn_kv_.size())) vn_kv = r_data.bus_vn_kv_[my_id];
 }
 
 

--- a/src/core/SubstationContainer.hpp
+++ b/src/core/SubstationContainer.hpp
@@ -226,35 +226,41 @@ class LS2G_API SubstationContainer final : public IteratorAdder<SubstationContai
         }
 
         /**
-         * Every busbar of a substation must carry the same nominal voltage.
+         * Every bus of a substation carries that substation's nominal voltage.
          *
-         * A gridmodel bus id is laid out as `sub_id + (local_bus_id - 1) * n_sub_`
-         * (see local_to_gridmodel), so the buses of one substation are strided by
-         * **n_sub_**, not by nmax_busbar_per_sub_, and LocalBusId is 1-BASED:
-         * local id 1 is the first busbar (gridmodel id == sub_id), local id
-         * nmax_busbar_per_sub_ is the last one.
+         * With `n` = n_sub_ and `k` = nmax_busbar_per_sub_, the buses of substation
+         * `I` are the ids `I, I + n, I + 2n, ..., I + (k-1)n` -- so the invariant is
          *
-         * That 1-based convention is what made the original loop here a no-op: it
-         * ran local ids `[1, nmax_busbar_per_sub_)`, so it started by comparing the
-         * reference bus with itself and stopped one busbar short -- with the usual
-         * nmax_busbar_per_sub_ == 2 it compared bus `sub_id` to bus `sub_id` and
-         * checked nothing at all. Hence the range below: local ids 2 .. nmax
-         * inclusive, i.e. every busbar *after* the reference one.
+         *     for all 0 <= I < n, for all 0 <= j < k:  bus_vn_kv[I] == bus_vn_kv[I + j*n]
+         *
+         * and that is exactly the loop below, written as plain index arithmetic on
+         * bus_vn_kv_ (the stride is `n`, NOT 1 and not `k`: consecutive entries of
+         * bus_vn_kv_ are different SUBSTATIONS, which is why eg the case14 fixture
+         * legitimately has bus_vn_kv_[4] == 138 next to bus_vn_kv_[5] == 20).
+         *
+         * NB this used to be expressed via local_to_gridmodel(sub_id, LocalBusId(..)),
+         * which is where it went wrong: LocalBusId is 1-based (bus id ==
+         * `sub_id + (local_bus_id - 1) * n`), and the loop ran local ids `[1, k)`, so
+         * it opened by comparing bus `I` with itself and stopped one busbar short.
+         * At the usual k == 2 that compared bus `I` to bus `I` and checked nothing at
+         * all -- the invariant was silently unenforced on every path.
          */
         void check_bus_vn_kv_uniform_per_sub() const
         {
-            for(int sub_id = 0; sub_id < n_sub_; sub_id++){
-                const real_type ref_vn_kv = bus_vn_kv_(sub_id);
-                for(int local_bus_id = 2; local_bus_id <= nmax_busbar_per_sub_; local_bus_id++)
+            const int n = n_sub_;
+            const int k = nmax_busbar_per_sub_;
+            for(int I = 0; I < n; ++I){
+                const real_type ref_vn_kv = bus_vn_kv_(I);
+                for(int j = 1; j < k; ++j)
                 {
-                    const int bus_id = local_to_gridmodel(sub_id, LocalBusId(local_bus_id)).cast_int();
+                    const int bus_id = I + j * n;
                     const real_type this_bus_vn_kv = bus_vn_kv_(bus_id);
                     if(std::abs(this_bus_vn_kv - ref_vn_kv) > BaseConstants::_tol_equal_float){
                         std::ostringstream exc_;
                         exc_ << "SubstationContainer: each bus of a substation must have the same nominal "
-                             << "voltage. Substation " << sub_id << " has " << ref_vn_kv
-                             << " kV on its busbar 1 (bus id " << sub_id << ") but " << this_bus_vn_kv
-                             << " kV on its busbar " << local_bus_id << " (bus id " << bus_id << ").";
+                             << "voltage. Substation " << I << " has " << ref_vn_kv
+                             << " kV on bus id " << I << " but " << this_bus_vn_kv
+                             << " kV on bus id " << bus_id << " (its busbar " << (j + 1) << ").";
                         throw std::runtime_error(exc_.str());
                     }
                 }
@@ -313,6 +319,37 @@ class LS2G_API SubstationContainer final : public IteratorAdder<SubstationContai
         int n_sub_;
         int nmax_busbar_per_sub_;
         int n_bus_max_;
+        /**
+         * TODO sub_vn_kv_ IS DEAD STATE: nothing ever sets it, and nothing reads it.
+         *
+         * The only two writers are `init_sub()` and the two-argument constructor
+         * `SubstationContainer(n_sub, nmax_busbar_per_sub)` -- and NEITHER is called
+         * anywhere in the codebase (nor exposed to python). Every grid is built by
+         * the default constructor followed by `init_bus()`, which fills bus_vn_kv_
+         * only, so this vector is EMPTY on every grid produced by
+         * init_from_pandapower / _pypowsybl / _matpower / _powermodels, and empty in
+         * every binary file saved so far (including the format-4 fixture in
+         * lightsim2grid/tests/binary_format_fixture/). It is nevertheless part of
+         * StateRes, so it is serialized -- as an empty vector -- into every pickle
+         * and every binary file.
+         *
+         * It is also fully REDUNDANT: a substation's nominal voltage is by
+         * definition the common vn_kv of its buses (see
+         * check_bus_vn_kv_uniform_per_sub), i.e. sub_vn_kv_[I] == bus_vn_kv_[I] for
+         * 0 <= I < n_sub_. check_valid() enforces exactly that whenever it is
+         * non-empty.
+         *
+         * So it must stay OPTIONAL: requiring it whenever bus_vn_kv_ is set would
+         * reject every grid and every saved file that exists today.
+         *
+         * Decide before a release which way to go, and do not leave it as is:
+         *   - either DROP it from StateRes (it is derivable from bus_vn_kv_ and read
+         *     by nobody) -- needs a BINARY_FORMAT_VERSION bump; or
+         *   - have `init_bus()` populate it (`sub_vn_kv_ = bus_vn_kv.head(n_sub)`)
+         *     and make check_valid() require it -- this changes what newly-saved
+         *     files contain, and the requirement can only be turned on once no
+         *     already-saved file needs to load.
+         */
         RealVect sub_vn_kv_;
         std::vector<bool> bus_status_;
         RealVect bus_vn_kv_;

--- a/src/core/element_container/GeneratorContainer.cpp
+++ b/src/core/element_container/GeneratorContainer.cpp
@@ -597,6 +597,16 @@ void GeneratorContainer::update_slack_weights(
     DualAlgoControl & solver_control)
 {
     const int nb_gen = nb();
+    // `could_be_slack` comes from python and is indexed by generator id below with
+    // an unchecked Eigen operator(): a shorter array would be read out of bounds
+    // (release wheels are -O3 -DNDEBUG, so Eigen's own assert is gone).
+    if(could_be_slack.rows() != nb_gen){
+        std::ostringstream exc_;
+        exc_ << "GeneratorContainer::update_slack_weights: 'could_be_slack' has "
+             << could_be_slack.rows() << " elements but this grid has " << nb_gen
+             << " generators. It is indexed by generator id, so both must match.";
+        throw std::runtime_error(exc_.str());
+    }
     std::vector<int> gen_slack_id;
     for(int gen_id = 0; gen_id < nb_gen; ++gen_id)
     {

--- a/src/core/powerflow_algorithm/NRAlgo.hpp
+++ b/src/core/powerflow_algorithm/NRAlgo.hpp
@@ -227,6 +227,37 @@ public:
         }
         return v;
     }
+    // An AlgoConfig stores the two policy enums as plain ints, and it can come from
+    // a pickle or a binary file: an out-of-range value would be cast to the scoped
+    // enum and then silently fall into a `default:` branch, quietly changing the
+    // algorithm's behaviour AND round-tripping back out through get_config(). Reject
+    // it instead. (create_scaling_policy() already throws on an unknown scaling type;
+    // this makes the refactor side symmetric and gives a better message for both.)
+    static RefactorPolicyType _checked_refactor_policy(int v) {
+        if ((v < static_cast<int>(RefactorPolicyType::AlwaysRefactor)) ||
+            (v > static_cast<int>(RefactorPolicyType::Chord))) {
+            std::ostringstream exc_;
+            exc_ << "NRAlgo: unknown refactorization policy " << v << " (expected "
+                 << static_cast<int>(RefactorPolicyType::AlwaysRefactor) << " = AlwaysRefactor, "
+                 << static_cast<int>(RefactorPolicyType::EveryN) << " = EveryN or "
+                 << static_cast<int>(RefactorPolicyType::Chord) << " = Chord).";
+            throw std::runtime_error(exc_.str());
+        }
+        return static_cast<RefactorPolicyType>(v);
+    }
+    static ScalingPolicyType _checked_scaling_policy(int v) {
+        if ((v < static_cast<int>(ScalingPolicyType::NoScaling)) ||
+            (v > static_cast<int>(ScalingPolicyType::Iwamoto))) {
+            std::ostringstream exc_;
+            exc_ << "NRAlgo: unknown step-scaling policy " << v << " (expected "
+                 << static_cast<int>(ScalingPolicyType::NoScaling) << " = NoScaling, "
+                 << static_cast<int>(ScalingPolicyType::MaxVoltageChange) << " = MaxVoltageChange, "
+                 << static_cast<int>(ScalingPolicyType::LineSearch) << " = LineSearch or "
+                 << static_cast<int>(ScalingPolicyType::Iwamoto) << " = Iwamoto).";
+            throw std::runtime_error(exc_.str());
+        }
+        return static_cast<ScalingPolicyType>(v);
+    }
 
     // MaxVoltageChange params
     real_type get_max_dVa() const { return max_dVa_; }
@@ -276,6 +307,11 @@ public:
     void set_config(const AlgoConfig& cfg) override {
         if (cfg.int_params.size()  < 4) throw std::runtime_error("NRAlgo::set_config: int_params must have at least 4 elements");
         if (cfg.real_params.size() < 6) throw std::runtime_error("NRAlgo::set_config: real_params must have at least 6 elements");
+        // Validate the two policy enums BEFORE touching any member: applying a
+        // config must be all-or-nothing, otherwise a config rejected halfway
+        // through leaves the algorithm with a mix of new and old parameters.
+        const RefactorPolicyType new_refactor_policy = _checked_refactor_policy(cfg.int_params[1]);
+        const ScalingPolicyType  new_scaling_policy  = _checked_scaling_policy(cfg.int_params[0]);
         // NB an AlgoConfig is part of the serialized grid state, so these values
         // can come straight from a pickle or a binary file: validate them exactly
         // like the setters do (see the note on _checked_refactor_every_n).
@@ -287,8 +323,8 @@ public:
         iw_mu_max_       = _checked_finite(static_cast<real_type>(cfg.real_params[5]), "iw_mu_max");
         ls_max_iter_     = _checked_non_negative(cfg.int_params[2], "ls_max_iter");
         refactor_every_n_= _checked_refactor_every_n(cfg.int_params[3]);
-        refactor_policy_ = static_cast<RefactorPolicyType>(cfg.int_params[1]);
-        set_scaling_policy(static_cast<ScalingPolicyType>(cfg.int_params[0]));
+        refactor_policy_ = new_refactor_policy;
+        set_scaling_policy(new_scaling_policy);
     }
 
     // ----- debug ---------------------------------------------------------------

--- a/src/tests/test_check_grid.cpp
+++ b/src/tests/test_check_grid.cpp
@@ -30,6 +30,7 @@
 
 #include "LSGrid.hpp"
 #include "AlgorithmRegistry.hpp"
+#include "AlgorithmTypeNames.hpp"  // name_to_algo_type
 #include "powerflow_algorithm/BaseAlgo.hpp"
 
 using ls2g::LSGrid;
@@ -765,6 +766,67 @@ TEST_CASE("a state with an unknown scaling policy is rejected", "[check_grid][al
 
     LSGrid restored;
     CHECK_THROWS_AS(restored.set_state(st), std::runtime_error);
+}
+
+TEST_CASE("built-in vs plugin is decided by the registry, not by AlgorithmType", "[check_grid][plugin]")
+{
+    // AlgorithmType is a fixed enum of *serialized* solver identities; a built-in
+    // only appears in it if a member was added for it. The NRRefactorRetry_* family
+    // never got one, so name_to_algo_type() reports those three IN-TREE solvers as
+    // AlgorithmType::Custom, exactly like a plugin -- and everything gating on
+    // `== Custom` (notably the external-solver output check in
+    // LSGrid::process_results) silently mistreated them. Origin is recorded at
+    // registration time instead.
+    auto & registry = ls2g::AlgorithmRegistry::instance();
+
+    // a built-in that DOES have an AlgorithmType member
+    CHECK(registry.is_builtin("NR_SparseLU"));
+    CHECK(registry.origin_of("NR_SparseLU") == ls2g::SolverOrigin::Builtin);
+
+    // the real regression: a built-in whose name maps to AlgorithmType::Custom must
+    // still be reported as built-in. Only registered when KLU/NICSLU/CKTSO is
+    // available, so assert it for whichever of them this build has.
+    const std::vector<std::string> refactor_retry = {
+        "NRRefactorRetry_KLU", "NRRefactorRetry_NICSLU", "NRRefactorRetry_CKTSO"};
+    for (const auto & name : refactor_retry) {
+        if (!registry.is_registered(name)) continue;
+        INFO("solver " << name);
+        CHECK(ls2g::name_to_algo_type(name) == ls2g::AlgorithmType::Custom);  // no enum member
+        CHECK(registry.is_builtin(name));                                     // yet in-tree
+    }
+
+    // a solver registered the way a plugin does is External, and stays External
+    // even though its name likewise maps to Custom.
+    registry.register_solver("__origin_probe_external__",
+                             [] { return std::unique_ptr<ls2g::BaseAlgo>(new PluginLikeAlgo()); });
+    CHECK(ls2g::name_to_algo_type("__origin_probe_external__") == ls2g::AlgorithmType::Custom);
+    CHECK_FALSE(registry.is_builtin("__origin_probe_external__"));
+
+    // an unregistered name is reported External (the cautious answer)
+    CHECK_FALSE(registry.is_builtin("__never_registered__"));
+
+    // and every name the registry calls built-in really is registered
+    for (const auto & name : registry.builtin_algorithm_names()) {
+        INFO("builtin " << name);
+        CHECK(registry.is_registered(name));
+    }
+}
+
+TEST_CASE("the selector caches the origin of the algorithm it selects", "[check_grid][plugin]")
+{
+    auto & registry = ls2g::AlgorithmRegistry::instance();
+    registry.register_solver("__origin_probe_selector__",
+                             [] { return std::unique_ptr<ls2g::BaseAlgo>(new PluginLikeAlgo()); });
+
+    LSGrid grid = make_valid_grid();
+    // default solver is a built-in
+    CHECK(grid.get_algo().is_builtin_algo());
+
+    grid.change_algorithm("__origin_probe_selector__");
+    CHECK_FALSE(grid.get_algo().is_builtin_algo());
+
+    grid.change_algorithm("NR_SparseLU");
+    CHECK(grid.get_algo().is_builtin_algo());
 }
 
 TEST_CASE("a solver returning a wrong-sized voltage vector is rejected, not indexed", "[check_grid][plugin]")

--- a/src/tests/test_check_grid.cpp
+++ b/src/tests/test_check_grid.cpp
@@ -119,6 +119,49 @@ std::vector<int>& gen_regulated_bus(LSGrid::StateRes & st)
 {
     return std::get<8>(std::get<LSGrid::GEN_ID>(st));
 }
+// SUBSTATION_ID -> SubstationContainer::StateRes = tuple<[0] n_sub,
+//   [1] nmax_busbar_per_sub, [2] sub_vn_kv, [3] bus_status, [4] bus_vn_kv,
+//   [5] sub_names, [6] bus_vmin_kv, [7] bus_vmax_kv>
+int& sub_n_sub(LSGrid::StateRes & st)
+{
+    return std::get<0>(std::get<LSGrid::SUBSTATION_ID>(st));
+}
+int& sub_nmax_busbar(LSGrid::StateRes & st)
+{
+    return std::get<1>(std::get<LSGrid::SUBSTATION_ID>(st));
+}
+std::vector<real_type>& sub_sub_vn_kv(LSGrid::StateRes & st)
+{
+    return std::get<2>(std::get<LSGrid::SUBSTATION_ID>(st));
+}
+std::vector<bool>& sub_bus_status(LSGrid::StateRes & st)
+{
+    return std::get<3>(std::get<LSGrid::SUBSTATION_ID>(st));
+}
+std::vector<real_type>& sub_bus_vn_kv(LSGrid::StateRes & st)
+{
+    return std::get<4>(std::get<LSGrid::SUBSTATION_ID>(st));
+}
+std::vector<std::string>& sub_names(LSGrid::StateRes & st)
+{
+    return std::get<5>(std::get<LSGrid::SUBSTATION_ID>(st));
+}
+std::vector<int>& ls_to_orig(LSGrid::StateRes & st)
+{
+    return std::get<LSGrid::LS_TO_ORIG_ID>(st);
+}
+std::vector<std::string>& init_kwargs_keys(LSGrid::StateRes & st)
+{
+    return std::get<LSGrid::INIT_KWARGS_KEYS_ID>(st);
+}
+std::vector<std::string>& init_kwargs_values(LSGrid::StateRes & st)
+{
+    return std::get<LSGrid::INIT_KWARGS_VALUES_ID>(st);
+}
+std::vector<int>& bus_fusion_rep(LSGrid::StateRes & st)
+{
+    return std::get<LSGrid::BUS_FUSION_REP_ID>(st);
+}
 
 // A well-behaved AC solver (returns the input voltages, claims convergence).
 // Registered under a non-built-in name it stands in for a plugin solver, whose
@@ -313,6 +356,245 @@ TEST_CASE("check_grid rejects an out-of-range pos_topo_vect entry", "[check_grid
     CHECK_THROWS_AS(grid.check_grid(), std::out_of_range);
 }
 
+// --- the substation container: the ROOT of the grid's index space ------------
+// nb_bus() (= bus_vn_kv_.size()) is the bound every element's bus id is checked
+// against, bus_status_ is what those same ids actually index, and n_sub_ is both
+// the substation-id bound and a modulo divisor (sub_id_of_bus). Nothing
+// re-derives them from one another, so a state in which they disagree turns a
+// *validated* bus id into an out-of-bounds access -- disconnect_all_buses()
+// writes nb_bus() entries into bus_status_, which is a heap write past the end.
+// These must be rejected by set_state()/check_grid(), never reach a powerflow.
+
+TEST_CASE("check_grid rejects a bus_status shorter than the bus count", "[check_grid][substation]")
+{
+    LSGrid grid = make_valid_grid();
+    LSGrid::StateRes st = grid.get_state();
+    REQUIRE(sub_bus_status(st).size() == 3);
+    sub_bus_status(st).resize(1);  // 1 status for 3 buses
+
+    LSGrid restored;
+    CHECK_THROWS_AS(restored.set_state(st), std::runtime_error);
+}
+
+TEST_CASE("check_grid rejects a bus count that disagrees with n_sub * nmax_busbar", "[check_grid][substation]")
+{
+    LSGrid grid = make_valid_grid();
+    LSGrid::StateRes st = grid.get_state();
+    sub_nmax_busbar(st) = 1000;  // 3 * 1000 buses claimed, 3 actually stored
+
+    LSGrid restored;
+    CHECK_THROWS_AS(restored.set_state(st), std::runtime_error);
+}
+
+TEST_CASE("check_grid rejects a zero substation count (modulo divisor)", "[check_grid][substation]")
+{
+    // sub_id_of_bus() does `gridmodel_bus_id % n_sub_`: n_sub_ == 0 is an integer
+    // division by zero (SIGFPE), the same class of bug as refactor_every_n == 0.
+    LSGrid grid = make_valid_grid();
+    LSGrid::StateRes st = grid.get_state();
+    sub_n_sub(st) = 0;
+
+    LSGrid restored;
+    CHECK_THROWS_AS(restored.set_state(st), std::runtime_error);
+}
+
+TEST_CASE("check_grid rejects an n_sub * nmax_busbar product that overflows", "[check_grid][substation]")
+{
+    LSGrid grid = make_valid_grid();
+    LSGrid::StateRes st = grid.get_state();
+    sub_n_sub(st) = 100000;
+    sub_nmax_busbar(st) = 100000;  // 10^10 does not fit in the int n_bus_max_
+
+    LSGrid restored;
+    CHECK_THROWS_AS(restored.set_state(st), std::runtime_error);
+}
+
+TEST_CASE("check_grid rejects a partially-filled substation names vector", "[check_grid][substation]")
+{
+    LSGrid grid = make_valid_grid();
+    grid.set_substation_names({"a", "b", "c"});
+    LSGrid::StateRes st = grid.get_state();
+    REQUIRE(sub_names(st).size() == 3);
+    sub_names(st).resize(2);  // names are optional, but all-or-nothing
+
+    LSGrid restored;
+    CHECK_THROWS_AS(restored.set_state(st), std::runtime_error);
+}
+
+TEST_CASE("check_grid rejects a sub_vn_kv that does not match n_sub", "[check_grid][substation]")
+{
+    LSGrid grid = make_valid_grid();
+    LSGrid::StateRes st = grid.get_state();
+    sub_sub_vn_kv(st).resize(1);
+
+    LSGrid restored;
+    CHECK_THROWS_AS(restored.set_state(st), std::runtime_error);
+}
+
+TEST_CASE("substation info is readable on a grid with no substation names", "[check_grid][substation]")
+{
+    // sub_names_ is OPTIONAL (the pandapower / matpower / powermodels loaders never
+    // set it), and SubstationInfo used to read sub_names_[id] unconditionally --
+    // an out-of-bounds read of a std::string on any such grid, no poisoned input
+    // needed at all.
+    LSGrid grid = make_valid_grid();
+    REQUIRE(grid.get_substation_names().empty());
+    const auto & substations = grid.get_substations();
+    for (int sub_id = 0; sub_id < 3; ++sub_id) {
+        ls2g::SubstationInfo info(substations, sub_id);
+        CHECK(info.id == sub_id);
+        CHECK(info.name.empty());
+        CHECK(info.vn_kv == 138.);
+    }
+}
+
+// --- the bus-id mapping vectors ----------------------------------------------
+
+TEST_CASE("a negative (non-sentinel) _ls_to_orig entry is rejected, not indexed", "[check_grid]")
+{
+    // set_ls_to_orig_internal sizes _orig_to_ls from lpNorm<Infinity>() (the max
+    // ABSOLUTE value) and then writes at _orig_to_ls[el]: an entry of -5 sizes the
+    // vector from 5 and writes at index -5 -- an out-of-bounds heap write.
+    LSGrid grid = make_valid_grid();
+    LSGrid::StateRes st = grid.get_state();
+    ls_to_orig(st) = {-5, 1, 2};
+
+    LSGrid restored;
+    CHECK_THROWS_AS(restored.set_state(st), std::out_of_range);
+}
+
+TEST_CASE("an absurdly large _ls_to_orig entry is rejected, not allocated for", "[check_grid]")
+{
+    LSGrid grid = make_valid_grid();
+    LSGrid::StateRes st = grid.get_state();
+    ls_to_orig(st) = {std::numeric_limits<int>::max(), 1, 2};
+
+    LSGrid restored;
+    CHECK_THROWS_AS(restored.set_state(st), std::out_of_range);
+}
+
+TEST_CASE("a valid _ls_to_orig still round-trips", "[check_grid]")
+{
+    LSGrid grid = make_valid_grid();
+    LSGrid::StateRes st = grid.get_state();
+    ls_to_orig(st) = {2, 0, 1};
+
+    LSGrid restored;
+    REQUIRE_NOTHROW(restored.set_state(st));
+    const IntVect & back = restored.get_ls_to_orig();
+    REQUIRE(back.size() == 3);
+    CHECK(back(0) == 2);
+    CHECK(back(1) == 0);
+    CHECK(back(2) == 1);
+}
+
+TEST_CASE("_orig_to_ls and _ls_to_orig really are inverses of each other", "[check_grid]")
+{
+    // orig bus 0 has no lightsim counterpart; orig 1 -> ls 2, orig 2 -> ls 0,
+    // orig 3 -> ls 1. The inverse must therefore be ls 0 -> 2, ls 1 -> 3, ls 2 -> 1.
+    LSGrid grid = make_valid_grid();
+    IntVect orig_to_ls(4);
+    orig_to_ls << -1, 2, 0, 1;
+    REQUIRE_NOTHROW(grid.set_orig_to_ls(orig_to_ls));
+    const IntVect & back = grid.get_ls_to_orig();
+    REQUIRE(back.size() == 3);
+    CHECK(back(0) == 2);
+    CHECK(back(1) == 3);
+    CHECK(back(2) == 1);
+}
+
+TEST_CASE("an out-of-range _orig_to_ls entry is rejected, not indexed", "[check_grid]")
+{
+    LSGrid grid = make_valid_grid();
+    IntVect orig_to_ls(3);
+    orig_to_ls << 0, 1, 99;  // 99 is used to index a 3-slot _ls_to_orig
+    CHECK_THROWS_AS(grid.set_orig_to_ls(orig_to_ls), std::out_of_range);
+}
+
+TEST_CASE("an out-of-range _bus_fusion_rep entry is rejected", "[check_grid]")
+{
+    LSGrid grid = make_valid_grid();
+    LSGrid::StateRes st = grid.get_state();
+    bus_fusion_rep(st) = {0, 1, 9999};
+
+    LSGrid restored;
+    CHECK_THROWS_AS(restored.set_state(st), std::out_of_range);
+}
+
+// --- the serialized _init_kwargs map -----------------------------------------
+
+TEST_CASE("_init_kwargs with more keys than values is rejected, not over-read", "[check_grid]")
+{
+    // the map is serialized as two parallel vectors whose lengths are stored
+    // independently: set_state used to walk the keys and index the values with the
+    // same counter, ie construct std::strings from whatever lay past the end.
+    LSGrid grid = make_valid_grid();
+    LSGrid::StateRes st = grid.get_state();
+    init_kwargs_keys(st) = {"a", "b", "c"};
+    init_kwargs_values(st) = {"1"};
+
+    LSGrid restored;
+    CHECK_THROWS_AS(restored.set_state(st), std::runtime_error);
+}
+
+TEST_CASE("a consistent _init_kwargs still round-trips", "[check_grid]")
+{
+    LSGrid grid = make_valid_grid();
+    LSGrid::StateRes st = grid.get_state();
+    init_kwargs_keys(st) = {"sort_index", "buses_for_sub"};
+    init_kwargs_values(st) = {"True", "False"};
+
+    LSGrid restored;
+    REQUIRE_NOTHROW(restored.set_state(st));
+    const auto & kwargs = restored.get_init_kwargs();
+    REQUIRE(kwargs.size() == 2);
+    CHECK(kwargs.at("sort_index") == "True");
+    CHECK(kwargs.at("buses_for_sub") == "False");
+}
+
+// --- caller-supplied arrays indexed by position / by element id --------------
+
+TEST_CASE("update_topo rejects arrays that are not dim_topo long", "[check_grid]")
+{
+    // each container does has_changed(pos_topo_vect_(el_id)) with an unchecked
+    // Eigen operator(): the positions are validated, the caller's array length was
+    // not, so a short array was simply read past its end.
+    LSGrid grid = make_valid_grid();
+    IntVect load_pos(1); load_pos << 0;
+    IntVect gen_pos(1);  gen_pos  << 1;
+    IntVect line_pos1(2); line_pos1 << 2, 3;
+    IntVect line_pos2(2); line_pos2 << 4, 5;
+    grid.set_load_pos_topo_vect(load_pos);
+    grid.set_gen_pos_topo_vect(gen_pos);
+    grid.set_line_pos1_topo_vect(line_pos1);
+    grid.set_line_pos2_topo_vect(line_pos2);
+    REQUIRE_NOTHROW(grid.check_grid());  // 6 topo slots, a valid permutation
+
+    Eigen::Array<bool, Eigen::Dynamic, Eigen::RowMajor> too_short_flags(2);
+    too_short_flags << false, false;
+    Eigen::Array<int, Eigen::Dynamic, Eigen::RowMajor> too_short_vals(2);
+    too_short_vals << 1, 1;
+    CHECK_THROWS_AS(grid.update_topo(too_short_flags, too_short_vals), std::runtime_error);
+
+    // the correctly-sized, no-op call must still work
+    Eigen::Array<bool, Eigen::Dynamic, Eigen::RowMajor> flags(6);
+    flags << false, false, false, false, false, false;
+    Eigen::Array<int, Eigen::Dynamic, Eigen::RowMajor> vals(6);
+    vals << 1, 1, 1, 1, 1, 1;
+    CHECK_NOTHROW(grid.update_topo(flags, vals));
+}
+
+TEST_CASE("update_slack_weights rejects an array that is not nb_gen long", "[check_grid]")
+{
+    LSGrid grid = make_valid_grid();  // exactly one generator
+    Eigen::Array<bool, Eigen::Dynamic, Eigen::RowMajor> too_short(0);
+    CHECK_THROWS_AS(grid.update_slack_weights(too_short), std::runtime_error);
+
+    Eigen::Array<bool, Eigen::Dynamic, Eigen::RowMajor> ok(1);
+    ok << true;
+    CHECK_NOTHROW(grid.update_slack_weights(ok));
+}
+
 // --- solver policy parameters carried by the serialized state ----------------
 // AlgoConfig is part of StateRes, so these values arrive from a pickle / binary
 // file. refactor_every_n == 0 used to reach `iter % refactor_every_n` and kill
@@ -366,6 +648,30 @@ TEST_CASE("a valid algo config still round-trips", "[check_grid][algo_config]")
     LSGrid restored;
     CHECK_NOTHROW(restored.set_state(st));
     CHECK(restored.get_ac_algo_config().int_params[3] == grid.get_ac_algo_config().int_params[3]);
+}
+
+TEST_CASE("a state with an unknown refactor policy is rejected", "[check_grid][algo_config]")
+{
+    // int_params[1] is a RefactorPolicyType stored as a plain int. An out-of-range
+    // value used to be cast to the scoped enum, fall into should_refactor_policy's
+    // `default:` branch and round-trip back out of get_config() unchanged.
+    LSGrid grid = make_valid_grid();
+    LSGrid::StateRes st = grid.get_state();
+    REQUIRE(ac_algo_int_params(st).size() >= 4);
+    ac_algo_int_params(st)[1] = 42;
+
+    LSGrid restored;
+    CHECK_THROWS_AS(restored.set_state(st), std::runtime_error);
+}
+
+TEST_CASE("a state with an unknown scaling policy is rejected", "[check_grid][algo_config]")
+{
+    LSGrid grid = make_valid_grid();
+    LSGrid::StateRes st = grid.get_state();
+    ac_algo_int_params(st)[0] = 42;
+
+    LSGrid restored;
+    CHECK_THROWS_AS(restored.set_state(st), std::runtime_error);
 }
 
 TEST_CASE("a solver returning a wrong-sized voltage vector is rejected, not indexed", "[check_grid][plugin]")

--- a/src/tests/test_check_grid.cpp
+++ b/src/tests/test_check_grid.cpp
@@ -431,6 +431,99 @@ TEST_CASE("check_grid rejects a sub_vn_kv that does not match n_sub", "[check_gr
     CHECK_THROWS_AS(restored.set_state(st), std::runtime_error);
 }
 
+TEST_CASE("busbars of one substation must share their nominal voltage", "[check_grid][substation]")
+{
+    // A gridmodel bus id is `sub_id + (local_bus_id - 1) * n_sub`, and LocalBusId
+    // runs 1..nmax_busbar_per_sub. The original check looped local ids
+    // [1, nmax_busbar_per_sub), so it compared the reference bus with ITSELF and
+    // stopped one busbar short -- with the usual nmax == 2 it checked nothing at
+    // all, and the invariant was silently unenforced on every path.
+    ls2g::SubstationContainer substations;
+    // 2 substations x 3 busbars: sub 0 owns bus ids 0, 2, 4 ; sub 1 owns 1, 3, 5.
+    RealVect bad(6);
+    bad << 100., 200., 100., 200., 999., 200.;  // sub 0's LAST busbar disagrees
+    CHECK_THROWS_AS(substations.init_bus(2, 3, bad), std::runtime_error);
+
+    // the nmax == 2 case, which the old loop could not catch at all
+    ls2g::SubstationContainer two_busbars;
+    RealVect bad2(4);
+    bad2 << 100., 200., 999., 200.;  // sub 0: busbar 1 = 100, busbar 2 = 999
+    CHECK_THROWS_AS(two_busbars.init_bus(2, 2, bad2), std::runtime_error);
+
+    // a uniform grid is still accepted (stride is n_sub, not nmax_busbar_per_sub)
+    ls2g::SubstationContainer ok;
+    RealVect good(6);
+    good << 225., 400., 225., 400., 225., 400.;
+    CHECK_NOTHROW(ok.init_bus(2, 3, good));
+    CHECK_NOTHROW(ok.check_valid());
+}
+
+TEST_CASE("check_grid rejects non-uniform busbar voltages restored from a state", "[check_grid][substation]")
+{
+    // set_state() bypasses init_bus() entirely, so this invariant has to be
+    // re-checked on load -- a crafted pickle / binary file could always carry it.
+    LSGrid grid = make_valid_grid();  // 3 substations, 1 busbar each
+    LSGrid::StateRes st = grid.get_state();
+    sub_n_sub(st) = 1;
+    sub_nmax_busbar(st) = 3;               // 1 substation x 3 busbars = 3 buses
+    sub_bus_vn_kv(st) = {138., 138., 400.};  // its third busbar disagrees
+
+    LSGrid restored;
+    CHECK_THROWS_AS(restored.set_state(st), std::runtime_error);
+}
+
+TEST_CASE("check_grid rejects a sub_vn_kv that contradicts bus_vn_kv", "[check_grid][substation]")
+{
+    LSGrid grid = make_valid_grid();
+    LSGrid::StateRes st = grid.get_state();
+    // sub_vn_kv is optional, but when present it must be the common nominal
+    // voltage of each substation's busbars (== bus_vn_kv on the first n_sub ids).
+    sub_sub_vn_kv(st) = {138., 400., 138.};  // substation 1 contradicts its bus
+
+    LSGrid restored;
+    CHECK_THROWS_AS(restored.set_state(st), std::runtime_error);
+
+    // the consistent value is accepted
+    LSGrid::StateRes ok = grid.get_state();
+    sub_sub_vn_kv(ok) = {138., 138., 138.};
+    LSGrid restored_ok;
+    CHECK_NOTHROW(restored_ok.set_state(ok));
+}
+
+TEST_CASE("init_sub is safe on the live construction path", "[check_grid][substation]")
+{
+    // sub_vn_kv_ is only sized by the two-argument constructor, which nothing uses:
+    // the live path is the default constructor + init_bus(), which leaves it EMPTY.
+    // init_sub() wrote n_sub_ doubles into it with an unchecked operator[], ie an
+    // out-of-bounds heap write. It must size its destinations instead.
+    ls2g::SubstationContainer substations;
+    RealVect bus_vn_kv(6);
+    bus_vn_kv << 90., 90., 90., 90., 90., 90.;
+    substations.init_bus(3, 2, bus_vn_kv);
+    REQUIRE(substations.nb_bus() == 6);
+
+    RealVect sub_vn_kv(3);
+    sub_vn_kv << 225., 400., 63.;
+    REQUIRE_NOTHROW(substations.init_sub(sub_vn_kv));
+    // every busbar of a substation inherits that substation's nominal voltage
+    // (bus id == sub_id + (busbar - 1) * n_sub)
+    CHECK(substations.get_bus_vn_kv()(0) == 225.);
+    CHECK(substations.get_bus_vn_kv()(1) == 400.);
+    CHECK(substations.get_bus_vn_kv()(2) == 63.);
+    CHECK(substations.get_bus_vn_kv()(3) == 225.);
+    CHECK(substations.get_bus_vn_kv()(5) == 63.);
+    CHECK_NOTHROW(substations.check_valid());
+
+    // a wrong-sized input is still refused
+    RealVect too_short(2);
+    too_short << 225., 400.;
+    CHECK_THROWS(substations.init_sub(too_short));
+
+    // and it refuses to run at all before the substations are declared
+    ls2g::SubstationContainer fresh;
+    CHECK_THROWS_AS(fresh.init_sub(sub_vn_kv), std::runtime_error);
+}
+
 TEST_CASE("substation info is readable on a grid with no substation names", "[check_grid][substation]")
 {
     // sub_names_ is OPTIONAL (the pandapower / matpower / powermodels loaders never


### PR DESCRIPTION
Audit of every entry point consuming data from outside the C++ core — the python bindings, pickle, the binary format, and the `newtonpf` / solver entry point — in the spirit of the `refactor_every_n` SIGFPE fix.

Every issue below was confirmed with a working proof of concept **before** the fix (`SIGSEGV`, or `malloc(): unsorted double linked list corrupted`) and re-run after. Release wheels are `-O3 -DNDEBUG`, so neither Eigen's nor the standard library's own bounds checks are there to catch any of them.

## The serious one: `SubstationContainer::set_state` did no validation at all

Its body was `// check sizes` / `// TODO dev switches` followed by nothing — and it restores the **root of the grid's index space**: `nb_bus()` is the bound `check_grid()` validates every element bus id against, `bus_status_` is the vector those same ids then index, and `n_sub_` is both the substation-id bound and a modulo divisor. Nothing re-derives them from one another, so `check_grid()` was validating ids against one array while the code indexed a different, unrelated one.

Patching a saved `.lsb` to shrink `bus_status` from 4000 entries to 64:

```
LSGrid.load_binary('bad.lsb')  ->  LOADED WITHOUT ERROR. total_bus = 4000
free(): invalid pointer                    # heap corruption
```

`disconnect_all_buses()` writes `nb_bus()` entries into a 64-entry vector. This contradicted what `docs/security.rst` promised about the binary format, so that page is corrected too.

The same file also gave `n_sub_ == 0` → `bus_id % n_sub_` in `sub_id_of_bus()` — the same SIGFPE class as `refactor_every_n == 0`, in a different place. `n_sub_ * nmax_busbar_per_sub_` could also overflow the `int` holding it.

## The one needing no attacker at all

`SubstationInfo` read `sub_names_[id]` bounded only against the *substation count*, but names are optional and the pandapower / matpower / powermodels loaders never set them:

```python
for sub in grid.get_substations():   # Segmentation fault
```

A live crash in ordinary API use, unrelated to untrusted input.

## The per-substation voltage invariant was never enforced

With `n` = `n_sub` and `k` = `nmax_busbar_per_sub`, the buses of substation `I` are `I, I+n, …, I+(k-1)n`, so the invariant is

```
for all 0 <= I < n, for all 0 <= j < k:  bus_vn_kv[I] == bus_vn_kv[I + j*n]
```

`init_bus` has a check for exactly this, but it went through 1-based `LocalBusId` and looped local ids `[1, k)` — so it opened by comparing bus `I` with **itself** and stopped one busbar short. At the usual `k == 2` it compared bus `I` to bus `I` and checked nothing whatsoever; a substation with busbars at 100 kV and 999 kV was accepted. It is now written as the plain index relation above, and lifted into `check_valid()` so it is re-checked on load — `set_state` bypasses `init_bus` entirely.

## The rest

| Issue | Reachable from |
|---|---|
| `set_ls_to_orig_internal` sizes the reverse map from `lpNorm<Infinity>()` (max **absolute** value) then indexes with the values — `-5` sizes from 5, writes at index `-5` | `_ls_to_orig` property, pickle, binary |
| `_init_kwargs` keys/values lengths stored independently; `set_state` walked keys indexing values — over-read of `vector<string>` | pickle, binary |
| `update_topo` never checked its arrays are `dim_topo` long, though it indexes them by topology position | python |
| `update_slack_weights` never checked `could_be_slack` has one entry per generator | python |
| out-of-range policy enum in an `AlgoConfig` silently hit a `default:` branch and round-tripped back out | pickle, binary |
| `init_sub()` wrote `n_sub` doubles into an unsized `sub_vn_kv_` — latent (uncalled, unbound) but wrong for whoever wires it up | — |

Also fixed `set_orig_to_ls`, which did not build the inverse it claimed (wrong iteration range *and* wrong stored value), and `check_grid()` now covers the substation container and the bus-id mapping vectors (`_ls_to_orig` / `_orig_to_ls` / `_bus_fusion_rep`), which it previously ignored entirely.

## `sub_vn_kv` is dead state — documented, not silently left

Neither of its writers (`init_sub`, the two-argument constructor) is called anywhere and nothing reads it back, so it is empty on every grid every loader produces and in every binary file saved so far — including this repo's own format-4 fixture — yet it is serialized into all of them. It is also redundant: `sub_vn_kv_[I] == bus_vn_kv_[I]` for `I < n_sub`, which `check_valid()` now enforces when it is present. **It therefore has to stay optional**: requiring it would reject every existing grid and every already-saved file. A `TODO` on the member and an entry in the CHANGELOG's `[TODO]` section record the two ways out — drop it from `StateRes` (needs a format bump), or have `init_bus` fill it and require it (changes what newly-saved files contain, and can only become mandatory once no already-saved file needs to load). That call is left to you.

## Verification

- Every PoC now raises a clean `IndexError` / `RuntimeError` instead of crashing, across all three channels (python property, `pickle.loads`, `LSGrid.load_binary`).
- **No behaviour change on real grids**: case14 / case118 / case300 (pandapower), ieee14 (pypowsybl) and the shipped format-4 binary fixture all still pass `check_grid()`.
- C++ suite: **108 cases green** (~35 added here). `[check_grid]` under **valgrind: 0 errors from 0 contexts**.
- Python: the same **123 pre-existing** failures as the unmodified tree, **zero new** — verified by building the pre-fix tree and diffing the failure lists, which come back identical. Those 123 are environmental in this container (missing grid2op data, missing `old_pickle/` fixtures, no KLU in this build).

## Worth knowing before merging

The per-substation voltage invariant has been unenforced for as long as that loop has existed, so if any grid in the wild violates it, this turns a silent acceptance into a hard failure on load. Every grid I could test is clean, but only pandapower and pypowsybl were available in this container — **matpower and powermodels went untested**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015CfJVFAd2ifp4qyZxp5Ec5

---
_Generated by [Claude Code](https://claude.ai/code/session_015CfJVFAd2ifp4qyZxp5Ec5)_