### PR TITLE
Second security audit: six more holes on the untrusted-input paths

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -134,6 +134,25 @@ TODO: Levenberg-Marquardt damping (a.k.a. Tikhonov-regularized Newton) : adding 
   / ``init_from_powermodels``). A well-formed but inconsistent state (e.g. an
   out-of-range bus id in a crafted binary file) now raises a clean exception instead
   of causing an out-of-bounds access during the next powerflow.
+- [FIXED] ``sn_mva`` (the base power of the whole per-unit system) and ``init_vm_pu``
+  (the flat-start voltage magnitude) were validated **nowhere**: not by their python
+  setters, not by ``check_grid()``, and the loaders take them verbatim from their source
+  file (``init_from_powermodels`` / ``init_from_matpower`` do
+  ``set_sn_mva(float(network["baseMVA"]))``). A degenerate value does not make the
+  powerflow fail, it makes it *quietly wrong*: with ``sn_mva = NaN`` the **DC powerflow
+  reported convergence and returned NaN branch flows**, and with a negative one it
+  returned a plausible-looking but sign-inverted per-unit system. The built-in solvers'
+  own finiteness guards cannot catch this -- they check ``Va``, which is finite, since
+  ``Bbus`` does not involve ``sn_mva``; the NaN only appears afterwards, when the results
+  are scaled back to MW / MVar -- and the size/finiteness check on the solver output is
+  deliberately reserved for external solvers. Both scalars must now be finite and
+  strictly positive, checked by the setters and re-checked by ``check_grid()`` (which is
+  what covers pickle, the binary format and every loader, since ``set_state`` bypasses
+  the setters).
+- [FIXED] ``PandaPowerConverter::_check_init`` tested ``sn_mva_ <= 0.`` / ``f_hz_ <= 0.``.
+  Every comparison with NaN is false, so a NaN sailed through both -- and they are
+  divisors in every method of that class, so the whole converted grid came back NaN with
+  no error raised anywhere. Both are now checked as finite and strictly positive.
 - [FIXED] ``PandaPowerConverter`` (``get_trafo_param_pp2`` / ``get_trafo_param_pp3`` /
   ``get_line_param`` / ``get_line_param_legacy``, all exposed to python) never checked
   that the arrays it is given have the same length -- there was a ``TODO check all

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -134,6 +134,55 @@ TODO: Levenberg-Marquardt damping (a.k.a. Tikhonov-regularized Newton) : adding 
   / ``init_from_powermodels``). A well-formed but inconsistent state (e.g. an
   out-of-range bus id in a crafted binary file) now raises a clean exception instead
   of causing an out-of-bounds access during the next powerflow.
+- [FIXED] ``PandaPowerConverter`` (``get_trafo_param_pp2`` / ``get_trafo_param_pp3`` /
+  ``get_line_param`` / ``get_line_param_legacy``, all exposed to python) never checked
+  that the arrays it is given have the same length -- there was a ``TODO check all
+  vectors have the same size`` where the check belonged. Their element count is taken
+  from the *first* argument, and the others are then read with unchecked accessors
+  (``vect.coeff(i)``, ``is_tap_hv_side[i]``) and combined in coefficient-wise Eigen
+  expressions whose result is sized from one of them. Eigen's own size assertions are
+  compiled out of the release wheels (``-O3 -DNDEBUG``), so a caller passing a longer
+  first array both read *and wrote* past the end of the shorter ones -- reproducible as
+  ``free(): invalid next size (fast)``, i.e. heap corruption, from a handful of lines of
+  plain python. All the input lengths are now checked up front.
+- [FIXED] ``TrafoContainer::set_state`` copied the two per-transformer
+  ``alpha -> r/x correction`` tables (the phase-shifter impedance dependency, see
+  ``set_shift_dependent_rx``) out of the state with no check at all, and then called
+  ``_update_model_coeffs()``, which indexes ``rx_corr_alpha_[el_id]`` /
+  ``rx_corr_pct_[el_id]`` for every transformer with an unchecked
+  ``std::vector::operator[]``. A pickle or binary file declaring fewer tables than
+  transformers therefore read a ``std::vector`` object out of heap memory past the end
+  of the array and dereferenced its pointers -- a segfault, or worse. Two tables of
+  *different* lengths for the same transformer had the same effect one level down
+  (``_shift_rx_corr_pct`` interpolates ``ys`` with indices derived from ``xs.size()``).
+  This ran inside ``set_state``, i.e. **before** ``check_grid()``; both shapes are now
+  validated there, exactly as ``init()`` / ``set_shift_dependent_rx()`` maintain them.
+- [FIXED] ``TwoSidesContainer::set_tsc_state`` (powerlines, transformers, hvdc lines)
+  never checked the length of ``status_global_``: ``nb()`` is ``side_1_.nb()``, so a
+  pickle or binary file could declare a shorter -- in particular empty --
+  ``status_global`` while both sides carried the real element count. That vector is then
+  indexed with element ids bounded by ``nb()`` all over the class and the batch solvers
+  (``resolve_status``, ``_deactivate``, ``fillYbus``, ``ContingencyAnalysis``...) with an
+  unchecked ``operator[]``. Its length must now match exactly.
+- [FIXED] ``check_grid()`` did not range-check ``SvcContainer``'s ``regulated_bus_id_``,
+  although it is a gridmodel bus id used *directly as an index* by the powerflow --
+  ``id_grid_to_solver[regulated_bus_id_(svc_id)]`` in ``SvcContainer::set_vm`` (followed
+  by a **write** into ``V``) and in ``LSGrid::fill_voltage_control_solver_data``. Nothing
+  bounded it: ``init_svcs`` only checks the vector's length, so an SVC regulating an
+  out-of-range bus -- from a crafted pickle / binary file, or straight from a grid file
+  through ``init_from_pypowsybl`` -- passed ``check_grid()`` and then read and wrote out
+  of bounds on the next ``ac_pf``. It is now validated like the generator field of the
+  same name (``-1``, meaning "regulates no bus", stays legal).
+- [FIXED] ``check_grid()`` collected the (optional) ``pos_topo_vect`` of *every*
+  container -- shunts, static generators, svcs and hvdc lines included -- into the set it
+  proves is a permutation of ``[0, dim_topo)``. But ``dim_topo`` there was just how many
+  positions it had collected, while ``update_topo()`` sizes its caller arrays as
+  ``nb loads + nb gens + nb storages + 2 * nb lines + 2 * nb trafos``, which excludes
+  those containers. A state putting positions on a shunt therefore inflated the bound, so
+  a *validated* load position could still be past the end of the array ``update_topo()``
+  indexes with it. Only the containers ``update_topo()`` actually drives contribute now,
+  and a shunt / sgen / svc / hvdc carrying a topology-vector position (there is no setter
+  for one: such a state can only come from a crafted file) is rejected.
 - [FIXED] ``SubstationContainer::set_state`` performed **no** validation at all, and it
   restores the root of the grid's index space: ``nb_bus()`` (the bound ``check_grid()``
   validates every element bus id against), ``bus_status_`` (the vector those same ids are

--- a/docs/security.rst
+++ b/docs/security.rst
@@ -88,7 +88,11 @@ additionally required to form a permutation of ``[0, dim_topo)`` over exactly th
 elements :py:meth:`LSGrid.update_topo` drives (loads, generators, storage units,
 powerlines and transformers): that is what makes them safe to index the
 ``dim_topo``-sized arrays that method is given, so a shunt, static generator, SVC
-or hvdc line claiming a position in that vector is rejected. It also checks the *shape* of the grid
+or hvdc line claiming a position in that vector is rejected. It checks the two
+grid-wide per-unit scalars, ``sn_mva`` (the base power the whole grid is
+normalised against) and ``init_vm_pu``, are finite and strictly positive — a
+degenerate value there does not make a powerflow fail, it makes it silently
+*wrong*. It also checks the *shape* of the grid
 itself: that the substation container's own arrays agree with each other (the bus
 count, the per-bus status vector and ``n_sub × nmax_busbar_per_sub`` all describe
 the same set of buses), and that the bus-id mapping vectors carried alongside the
@@ -109,6 +113,37 @@ You normally do not need to call it yourself:
 It is exposed so you can validate a grid you built or modified by hand. It runs
 in time proportional to the number of elements in the grid, so it is relatively
 cheap compared to a powerflow.
+
+What it deliberately does **not** check is the *value* of the per-element
+electrical parameters: a line's ``r`` / ``x``, a transformer's tap ratio, an
+injection's ``p`` / ``q``. Values that look degenerate are usually legitimate —
+``r = 0`` is a lossless branch, a **negative reactance is a series capacitor**,
+and negative ``r`` / ``x`` also come out of three-winding-transformer star
+equivalents (pandapower's own ``case300`` and ``case9241pegase`` carry them).
+Non-finite values are legitimate too: pypowsybl encodes "no thermal limit" as a
+non-finite ``limit_a_ka``, and unbounded generator reactive limits are
+conventionally ``±Inf``. None of these can corrupt anything either — they are
+never used as indices, so they cannot cause an out-of-bounds access; they flow
+into ``Ybus`` / ``Bbus`` and the solvers' own guards report the solve as
+**non-converged**.
+
+What *is* checked are the two grid-wide scalars ``sn_mva`` and ``init_vm_pu``.
+They escape the safety net above: ``sn_mva`` scales results back to MW / MVar
+*outside* the solver, so a bad value is invisible to the solver's guards — a NaN
+there produced a DC powerflow that reported convergence and returned NaN flows.
+
+.. warning::
+    The solver's guards are not a complete safety net for the *derived* results.
+    They check the bus voltages, not the branch flows computed from them, so a
+    grid whose model is degenerate in a way that leaves the voltages finite can
+    still produce a **converged** solve with non-finite flows. A connected branch
+    with ``r == 0`` *and* ``x == 0`` is the known case: its admittance
+    ``1 / (r + j.x)`` is infinite, and in DC the flows come out non-finite while
+    the solve reports success. Such a branch is not rejected on load, because a
+    lossless branch can be perfectly legitimate (an ideal step-up transformer),
+    and ``init_from_pypowsybl(fuse_zero_impedance_branches=True)`` exists exactly
+    to fuse the buses of the ones that are not. **Check that the flows you get
+    back are finite** if your grid may contain zero-impedance branches.
 
 .. note::
 

--- a/docs/security.rst
+++ b/docs/security.rst
@@ -82,8 +82,13 @@ the file, and it is validated at two levels:
 :py:meth:`LSGrid.check_grid` verifies that a grid
 is internally consistent and safe to run a powerflow on. It checks that every
 index the grid carries is in range — the bus id of every element, the substation
-id and the position in the topology vector (both optional), and the generator
-slack and remote-regulated bus references. It also checks the *shape* of the grid
+id and the position in the topology vector (both optional), and the generator and
+SVC slack / remote-regulated bus references. The topology-vector positions are
+additionally required to form a permutation of ``[0, dim_topo)`` over exactly the
+elements :py:meth:`LSGrid.update_topo` drives (loads, generators, storage units,
+powerlines and transformers): that is what makes them safe to index the
+``dim_topo``-sized arrays that method is given, so a shunt, static generator, SVC
+or hvdc line claiming a position in that vector is rejected. It also checks the *shape* of the grid
 itself: that the substation container's own arrays agree with each other (the bus
 count, the per-bus status vector and ``n_sub × nmax_busbar_per_sub`` all describe
 the same set of buses), and that the bus-id mapping vectors carried alongside the

--- a/lightsim2grid/tests/test_state_poisoning.py
+++ b/lightsim2grid/tests/test_state_poisoning.py
@@ -212,6 +212,75 @@ class TestPoisonedState(unittest.TestCase):
         grid.update_topo(np.zeros(dim_topo, dtype=bool), np.ones(dim_topo, dtype=np.int32))
 
 
+class TestDegenerateGridScalars(unittest.TestCase):
+    """``sn_mva`` is the base power of the whole per-unit system and ``init_vm_pu``
+    the flat-start voltage magnitude. Neither was validated anywhere, and a
+    degenerate value does not make the powerflow fail -- it makes it quietly
+    wrong. With ``sn_mva = nan`` the DC powerflow used to report CONVERGENCE and
+    return NaN branch flows: the built-in solvers' own finiteness guards see a
+    perfectly finite ``Va`` (Bbus does not involve sn_mva), the NaN only appears
+    later when the results are scaled back to MW, and the size/finiteness check on
+    the solver output is deliberately reserved for external solvers."""
+
+    BAD = (0.0, -100.0, float("nan"), float("inf"))
+
+    def test_set_sn_mva_rejects_degenerate_values(self):
+        grid = build_exotic_elements_case_grid()
+        for v in self.BAD:
+            with self.subTest(sn_mva=v), self.assertRaises(RuntimeError):
+                grid.set_sn_mva(v)
+
+    def test_set_init_vm_pu_rejects_degenerate_values(self):
+        grid = build_exotic_elements_case_grid()
+        for v in self.BAD:
+            with self.subTest(init_vm_pu=v), self.assertRaises(RuntimeError):
+                grid.set_init_vm_pu(v)
+
+    def test_check_grid_rejects_degenerate_sn_mva_from_a_state(self):
+        # set_state assigns sn_mva straight from the serialized state, bypassing
+        # the setter: check_grid() is the backstop for pickle / the binary format
+        state = build_exotic_elements_case_grid().__getstate__()
+        for v in self.BAD:
+            with self.subTest(sn_mva=v), self.assertRaises(RuntimeError):
+                _rebuild(_set_at(state, (3, 5), v))
+
+    def test_check_grid_rejects_degenerate_init_vm_pu_from_a_state(self):
+        state = build_exotic_elements_case_grid().__getstate__()
+        for v in self.BAD:
+            with self.subTest(init_vm_pu=v), self.assertRaises(RuntimeError):
+                _rebuild(_set_at(state, (3, 4), v))
+
+    def test_good_scalars_still_accepted(self):
+        grid = build_exotic_elements_case_grid()
+        grid.set_sn_mva(100.0)
+        grid.set_init_vm_pu(1.04)
+        self.assertIsNone(grid.check_grid())
+        v0 = np.ones(grid.total_bus(), dtype=complex)
+        self.assertNotEqual(len(grid.ac_pf(v0, 20, 1e-7)), 0)
+
+    def test_powermodels_loader_rejects_a_degenerate_baseMVA(self):
+        # init_from_matpower routes through this loader, which does
+        # `set_sn_mva(float(network["baseMVA"]))` straight from the source file
+        import copy
+        import json
+        import os
+        try:
+            from lightsim2grid.network import init_from_powermodels
+        except ImportError:
+            self.skipTest("powermodels loader not available")
+        path = os.path.join(os.path.dirname(os.path.abspath(__file__)),
+                            "pf_delta_case14.json")
+        if not os.path.exists(path):
+            self.skipTest("pf_delta_case14.json fixture not available")
+        with open(path) as f:
+            network = json.load(f)["network"]
+        for v in (0.0, -100.0, float("nan")):
+            bad = copy.deepcopy(network)
+            bad["baseMVA"] = v
+            with self.subTest(baseMVA=v), self.assertRaises(RuntimeError):
+                init_from_powermodels(bad)
+
+
 class TestPandaPowerConverterInputSizes(unittest.TestCase):
     """``PandaPowerConverter`` walks its inputs together element by element with
     unchecked accessors, and combines them in coefficient-wise Eigen expressions
@@ -238,6 +307,20 @@ class TestPandaPowerConverterInputSizes(unittest.TestCase):
     def test_get_trafo_param_pp3_rejects_mismatched_sizes(self):
         with self.assertRaises(RuntimeError):
             self.conv.get_trafo_param_pp3(*self._trafo_args(self.long), True)
+
+    def test_check_init_rejects_a_nan_sn_mva_or_f_hz(self):
+        # the guard was `sn_mva_ <= 0.`, and every comparison with NaN is false, so a
+        # NaN went straight through -- and it is a divisor in every method here
+        conv = PandaPowerConverter()
+        conv.set_sn_mva(float("nan"))
+        conv.set_f_hz(50.0)
+        with self.assertRaises(RuntimeError):
+            conv.get_line_param(self.one, self.one, self.one, self.one, self.one, self.one)
+        conv2 = PandaPowerConverter()
+        conv2.set_sn_mva(100.0)
+        conv2.set_f_hz(float("nan"))
+        with self.assertRaises(RuntimeError):
+            conv2.get_line_param(self.one, self.one, self.one, self.one, self.one, self.one)
 
     def test_get_trafo_param_rejects_a_short_bool_vector(self):
         args = (self.one, self.one, self.one, [],  # is_tap_hv_side empty

--- a/lightsim2grid/tests/test_state_poisoning.py
+++ b/lightsim2grid/tests/test_state_poisoning.py
@@ -1,0 +1,284 @@
+# Copyright (c) 2026, RTE (https://www.rte-france.com)
+# See AUTHORS.txt
+# This Source Code Form is subject to the terms of the Mozilla Public License, version 2.0.
+# If a copy of the Mozilla Public License, version 2.0 was not distributed with this file,
+# you can obtain one at http://mozilla.org/MPL/2.0/.
+# SPDX-License-Identifier: MPL-2.0
+# This file is part of LightSim2grid, LightSim2grid implements a c++ backend targeting the Grid2Op platform.
+
+"""Python-visible behaviour of the "poisoned state" rejections.
+
+A pickle (or a binary file: both go through ``LSGrid::set_state``) is only
+length-checked while it is being read. Whatever it declares afterwards is copied
+straight into the C++ containers, and release wheels are built ``-O3 -DNDEBUG``,
+so an inconsistency that nothing rejects becomes an out-of-bounds read or write
+on the next powerflow rather than an error. Every case below segfaulted the
+interpreter before its fix.
+
+The deep ``set_state`` cases are covered exhaustively (and under
+valgrind/ASan) by the C++ suite, ``src/tests/test_state_poisoning.cpp``; what is
+checked here is that the same poisoned states raise a clean Python exception
+through the real ``pickle.loads`` path, and that the checks reachable without any
+serialization at all (an out-of-range SVC regulated bus set by a grid loader)
+raise too.
+"""
+
+import pickle
+import unittest
+
+import numpy as np
+
+from lightsim2grid.lightsim2grid_cpp import LSGrid, PandaPowerConverter
+from lightsim2grid.tests._exotic_elements_case_ls import build_exotic_elements_case_grid
+
+
+# state indices, mirroring LSGrid::StateRes (see LSGrid.hpp)
+LINE_ID = 8
+SHUNT_ID = 9
+TRAFO_ID = 10
+HVDC_ID = 15
+SVC_ID = 16
+
+BIG = 10 ** 7
+
+
+def _rebuild(state):
+    """Reconstruct an LSGrid from a (possibly tampered) pickle state, exactly the
+    way ``pickle.loads`` does -- ``__setstate__`` on an already-built object is a
+    no-op for a pybind11 ``py::pickle`` type."""
+    obj = LSGrid.__new__(LSGrid)
+    obj.__setstate__(state)
+    return obj
+
+
+def _set_at(state, path, value):
+    """Return a copy of the nested state tuple with `path` replaced by `value`."""
+    if not path:
+        return value
+    head, rest = path[0], path[1:]
+    as_list = list(state)
+    as_list[head] = _set_at(as_list[head], rest, value)
+    return tuple(as_list)
+
+
+def _get_at(state, path):
+    for i in path:
+        state = state[i]
+    return state
+
+
+class TestPoisonedState(unittest.TestCase):
+    """The grid carries a phase-shifting transformer, an SVC and 3 HVDC lines, so
+    every container the cases below poison is non-empty."""
+
+    def setUp(self):
+        self.grid = build_exotic_elements_case_grid()
+        self.state = self.grid.__getstate__()
+        # (version_major, version_medium, version_minor, LSGrid::StateRes)
+        self.inner = (3,)
+
+    def _poison(self, path, value):
+        return _set_at(self.state, self.inner + tuple(path), value)
+
+    # ------------------------------------------------------------------
+    # sanity: the untouched state round-trips
+    # ------------------------------------------------------------------
+    def test_valid_state_round_trips(self):
+        grid = pickle.loads(pickle.dumps(self.grid))
+        self.assertIsNone(grid.check_grid())
+        v0 = np.ones(grid.total_bus(), dtype=complex)
+        self.assertNotEqual(len(grid.ac_pf(v0, 20, 1e-7)), 0)
+
+    # ------------------------------------------------------------------
+    # TrafoContainer: the (alpha -> r/x correction) tables. They are indexed by
+    # transformer id inside set_state itself (_update_model_coeffs), i.e. before
+    # check_grid() gets a chance to run.
+    # ------------------------------------------------------------------
+    def test_rx_corr_tables_missing_is_rejected(self):
+        # shift-dependent r/x enabled (it is, in this grid) but no table at all
+        self.assertTrue(_get_at(self.state, (3, TRAFO_ID, 5)))
+        bad = self._poison((TRAFO_ID, 8), ())
+        bad = _set_at(bad, (3, TRAFO_ID, 9), ())
+        with self.assertRaises(RuntimeError):
+            _rebuild(bad)
+
+    def test_rx_corr_tables_too_short_is_rejected(self):
+        alpha = _get_at(self.state, (3, TRAFO_ID, 8))
+        self.assertGreater(len(alpha), 1)
+        with self.assertRaises(RuntimeError):
+            _rebuild(self._poison((TRAFO_ID, 8), tuple(alpha)[:-1]))
+
+    def test_rx_corr_alpha_and_pct_of_different_lengths_is_rejected(self):
+        alpha = list(_get_at(self.state, (3, TRAFO_ID, 8)))
+        pct = list(_get_at(self.state, (3, TRAFO_ID, 9)))
+        alpha[0] = (-0.5, 0.0, 0.5)
+        pct[0] = (1.0, 2.0)  # one correction short
+        bad = self._poison((TRAFO_ID, 8), tuple(alpha))
+        bad = _set_at(bad, (3, TRAFO_ID, 9), tuple(pct))
+        with self.assertRaises(RuntimeError):
+            _rebuild(bad)
+
+    # ------------------------------------------------------------------
+    # TwoSidesContainer: status_global_. `nb()` is side_1_.nb(), so nothing tied
+    # status_global_'s length to the number of elements indexing it.
+    # ------------------------------------------------------------------
+    def test_empty_status_global_on_lines_is_rejected(self):
+        with self.assertRaises(RuntimeError):
+            _rebuild(self._poison((LINE_ID, 0, 0, 3), ()))
+
+    def test_short_status_global_on_lines_is_rejected(self):
+        status = _get_at(self.state, (3, LINE_ID, 0, 0, 3))
+        with self.assertRaises(RuntimeError):
+            _rebuild(self._poison((LINE_ID, 0, 0, 3), tuple(status)[:-1]))
+
+    def test_wrong_status_global_on_trafos_is_rejected(self):
+        with self.assertRaises(RuntimeError):
+            _rebuild(self._poison((TRAFO_ID, 0, 0, 3), ()))
+
+    def test_wrong_status_global_on_hvdc_is_rejected(self):
+        status = _get_at(self.state, (3, HVDC_ID, 0, 3))
+        with self.assertRaises(RuntimeError):
+            _rebuild(self._poison((HVDC_ID, 0, 3), tuple(status) + (True,)))
+
+    # ------------------------------------------------------------------
+    # SvcContainer: the regulated bus id, used as an index by the powerflow.
+    # ------------------------------------------------------------------
+    def test_out_of_range_svc_regulated_bus_is_rejected(self):
+        reg = _get_at(self.state, (3, SVC_ID, 6))
+        self.assertGreater(len(reg), 0)
+        with self.assertRaises(IndexError):
+            _rebuild(self._poison((SVC_ID, 6), (BIG,) * len(reg)))
+
+    def test_negative_svc_regulated_bus_is_rejected(self):
+        reg = _get_at(self.state, (3, SVC_ID, 6))
+        with self.assertRaises(IndexError):
+            _rebuild(self._poison((SVC_ID, 6), (-5,) * len(reg)))
+
+    def test_minus_one_svc_regulated_bus_is_accepted(self):
+        reg = _get_at(self.state, (3, SVC_ID, 6))
+        grid = _rebuild(self._poison((SVC_ID, 6), (-1,) * len(reg)))
+        self.assertIsNone(grid.check_grid())
+
+    def test_out_of_range_svc_regulated_bus_from_init_svcs_is_rejected(self):
+        # the same hole with no serialization involved: this is what
+        # init_from_pypowsybl does with the bus ids it reads from the source grid
+        grid = build_exotic_elements_case_grid()
+        grid.init_svcs([1],
+                       np.array([1.0]), np.array([0.0]), np.array([0.0]),
+                       np.array([-0.03]), np.array([0.03]),
+                       np.array([BIG], dtype=np.int32),   # regulated bus, out of range
+                       np.array([5], dtype=np.int32))
+        with self.assertRaises(IndexError):
+            grid.check_grid()
+
+    # ------------------------------------------------------------------
+    # pos_topo_vect on an element that is not in the grid2op topology vector.
+    # check_grid() proved the collected positions were a permutation of [0, K)
+    # with K counting shunts / sgens / svcs / hvdc too, while update_topo() sizes
+    # its caller arrays without them -- so a validated load position could still
+    # be past the end of the array update_topo() indexes with it.
+    # ------------------------------------------------------------------
+    def test_pos_topo_vect_on_a_shunt_is_rejected(self):
+        nb_shunt = len(_get_at(self.state, (3, SHUNT_ID, 0, 0, 1)))
+        self.assertGreater(nb_shunt, 0)
+        bad = self._poison((SHUNT_ID, 0, 0, 5), True)
+        bad = _set_at(bad, (3, SHUNT_ID, 0, 0, 6), tuple(range(nb_shunt)))
+        with self.assertRaises(RuntimeError):
+            _rebuild(bad)
+
+    def test_update_topo_stays_in_bounds_with_a_full_topo_vect(self):
+        # the legitimate arrangement the check above protects: positions only on
+        # the containers update_topo() drives, forming a permutation of
+        # [0, dim_topo).
+        grid = build_exotic_elements_case_grid()
+        n_load = len(grid.get_loads())
+        n_gen = len(grid.get_generators())
+        n_sto = len(grid.get_storages())
+        n_line = len(grid.get_lines())
+        n_trafo = len(grid.get_trafos())
+        dim_topo = n_load + n_gen + n_sto + 2 * n_line + 2 * n_trafo
+        pos = np.arange(dim_topo, dtype=np.int32)
+        off = 0
+        for setter, nb in ((grid.set_load_pos_topo_vect, n_load),
+                           (grid.set_gen_pos_topo_vect, n_gen),
+                           (grid.set_storage_pos_topo_vect, n_sto),
+                           (grid.set_line_pos1_topo_vect, n_line),
+                           (grid.set_line_pos2_topo_vect, n_line),
+                           (grid.set_trafo_pos1_topo_vect, n_trafo),
+                           (grid.set_trafo_pos2_topo_vect, n_trafo)):
+            setter(pos[off:off + nb])
+            off += nb
+        self.assertIsNone(grid.check_grid())
+        grid.update_topo(np.zeros(dim_topo, dtype=bool), np.ones(dim_topo, dtype=np.int32))
+
+
+class TestPandaPowerConverterInputSizes(unittest.TestCase):
+    """``PandaPowerConverter`` walks its inputs together element by element with
+    unchecked accessors, and combines them in coefficient-wise Eigen expressions
+    sized from one of them. Eigen's own size assertions are compiled out of the
+    release wheels, so mismatched lengths used to write past the end of the
+    shorter arrays -- observed as heap corruption (``free(): invalid next size``),
+    not an exception."""
+
+    def setUp(self):
+        self.conv = PandaPowerConverter()
+        self.conv.set_f_hz(50.0)
+        self.conv.set_sn_mva(100.0)
+        self.long = np.ones(200)
+        self.one = np.ones(1)
+
+    def _trafo_args(self, first):
+        return (first, self.one, self.one, [True],
+                self.one, self.one, self.one, self.one, self.one, self.one, self.one)
+
+    def test_get_trafo_param_pp2_rejects_mismatched_sizes(self):
+        with self.assertRaises(RuntimeError):
+            self.conv.get_trafo_param_pp2(*self._trafo_args(self.long))
+
+    def test_get_trafo_param_pp3_rejects_mismatched_sizes(self):
+        with self.assertRaises(RuntimeError):
+            self.conv.get_trafo_param_pp3(*self._trafo_args(self.long), True)
+
+    def test_get_trafo_param_rejects_a_short_bool_vector(self):
+        args = (self.one, self.one, self.one, [],  # is_tap_hv_side empty
+                self.one, self.one, self.one, self.one, self.one, self.one, self.one)
+        with self.assertRaises(RuntimeError):
+            self.conv.get_trafo_param_pp2(*args)
+
+    def test_get_line_param_rejects_mismatched_sizes(self):
+        with self.assertRaises(RuntimeError):
+            self.conv.get_line_param(self.long, self.one, self.one, self.one,
+                                     self.one, self.one)
+
+    def test_get_line_param_legacy_rejects_mismatched_sizes(self):
+        with self.assertRaises(RuntimeError):
+            self.conv.get_line_param_legacy(self.one, self.one, self.one, self.long,
+                                            self.one, self.one)
+
+    def test_malformed_pandapower_net_raises_instead_of_corrupting_the_heap(self):
+        # the same hole, reached through init_from_pandapower: the loader looks the
+        # transformer / line end voltages up with `pp_net.bus.loc[pp_net.trafo["hv_bus"]]`,
+        # so a net whose bus index carries a DUPLICATE label hands the converter more
+        # nominal voltages than there are branches.
+        try:
+            import pandas as pd
+            import pandapower.networks as pn
+            from lightsim2grid.network import init_from_pandapower
+        except ImportError:
+            self.skipTest("pandapower is not installed")
+        net = pn.case14()
+        net.bus = pd.concat([net.bus, net.bus.loc[[3]].copy()])  # bus label 3 twice
+        with self.assertRaises(RuntimeError):
+            init_from_pandapower(net)
+
+    def test_matching_sizes_still_work(self):
+        n = 3
+        v = np.ones(n)
+        r, x, h = self.conv.get_trafo_param_pp2(v, v, v, [True] * n, v, v, v, v, v, v, v)
+        self.assertEqual(r.shape[0], n)
+        lr, lx, h_or, h_ex = self.conv.get_line_param(v, v, v, v, v, v)
+        self.assertEqual(lr.shape[0], n)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/core/DataConverter.cpp
+++ b/src/core/DataConverter.cpp
@@ -9,9 +9,70 @@
 #include "DataConverter.hpp"
 
 #include <iostream>
+#include <sstream>
+#include <stdexcept>
 
 namespace ls2g {
 
+void PandaPowerConverter::_check_same_size(const std::string & fun_name,
+                                           Eigen::Index expected,
+                                           const std::string & expected_name,
+                                           const std::string & name,
+                                           Eigen::Index actual)
+{
+    if(actual == expected) return;
+    std::ostringstream exc_;
+    exc_ << "PandaPowerConverter::" << fun_name << ": '" << name << "' has " << actual
+         << " element(s) while '" << expected_name << "' has " << expected
+         << ". All the inputs describe the same elements, one entry each, and are read "
+            "together element by element: they must all have the same length.";
+    throw std::runtime_error(exc_.str());
+}
+
+void PandaPowerConverter::_check_trafo_inputs(const std::string & fun_name,
+                                              const Eigen::Ref<const RealVect> & tap_step_pct,
+                                              const Eigen::Ref<const RealVect> & tap_pos,
+                                              const Eigen::Ref<const RealVect> & tap_angles,
+                                              const std::vector<bool> & is_tap_hv_side,
+                                              const Eigen::Ref<const RealVect> & vn_hv,
+                                              const Eigen::Ref<const RealVect> & vn_lv,
+                                              const Eigen::Ref<const RealVect> & trafo_vk_percent,
+                                              const Eigen::Ref<const RealVect> & trafo_vkr_percent,
+                                              const Eigen::Ref<const RealVect> & trafo_sn_trafo_mva,
+                                              const Eigen::Ref<const RealVect> & trafo_pfe_kw,
+                                              const Eigen::Ref<const RealVect> & trafo_i0_pct)
+{
+    const Eigen::Index nb_trafo = tap_step_pct.size();
+    const char * ref = "tap_step_pct";
+    _check_same_size(fun_name, nb_trafo, ref, "tap_pos", tap_pos.size());
+    _check_same_size(fun_name, nb_trafo, ref, "tap_angles", tap_angles.size());
+    _check_same_size(fun_name, nb_trafo, ref, "is_tap_hv_side",
+                     static_cast<Eigen::Index>(is_tap_hv_side.size()));
+    _check_same_size(fun_name, nb_trafo, ref, "vn_hv", vn_hv.size());
+    _check_same_size(fun_name, nb_trafo, ref, "vn_lv", vn_lv.size());
+    _check_same_size(fun_name, nb_trafo, ref, "trafo_vk_percent", trafo_vk_percent.size());
+    _check_same_size(fun_name, nb_trafo, ref, "trafo_vkr_percent", trafo_vkr_percent.size());
+    _check_same_size(fun_name, nb_trafo, ref, "trafo_sn_trafo_mva", trafo_sn_trafo_mva.size());
+    _check_same_size(fun_name, nb_trafo, ref, "trafo_pfe_kw", trafo_pfe_kw.size());
+    _check_same_size(fun_name, nb_trafo, ref, "trafo_i0_pct", trafo_i0_pct.size());
+}
+
+void PandaPowerConverter::_check_line_inputs(const std::string & fun_name,
+                                             const Eigen::Ref<const RealVect> & branch_r,
+                                             const Eigen::Ref<const RealVect> & branch_x,
+                                             const Eigen::Ref<const RealVect> & branch_g,
+                                             const Eigen::Ref<const RealVect> & branch_c,
+                                             const Eigen::Ref<const RealVect> & branch_from_kv,
+                                             const Eigen::Ref<const RealVect> & branch_to_kv)
+{
+    const Eigen::Index nb_line = branch_r.size();
+    const char * ref = "branch_r";
+    _check_same_size(fun_name, nb_line, ref, "branch_x", branch_x.size());
+    _check_same_size(fun_name, nb_line, ref, "branch_g", branch_g.size());
+    _check_same_size(fun_name, nb_line, ref, "branch_c", branch_c.size());
+    _check_same_size(fun_name, nb_line, ref, "branch_from_kv", branch_from_kv.size());
+    _check_same_size(fun_name, nb_line, ref, "branch_to_kv", branch_to_kv.size());
+}
 
 void PandaPowerConverter::_check_init() const {
     if(sn_mva_ <= 0.){
@@ -41,7 +102,9 @@ std::tuple<RealVect,
     _check_init();
 
     const int nb_trafo = static_cast<int>(tap_step_pct.size());
-    // TODO check all vectors have the same size
+    _check_trafo_inputs("get_trafo_param_pp2", tap_step_pct, tap_pos, tap_angles, is_tap_hv_side,
+                        vn_hv, vn_lv, trafo_vk_percent, trafo_vkr_percent, trafo_sn_trafo_mva,
+                        trafo_pfe_kw, trafo_i0_pct);
 
     // compute the adjusted for phase shifter and tap side
     auto tap_steps = 0.01 * tap_step_pct.array() * tap_pos.array();
@@ -134,10 +197,12 @@ std::tuple<RealVect,
                                                       const Eigen::Ref<const RealVect> & branch_g,
                                                       const Eigen::Ref<const RealVect> & branch_c,
                                                       const Eigen::Ref<const RealVect> & branch_from_kv,
-                                                      const Eigen::Ref<const RealVect> & /*branch_to_kv*/) const
+                                                      const Eigen::Ref<const RealVect> & branch_to_kv) const
 {
     //TODO does not use c at the moment!
     _check_init();
+    _check_line_inputs("get_line_param_legacy", branch_r, branch_x, branch_g, branch_c,
+                       branch_from_kv, branch_to_kv);
     const int nb_line = static_cast<int>(branch_r.size());
     RealVect branch_from_pu = branch_from_kv.array() * branch_from_kv.array() / sn_mva_;
 
@@ -166,9 +231,11 @@ std::tuple<RealVect,
                                         const Eigen::Ref<const RealVect> & branch_g,
                                         const Eigen::Ref<const RealVect> & branch_c,
                                         const Eigen::Ref<const RealVect> & branch_from_kv,
-                                        const Eigen::Ref<const RealVect> & /*branch_to_kv*/) const
+                                        const Eigen::Ref<const RealVect> & branch_to_kv) const
 {
     _check_init();
+    _check_line_inputs("get_line_param", branch_r, branch_x, branch_g, branch_c,
+                       branch_from_kv, branch_to_kv);
     const int nb_line = static_cast<int>(branch_r.size());
     RealVect branch_from_pu = branch_from_kv.array() * branch_from_kv.array() / sn_mva_;
 
@@ -212,7 +279,9 @@ std::tuple<RealVect,
     // see _calc_branch_values_from_trafo_df from pandapower.build_branch
 
     const int nb_trafo = static_cast<int>(tap_step_pct.size());
-    // TODO check all vectors have the same size
+    _check_trafo_inputs("get_trafo_param_pp3", tap_step_pct, tap_pos, tap_angles, is_tap_hv_side,
+                        vn_hv, vn_lv, trafo_vk_percent, trafo_vkr_percent, trafo_sn_mva,
+                        trafo_pfe_kw, trafo_i0_pct);
 
     // compute the adjusted for phase shifter and tap side
     auto tap_steps = 0.01 * tap_step_pct.array() * tap_pos.array();

--- a/src/core/DataConverter.cpp
+++ b/src/core/DataConverter.cpp
@@ -8,6 +8,7 @@
 
 #include "DataConverter.hpp"
 
+#include <cmath>      // std::isfinite (_check_init)
 #include <iostream>
 #include <sstream>
 #include <stdexcept>
@@ -75,11 +76,22 @@ void PandaPowerConverter::_check_line_inputs(const std::string & fun_name,
 }
 
 void PandaPowerConverter::_check_init() const {
-    if(sn_mva_ <= 0.){
-        throw std::runtime_error("PandaPowerConverter::_check_init: sn_mva has not been initialized");
+    // `!(x > 0.)` rather than `x <= 0.`: every comparison with NaN is false, so the
+    // naive form let a NaN sn_mva / f_hz straight through -- and both are divisors
+    // here (`vk_percent / 100. / sn_trafo_mva * tap_lv`, `2 * f_hz * pi * c * baseR`),
+    // so the whole converted grid came back NaN with no error anywhere.
+    if(!(sn_mva_ > 0.) || !std::isfinite(sn_mva_)){
+        std::ostringstream exc_;
+        exc_ << "PandaPowerConverter::_check_init: sn_mva is " << sn_mva_
+             << "; it must be a finite, strictly positive number (it is the base power of the "
+                "per-unit system this converter produces).";
+        throw std::runtime_error(exc_.str());
     }
-    if(f_hz_ <= 0.){
-        throw std::runtime_error("PandaPowerConverter::_check_init: f_hz has not been initialized");
+    if(!(f_hz_ > 0.) || !std::isfinite(f_hz_)){
+        std::ostringstream exc_;
+        exc_ << "PandaPowerConverter::_check_init: f_hz is " << f_hz_
+             << "; it must be a finite, strictly positive number.";
+        throw std::runtime_error(exc_.str());
     }
 }
 

--- a/src/core/DataConverter.hpp
+++ b/src/core/DataConverter.hpp
@@ -8,6 +8,7 @@
 
 #ifndef DATACONVERTER_H
 #define DATACONVERTER_H
+#include <string>
 #include <vector>
 
 #include "Utils.hpp"
@@ -105,6 +106,42 @@ class LS2G_API PandaPowerConverter final : public BaseConstants
 
     private:
         void _check_init() const;
+
+        // Every method above walks its inputs together, element by element, with
+        // unchecked accessors (`vect.coeff(i)`, `is_tap_hv_side[i]`) and combines
+        // them in coefficient-wise Eigen expressions whose result is sized from
+        // one of them. Eigen's own size assertions are compiled out of release
+        // wheels (-O3 -DNDEBUG), so a caller passing arrays of different lengths
+        // reads AND writes past the end of the shorter ones (observed as heap
+        // corruption, not a clean error). These are public python bindings
+        // (`PandaPowerConverter`), so the sizes have to be checked here.
+        static void _check_same_size(const std::string & fun_name,
+                                     Eigen::Index expected,
+                                     const std::string & expected_name,
+                                     const std::string & name,
+                                     Eigen::Index actual);
+        // the shared input-shape check of get_trafo_param_pp2 / get_trafo_param_pp3
+        // (identical argument lists)
+        static void _check_trafo_inputs(const std::string & fun_name,
+                                        const Eigen::Ref<const RealVect> & tap_step_pct,
+                                        const Eigen::Ref<const RealVect> & tap_pos,
+                                        const Eigen::Ref<const RealVect> & tap_angles,
+                                        const std::vector<bool> & is_tap_hv_side,
+                                        const Eigen::Ref<const RealVect> & vn_hv,
+                                        const Eigen::Ref<const RealVect> & vn_lv,
+                                        const Eigen::Ref<const RealVect> & trafo_vk_percent,
+                                        const Eigen::Ref<const RealVect> & trafo_vkr_percent,
+                                        const Eigen::Ref<const RealVect> & trafo_sn_trafo_mva,
+                                        const Eigen::Ref<const RealVect> & trafo_pfe_kw,
+                                        const Eigen::Ref<const RealVect> & trafo_i0_pct);
+        // ... and of get_line_param / get_line_param_legacy
+        static void _check_line_inputs(const std::string & fun_name,
+                                       const Eigen::Ref<const RealVect> & branch_r,
+                                       const Eigen::Ref<const RealVect> & branch_x,
+                                       const Eigen::Ref<const RealVect> & branch_g,
+                                       const Eigen::Ref<const RealVect> & branch_c,
+                                       const Eigen::Ref<const RealVect> & branch_from_kv,
+                                       const Eigen::Ref<const RealVect> & branch_to_kv);
 };
 
 // TODO have a converter from ppc !

--- a/src/core/LSGrid.cpp
+++ b/src/core/LSGrid.cpp
@@ -338,18 +338,37 @@ void LSGrid::check_grid() const
     const int nb_sub = substations_.nb_sub();
 
     // Per-container range + finiteness checks. Each container appends the
-    // pos_topo_vect entries it carries (an optional field) to all_pos_topo_vect
-    // for the global permutation check below.
-    std::vector<int> all_pos_topo_vect;
+    // pos_topo_vect entries it carries (an optional field) to the accumulator it is
+    // given, for the global permutation check below.
+    //
+    // Only the containers update_topo() actually walks may contribute to
+    // `all_pos_topo_vect`: that vector's own length is the `dim_topo` the permutation
+    // is proved against, and update_topo() sizes its caller arrays as
+    // `nb loads + nb gens + nb storages + 2 * nb lines + 2 * nb trafos`. Letting a
+    // shunt / sgen / svc / hvdc position into the same pot inflates that bound, so a
+    // *validated* load position could still be >= the length of the arrays
+    // update_topo() indexes with it. Those containers have no position in the grid2op
+    // topology vector to begin with (there is no setter for one), so a state carrying
+    // one is inconsistent: collect them apart and reject.
+    std::vector<int> all_pos_topo_vect;   // elements update_topo() drives
+    std::vector<int> pos_topo_vect_not_in_topo;  // must stay empty
     powerlines_.check_valid(nb_bus, nb_sub, substations_, all_pos_topo_vect);
     trafos_.check_valid(nb_bus, nb_sub, substations_, all_pos_topo_vect);
-    shunts_.check_valid(nb_bus, nb_sub, substations_, all_pos_topo_vect);
     generators_.check_valid(nb_bus, nb_sub, substations_, all_pos_topo_vect);
     loads_.check_valid(nb_bus, nb_sub, substations_, all_pos_topo_vect);
-    sgens_.check_valid(nb_bus, nb_sub, substations_, all_pos_topo_vect);
     storages_.check_valid(nb_bus, nb_sub, substations_, all_pos_topo_vect);
-    hvdc_lines_.check_valid(nb_bus, nb_sub, substations_, all_pos_topo_vect);
-    svcs_.check_valid(nb_bus, nb_sub, substations_, all_pos_topo_vect);
+    shunts_.check_valid(nb_bus, nb_sub, substations_, pos_topo_vect_not_in_topo);
+    sgens_.check_valid(nb_bus, nb_sub, substations_, pos_topo_vect_not_in_topo);
+    hvdc_lines_.check_valid(nb_bus, nb_sub, substations_, pos_topo_vect_not_in_topo);
+    svcs_.check_valid(nb_bus, nb_sub, substations_, pos_topo_vect_not_in_topo);
+    if(!pos_topo_vect_not_in_topo.empty())
+    {
+        throw std::runtime_error(
+            "LSGrid::check_grid: a shunt, static generator, svc or hvdc line declares a position "
+            "in the grid2op topology vector. Only loads, generators, storage units, powerlines and "
+            "transformers are part of that vector (it is what sizes the arrays passed to "
+            "update_topo), so this state is inconsistent.");
+    }
 
     // pos_topo_vect is grid2op-specific and optional: it is either set on every
     // topology-participating element or on none. When set, the collected values

--- a/src/core/LSGrid.cpp
+++ b/src/core/LSGrid.cpp
@@ -10,7 +10,10 @@
 #include "AlgorithmSelector.hpp"  // to avoid circular references
 #include "BinaryArchive.hpp"
 
+#include <cmath>      // std::isfinite (check_positive_finite)
 #include <queue>
+#include <sstream>
+#include <stdexcept>
 
 namespace ls2g {
 
@@ -328,6 +331,23 @@ void LSGrid::_restore_algorithm(AlgorithmSelector & algo_selector,
 
 void LSGrid::check_grid() const
 {
+    // The two grid-wide scalars, before anything else. `set_state` assigns them
+    // straight from the serialized state (bypassing the setters), and the loaders take
+    // them verbatim from their source file -- `init_from_powermodels` /
+    // `init_from_matpower` do `set_sn_mva(float(network["baseMVA"]))`, and
+    // `init_from_pandapower` `set_sn_mva(pp_net.sn_mva)`.
+    //
+    // sn_mva_ is the base power of the whole per-unit system: Sbus is divided by it,
+    // every MW / MVar result multiplied back by it, and ac_pf even scales the solver
+    // tolerance with it. A degenerate value does not make the powerflow fail, it makes
+    // it *quietly wrong*: with sn_mva_ = NaN the DC powerflow reports CONVERGENCE and
+    // hands back NaN flows (the built-in solvers' own finiteness guards see a perfectly
+    // finite Va -- Bbus does not involve sn_mva -- and the size/finiteness check on the
+    // solver output is deliberately reserved for external solvers), and with a negative
+    // one it reports a plausible-looking but sign-inverted per-unit system.
+    check_positive_finite(sn_mva_, "sn_mva");
+    check_positive_finite(init_vm_pu_, "init_vm_pu");
+
     // The substation container FIRST: it defines nb_bus / nb_sub, the bounds every
     // per-element check below is expressed against, and it carries the vector
     // (bus_status_) those very ids are used to index. Validating elements against a
@@ -500,6 +520,18 @@ void LSGrid::set_ls_to_orig(const Eigen::Ref<const IntVect> & ls_to_orig){
 // allocation for a handful of buses). Both are rejected here, before any allocation.
 // This runs on the python property setter AND on set_state(), ie on every pickle and
 // every binary file.
+void LSGrid::check_positive_finite(real_type value, const char * name)
+{
+    // NB `!(value > 0.)`, not `value <= 0.`: every comparison with NaN is false, so the
+    // naive form silently accepts a NaN -- which is exactly the value that does the most
+    // damage here (see check_grid()).
+    if(std::isfinite(value) && (value > 0.)) return;
+    std::ostringstream exc_;
+    exc_ << "LSGrid: '" << name << "' is " << value
+         << "; it must be a finite, strictly positive number.";
+    throw std::runtime_error(exc_.str());
+}
+
 void LSGrid::check_ls_to_orig_values(const Eigen::Ref<const IntVect> & ls_to_orig)
 {
     // an original grid can never have more buses than the biggest vector we could

--- a/src/core/LSGrid.hpp
+++ b/src/core/LSGrid.hpp
@@ -309,10 +309,27 @@ class LS2G_API LSGrid final
 
         // All methods to init this data model, all need to be pair unit when applicable
         void init_bus(unsigned int n_sub, unsigned int n_busbar_per_sub, const Eigen::Ref<const RealVect> & bus_vn_kv, int nb_line, int nb_trafo);
-        void set_init_vm_pu(real_type init_vm_pu) {init_vm_pu_ = init_vm_pu; }
+        // Both scalars below must be finite and strictly positive: they are physical
+        // per-unit quantities, and a degenerate value does not fail loudly, it produces
+        // a *confidently wrong* answer. `sn_mva_` is the base power of the entire
+        // per-unit system (Sbus is divided by it, every MW/MVar result multiplied back
+        // by it, and even the solver tolerance is scaled by it in ac_pf), and
+        // `init_vm_pu_` is the flat-start voltage magnitude. See check_positive_finite.
+        void set_init_vm_pu(real_type init_vm_pu) {
+            check_positive_finite(init_vm_pu, "init_vm_pu");
+            init_vm_pu_ = init_vm_pu;
+        }
         [[nodiscard]] real_type get_init_vm_pu() const {return init_vm_pu_;}
-        void set_sn_mva(real_type sn_mva) {sn_mva_ = sn_mva; }
+        void set_sn_mva(real_type sn_mva) {
+            check_positive_finite(sn_mva, "sn_mva");
+            sn_mva_ = sn_mva;
+        }
         [[nodiscard]] real_type get_sn_mva() const {return sn_mva_;}
+
+        // Throws std::runtime_error unless `value` is finite and > 0. Written as
+        // `!(value > 0.)` on purpose: `value <= 0.` is FALSE for NaN, so the naive
+        // form lets a NaN straight through.
+        static void check_positive_finite(real_type value, const char * name);
 
         void init_powerlines(const Eigen::Ref<const RealVect> & branch_r,
                              const Eigen::Ref<const RealVect> & branch_x,

--- a/src/core/element_container/SvcContainer.cpp
+++ b/src/core/element_container/SvcContainer.cpp
@@ -11,6 +11,7 @@
 
 #include <iostream>
 #include <sstream>
+#include <stdexcept>
 
 namespace ls2g {
 
@@ -83,6 +84,39 @@ void SvcContainer::set_state(SvcContainer::StateRes & my_state)
     b_max_ = RealVect::Map(bmax.data(), bmax.size());
     regulated_bus_id_ = Eigen::VectorXi::Map(regulated_bus.data(), regulated_bus.size());
     reset_results();
+}
+
+void SvcContainer::check_valid(int nb_bus,
+                               int nb_sub,
+                               const SubstationContainer & substations,
+                               std::vector<int> & all_pos_topo_vect) const
+{
+    // one-side index checks (bus / subid / pos_topo_vect)
+    check_valid_osc(nb_bus, nb_sub, substations, all_pos_topo_vect, "svc");
+
+    // `regulated_bus_id_` is a gridmodel bus id that the powerflow uses *as an index*
+    // without re-checking it: `id_grid_to_solver[regulated_bus_id_(svc_id)]` in
+    // SvcContainer::set_vm and in LSGrid::fill_voltage_control_solver_data, and
+    // `Vm(regulated_bus_id_(svc_id))` in get_vm_for_dc. Nothing on the way in bounds it
+    // (SvcContainer::init only checks the vector's length, and a pickle / binary file
+    // sets it verbatim), so an out-of-range value is an out-of-bounds read followed by
+    // an out-of-bounds write into V. Same check as the generator field of the same name.
+    const int nb_svc = nb();
+    const bool has_reg_info = regulated_bus_id_.size() > 0;
+    if(!has_reg_info) return;
+    for(int svc_id = 0; svc_id < nb_svc; ++svc_id)
+    {
+        // -1 is legal: this SVC regulates no bus (disconnected / no remote target)
+        const int reg = regulated_bus_id_(svc_id);
+        if(reg == _deactivated_bus_id) continue;
+        if((reg < 0) || (reg >= nb_bus))
+        {
+            std::ostringstream exc_;
+            exc_ << "LSGrid::check_grid: svc id " << svc_id << " regulates bus id " << reg
+                 << " which is out of range [0, " << nb_bus << ").";
+            throw std::out_of_range(exc_.str());
+        }
+    }
 }
 
 void SvcContainer::fillSbus(Eigen::Ref<CplxVect> Sbus, const SolverBusIdVect & id_grid_to_solver, bool /*ac*/) const

--- a/src/core/element_container/SvcContainer.hpp
+++ b/src/core/element_container/SvcContainer.hpp
@@ -109,6 +109,16 @@ class LS2G_API SvcContainer final : public OneSideContainer_PQ, public IteratorA
         SvcContainer::StateRes get_state() const;
         void set_state(SvcContainer::StateRes & my_state);
 
+        // Whole-grid semantic validation (see GenericContainer::check_valid): the
+        // one-side checks, plus the range of `regulated_bus_id_`. That last one is
+        // a *grid* bus id used directly as an index (`id_grid_to_solver[...]` in
+        // set_vm / LSGrid::fill_voltage_control_solver_data, `Vm(...)` in
+        // get_vm_for_dc), exactly like the generator field of the same name.
+        void check_valid(int nb_bus,
+                         int nb_sub,
+                         const SubstationContainer & substations,
+                         std::vector<int> & all_pos_topo_vect) const override;
+
         // fast binary serialization (additive alternative to pickle, see BinaryArchive.hpp)
         void save_binary(const std::string & path, bool atomic = true) const;
         static SvcContainer load_binary(const std::string & path);

--- a/src/core/element_container/TrafoContainer.cpp
+++ b/src/core/element_container/TrafoContainer.cpp
@@ -128,8 +128,44 @@ void TrafoContainer::set_state(TrafoContainer::StateRes & my_state)
     GenericContainer::check_size(base_x, size, "base_x");
     base_r_ = RealVect::Map(base_r.data(), size);
     base_x_ = RealVect::Map(base_x.data(), size);
-    rx_corr_alpha_ = std::get<8>(my_state);
-    rx_corr_pct_ = std::get<9>(my_state);
+
+    // The two alpha -> r/x correction tables come straight from a pickle or a binary
+    // file. `_update_model_coeffs()` right below walks el_id over [0, nb()) and reads
+    // `rx_corr_alpha_[el_id]` / `rx_corr_pct_[el_id]` with an unchecked
+    // std::vector::operator[], and `_shift_rx_corr_pct` then interpolates `ys` using
+    // indices derived from `xs.size()`. So a state declaring fewer tables than
+    // transformers builds a std::vector out of whatever the heap holds past the end
+    // (and dereferences its pointers), and a state whose alpha / correction tables
+    // differ in length reads past the end of the shorter one. Neither is caught by
+    // check_grid(): this runs *before* it. Validate both shapes here, exactly the
+    // invariant init() and set_shift_dependent_rx() maintain.
+    const std::vector<std::vector<real_type> > & rx_corr_alpha = std::get<8>(my_state);
+    const std::vector<std::vector<real_type> > & rx_corr_pct = std::get<9>(my_state);
+    if(rx_corr_alpha.empty() && rx_corr_pct.empty()){
+        // no table at all: only legal when nothing would index them
+        if(shift_dependent_rx_ && (size > 0)){
+            std::ostringstream exc_;
+            exc_ << "TrafoContainer::set_state: shift-dependent r/x is enabled for " << size
+                 << " transformer(s) but the state carries no (alpha -> correction) table at all. "
+                 << "The tables are indexed by transformer id, so this state is inconsistent.";
+            throw std::runtime_error(exc_.str());
+        }
+    } else {
+        GenericContainer::check_size(rx_corr_alpha, size, "rx_corr_alpha");
+        GenericContainer::check_size(rx_corr_pct, size, "rx_corr_pct");
+        for(std::size_t el_id = 0; el_id < rx_corr_alpha.size(); ++el_id){
+            if(rx_corr_alpha[el_id].size() != rx_corr_pct[el_id].size()){
+                std::ostringstream exc_;
+                exc_ << "TrafoContainer::set_state: transformer " << el_id << " has "
+                     << rx_corr_alpha[el_id].size() << " alpha sample(s) but "
+                     << rx_corr_pct[el_id].size() << " r/x correction value(s). Both tables are "
+                     << "read together (one correction per alpha) and must have the same length.";
+                throw std::runtime_error(exc_.str());
+            }
+        }
+    }
+    rx_corr_alpha_ = rx_corr_alpha;
+    rx_corr_pct_ = rx_corr_pct;
 
     _update_model_coeffs();
     reset_results();

--- a/src/core/element_container/TwoSidesContainer.hpp
+++ b/src/core/element_container/TwoSidesContainer.hpp
@@ -430,6 +430,14 @@ class TwoSidesContainer : public GenericContainer
             if(names_.size() > 0) check_size(names_, size, "names");  // names are optional
             if(static_cast<size_t>(side_1_.nb()) != size) throw std::runtime_error("Side_1 do not have the proper size");
             if(static_cast<size_t>(side_2_.nb()) != size) throw std::runtime_error("Side_2 do not have the proper size");
+            // `nb()` is side_1_.nb(), NOT status_global_.size(): nothing above ties the
+            // two together, yet status_global_ is indexed with element ids bounded by
+            // nb() all over this class (resolve_status, _deactivate, fillYbus, the batch
+            // solvers...) with an unchecked operator[]. A pickle / binary file declaring
+            // a shorter (in particular empty) status_global_ therefore reads and writes
+            // past its end -- and check_grid() never sees it, it runs later and only
+            // looks at the per-side data. Demand the exact length here.
+            check_size(status_global_, size, "status_global");
         }
 
         bool resolve_status(int el_id, bool side_1_modif, DualAlgoControl & solver_control){

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -58,6 +58,7 @@ add_executable(lightsim2grid_unit_tests
     test_ls2g_abi_tag.cpp
     test_plugin_registration.cpp
     test_check_grid.cpp
+    test_state_poisoning.cpp
 )
 target_link_libraries(lightsim2grid_unit_tests PRIVATE lightsim2grid_core Catch2::Catch2WithMain)
 

--- a/src/tests/test_state_poisoning.cpp
+++ b/src/tests/test_state_poisoning.cpp
@@ -20,6 +20,8 @@
 // valgrind/ASan in the cpp_unit_tests workflow, which is what proves the
 // rejection happens *before* anything is indexed.
 
+#include <cmath>
+#include <limits>
 #include <stdexcept>
 #include <tuple>
 #include <vector>
@@ -272,6 +274,64 @@ TEST_CASE("set_state rejects a wrong-sized status_global on the hvdc lines", "[c
 
     LSGrid restored;
     CHECK_THROWS_AS(restored.set_state(st), std::runtime_error);
+}
+
+// ---------------------------------------------------------------------------
+// the grid-wide per-unit scalars
+// ---------------------------------------------------------------------------
+// sn_mva_ scales the whole per-unit system (Sbus is divided by it, results are
+// multiplied back by it, ac_pf even scales the solver tolerance with it) and
+// init_vm_pu_ is the flat-start voltage magnitude. Neither was validated
+// anywhere. A degenerate value does not fail loudly: with sn_mva_ = NaN the DC
+// powerflow reported CONVERGENCE and returned NaN flows, because the built-in
+// solvers' finiteness guards only see Va (which Bbus, and so sn_mva, never
+// touches) and the finiteness check on the solver output is reserved for
+// external solvers.
+
+TEST_CASE("check_grid rejects a non-positive or non-finite sn_mva", "[check_grid][state_poisoning]")
+{
+    LSGrid grid = exotic();
+    const std::vector<real_type> bad = {0.,
+                                        -100.,
+                                        std::numeric_limits<real_type>::quiet_NaN(),
+                                        std::numeric_limits<real_type>::infinity()};
+    for(const real_type v : bad)
+    {
+        LSGrid::StateRes st = grid.get_state();
+        std::get<LSGrid::SN_MVA_ID>(st) = v;
+        LSGrid restored;
+        CHECK_THROWS_AS(restored.set_state(st), std::runtime_error);
+    }
+}
+
+TEST_CASE("check_grid rejects a non-positive or non-finite init_vm_pu", "[check_grid][state_poisoning]")
+{
+    LSGrid grid = exotic();
+    const std::vector<real_type> bad = {0.,
+                                        -1.,
+                                        std::numeric_limits<real_type>::quiet_NaN(),
+                                        std::numeric_limits<real_type>::infinity()};
+    for(const real_type v : bad)
+    {
+        LSGrid::StateRes st = grid.get_state();
+        std::get<LSGrid::INIT_VM_PU_ID>(st) = v;
+        LSGrid restored;
+        CHECK_THROWS_AS(restored.set_state(st), std::runtime_error);
+    }
+}
+
+TEST_CASE("the sn_mva / init_vm_pu setters reject degenerate values", "[check_grid][state_poisoning]")
+{
+    LSGrid grid = exotic();
+    CHECK_THROWS_AS(grid.set_sn_mva(0.), std::runtime_error);
+    CHECK_THROWS_AS(grid.set_sn_mva(-100.), std::runtime_error);
+    CHECK_THROWS_AS(grid.set_sn_mva(std::numeric_limits<real_type>::quiet_NaN()), std::runtime_error);
+    CHECK_THROWS_AS(grid.set_init_vm_pu(std::numeric_limits<real_type>::infinity()), std::runtime_error);
+    // and a sane value still goes through, leaving a usable grid
+    REQUIRE_NOTHROW(grid.set_sn_mva(100.));
+    REQUIRE_NOTHROW(grid.set_init_vm_pu(1.04));
+    CHECK_NOTHROW(grid.check_grid());
+    CHECK(grid.ac_pf(flat_start(grid), 20, 1e-7).size() == 14);
 }
 
 // ---------------------------------------------------------------------------

--- a/src/tests/test_state_poisoning.cpp
+++ b/src/tests/test_state_poisoning.cpp
@@ -1,0 +1,300 @@
+// Copyright (c) 2026, RTE (https://www.rte-france.com)
+// See AUTHORS.txt
+// This Source Code Form is subject to the terms of the Mozilla Public License, version 2.0.
+// If a copy of the Mozilla Public License, version 2.0 was not distributed with this file,
+// you can obtain one at http://mozilla.org/MPL/2.0/.
+// SPDX-License-Identifier: MPL-2.0
+// This file is part of LightSim2grid, LightSim2grid implements a c++ backend targeting the Grid2Op platform.
+
+// Second round of "poisoned state" tests, on the element types the first one
+// (test_check_grid.cpp) could not reach with its 3-bus / 2-line / 1-load /
+// 1-gen fixture: transformers with a shift-dependent r/x table, SVCs, HVDC
+// lines. The grid comes from case_exotic_elements.hpp (IEEE14 + SVC + storage +
+// 3 HVDC lines + a phase-shifting transformer), so every container involved is
+// non-empty.
+//
+// Same concern as test_check_grid.cpp: release wheels are built -O3 -DNDEBUG, so
+// an inconsistency restored from a well-formed-but-poisoned pickle / binary file
+// turns into an out-of-bounds read or write rather than an error. Every case
+// below segfaulted before the corresponding fix; they also run under
+// valgrind/ASan in the cpp_unit_tests workflow, which is what proves the
+// rejection happens *before* anything is indexed.
+
+#include <stdexcept>
+#include <tuple>
+#include <vector>
+
+#include <catch2/catch_test_macros.hpp>
+
+#include "LSGrid.hpp"
+#include "case_exotic_elements.hpp"
+
+using ls2g::CplxVect;
+using ls2g::LSGrid;
+using ls2g::RealVect;
+using ls2g::cplx_type;
+using ls2g::real_type;
+
+namespace {
+
+LSGrid exotic() { return ls2g_test::make_exotic_elements_grid(); }
+
+CplxVect flat_start(const LSGrid & grid)
+{
+    return CplxVect::Constant(static_cast<Eigen::Index>(grid.total_bus()), cplx_type(1., 0.));
+}
+
+// --- accessors into the (deeply nested) StateRes tuple -----------------------
+// TRAFO_ID -> TrafoContainer::StateRes = tuple<[0] TwoSidesContainer_rxh_A::StateRes,
+//   ratio, is_tap_side1, shift, ignore_tap_side_for_shift, [5] shift_dependent_rx,
+//   base_r, base_x, [8] rx_corr_alpha, [9] rx_corr_pct>
+bool& trafo_shift_dependent_rx(LSGrid::StateRes & st)
+{
+    return std::get<5>(std::get<LSGrid::TRAFO_ID>(st));
+}
+std::vector<std::vector<real_type> >& trafo_rx_corr_alpha(LSGrid::StateRes & st)
+{
+    return std::get<8>(std::get<LSGrid::TRAFO_ID>(st));
+}
+std::vector<std::vector<real_type> >& trafo_rx_corr_pct(LSGrid::StateRes & st)
+{
+    return std::get<9>(std::get<LSGrid::TRAFO_ID>(st));
+}
+// SVC_ID -> SvcContainer::StateRes = tuple<OSC_PQ::StateRes, regulation_mode,
+//   target_vm_pu, slope_pu, b_min, b_max, [6] regulated_bus_id>
+std::vector<int>& svc_regulated_bus(LSGrid::StateRes & st)
+{
+    return std::get<6>(std::get<LSGrid::SVC_ID>(st));
+}
+// LINE_ID / TRAFO_ID -> [0] TwoSidesContainer_rxh_A::StateRes
+//   -> [0] TwoSidesContainer::StateRes = tuple<ignore_status_global,
+//          synch_status_both_side, names, [3] status_global, side_1, side_2>
+template<std::size_t BRANCH_ID>
+std::vector<bool>& branch_status_global(LSGrid::StateRes & st)
+{
+    return std::get<3>(std::get<0>(std::get<0>(std::get<BRANCH_ID>(st))));
+}
+// HVDC_ID -> HvdcLineContainer::StateRes = tuple<[0] TwoSidesContainer::StateRes, ...>
+std::vector<bool>& hvdc_status_global(LSGrid::StateRes & st)
+{
+    return std::get<3>(std::get<0>(std::get<LSGrid::HVDC_ID>(st)));
+}
+// SHUNT_ID -> ShuntContainer::StateRes -> [0] OneSideContainer_PQ::StateRes
+//   -> [0] OneSideContainer::StateRes = tuple<names, bus_id, status, has_subid,
+//          subid, [5] has_pos_topo_vect, [6] pos_topo_vect>
+bool& shunt_has_pos_topo_vect(LSGrid::StateRes & st)
+{
+    return std::get<5>(std::get<0>(std::get<0>(std::get<LSGrid::SHUNT_ID>(st))));
+}
+std::vector<int>& shunt_pos_topo_vect(LSGrid::StateRes & st)
+{
+    return std::get<6>(std::get<0>(std::get<0>(std::get<LSGrid::SHUNT_ID>(st))));
+}
+
+} // namespace
+
+TEST_CASE("the exotic-elements grid state round-trips and stays valid", "[check_grid][state_poisoning]")
+{
+    LSGrid grid = exotic();
+    LSGrid::StateRes st = grid.get_state();
+    LSGrid restored;
+    REQUIRE_NOTHROW(restored.set_state(st));
+    CHECK_NOTHROW(restored.check_grid());
+    const CplxVect V = restored.ac_pf(flat_start(restored), 20, 1e-7);
+    CHECK(V.size() == 14);
+}
+
+// ---------------------------------------------------------------------------
+// TrafoContainer: the (alpha -> r/x correction) tables
+// ---------------------------------------------------------------------------
+// `_update_model_coeffs()` runs at the very end of TrafoContainer::set_state --
+// long before check_grid() -- and reads rx_corr_alpha_[el_id] / rx_corr_pct_[el_id]
+// for el_id in [0, nb()) with an unchecked std::vector::operator[]. A state
+// declaring fewer tables than transformers therefore builds a std::vector out of
+// heap memory past the end of the array and dereferences its pointers.
+
+TEST_CASE("set_state rejects shift-dependent r/x with no correction table at all", "[check_grid][state_poisoning]")
+{
+    LSGrid grid = exotic();
+    LSGrid::StateRes st = grid.get_state();
+    REQUIRE(trafo_shift_dependent_rx(st));            // the fixture uses this feature
+    REQUIRE(trafo_rx_corr_alpha(st).size() == 3u);
+    trafo_rx_corr_alpha(st).clear();
+    trafo_rx_corr_pct(st).clear();
+
+    LSGrid restored;
+    CHECK_THROWS_AS(restored.set_state(st), std::runtime_error);
+}
+
+TEST_CASE("set_state rejects a correction table shorter than the number of trafos", "[check_grid][state_poisoning]")
+{
+    LSGrid grid = exotic();
+    LSGrid::StateRes st = grid.get_state();
+    REQUIRE(trafo_rx_corr_alpha(st).size() == 3u);
+    trafo_rx_corr_alpha(st).pop_back();               // 2 tables for 3 transformers
+
+    LSGrid restored;
+    CHECK_THROWS_AS(restored.set_state(st), std::runtime_error);
+}
+
+TEST_CASE("set_state rejects alpha / correction tables of different lengths", "[check_grid][state_poisoning]")
+{
+    LSGrid grid = exotic();
+    LSGrid::StateRes st = grid.get_state();
+    // one alpha sample without its correction: _shift_rx_corr_pct() indexes `ys`
+    // with positions derived from `xs.size()`
+    trafo_rx_corr_alpha(st)[0] = std::vector<real_type>{-0.5, 0., 0.5};
+    trafo_rx_corr_pct(st)[0] = std::vector<real_type>{1., 2.};
+
+    LSGrid restored;
+    CHECK_THROWS_AS(restored.set_state(st), std::runtime_error);
+}
+
+TEST_CASE("set_state accepts a grid with no correction table and the feature off", "[check_grid][state_poisoning]")
+{
+    LSGrid grid = exotic();
+    LSGrid::StateRes st = grid.get_state();
+    trafo_shift_dependent_rx(st) = false;
+    trafo_rx_corr_alpha(st).clear();
+    trafo_rx_corr_pct(st).clear();
+
+    LSGrid restored;
+    REQUIRE_NOTHROW(restored.set_state(st));
+    CHECK_NOTHROW(restored.check_grid());
+}
+
+// ---------------------------------------------------------------------------
+// SvcContainer: the regulated bus id
+// ---------------------------------------------------------------------------
+// `regulated_bus_id_` is a gridmodel bus id used directly as an index in
+// SvcContainer::set_vm (`id_grid_to_solver[...]`, then a write into V) and in
+// LSGrid::fill_voltage_control_solver_data. Nothing bounded it: SvcContainer::init
+// only checks the vector's length, and set_state copies it verbatim. It is the
+// exact counterpart of GeneratorContainer's field of the same name, which
+// check_grid() has always validated.
+
+TEST_CASE("check_grid rejects an out-of-range svc regulated bus id (set_state)", "[check_grid][state_poisoning]")
+{
+    LSGrid grid = exotic();
+    LSGrid::StateRes st = grid.get_state();
+    REQUIRE(svc_regulated_bus(st).size() == 1u);
+    svc_regulated_bus(st)[0] = 10000000;
+
+    LSGrid restored;
+    CHECK_THROWS_AS(restored.set_state(st), std::out_of_range);
+}
+
+TEST_CASE("check_grid rejects a negative (non-sentinel) svc regulated bus id", "[check_grid][state_poisoning]")
+{
+    LSGrid grid = exotic();
+    LSGrid::StateRes st = grid.get_state();
+    svc_regulated_bus(st)[0] = -5;
+
+    LSGrid restored;
+    CHECK_THROWS_AS(restored.set_state(st), std::out_of_range);
+}
+
+TEST_CASE("check_grid rejects an out-of-range svc regulated bus set through init_svcs", "[check_grid][state_poisoning]")
+{
+    // same hole, reached without any serialization: a grid loader (init_from_pypowsybl
+    // builds the SVCs) passing a bus id its source file got wrong.
+    LSGrid grid = exotic();
+    const std::vector<int> mode{1};                    // VOLTAGE
+    RealVect target_vm_pu(1), q_setpoint(1), slope(1), b_min(1), b_max(1);
+    target_vm_pu << 1.0;
+    q_setpoint << 0.;
+    slope << 0.;
+    b_min << -0.03;
+    b_max << 0.03;
+    Eigen::VectorXi regulated_bus(1), svc_bus(1);
+    regulated_bus << 10000000;                         // out of range
+    svc_bus << 5;
+    grid.init_svcs(mode, target_vm_pu, q_setpoint, slope, b_min, b_max, regulated_bus, svc_bus);
+
+    CHECK_THROWS_AS(grid.check_grid(), std::out_of_range);
+}
+
+TEST_CASE("check_grid accepts the -1 sentinel as an svc regulated bus", "[check_grid][state_poisoning]")
+{
+    LSGrid grid = exotic();
+    LSGrid::StateRes st = grid.get_state();
+    svc_regulated_bus(st)[0] = -1;                     // regulates no bus
+
+    LSGrid restored;
+    REQUIRE_NOTHROW(restored.set_state(st));
+    CHECK_NOTHROW(restored.check_grid());
+}
+
+// ---------------------------------------------------------------------------
+// TwoSidesContainer: status_global_
+// ---------------------------------------------------------------------------
+// `nb()` is side_1_.nb(), NOT status_global_.size(), and set_tsc_state tied the
+// two together nowhere -- while status_global_[el_id] (unchecked operator[], with
+// el_id bounded by nb()) is read all over the class and the batch solvers.
+
+TEST_CASE("set_state rejects an empty status_global on the powerlines", "[check_grid][state_poisoning]")
+{
+    LSGrid grid = exotic();
+    LSGrid::StateRes st = grid.get_state();
+    REQUIRE(!branch_status_global<LSGrid::LINE_ID>(st).empty());
+    branch_status_global<LSGrid::LINE_ID>(st).clear();
+
+    LSGrid restored;
+    CHECK_THROWS_AS(restored.set_state(st), std::runtime_error);
+}
+
+TEST_CASE("set_state rejects a short status_global on the powerlines", "[check_grid][state_poisoning]")
+{
+    LSGrid grid = exotic();
+    LSGrid::StateRes st = grid.get_state();
+    branch_status_global<LSGrid::LINE_ID>(st).pop_back();
+
+    LSGrid restored;
+    CHECK_THROWS_AS(restored.set_state(st), std::runtime_error);
+}
+
+TEST_CASE("set_state rejects a wrong-sized status_global on the trafos", "[check_grid][state_poisoning]")
+{
+    LSGrid grid = exotic();
+    LSGrid::StateRes st = grid.get_state();
+    branch_status_global<LSGrid::TRAFO_ID>(st).clear();
+
+    LSGrid restored;
+    CHECK_THROWS_AS(restored.set_state(st), std::runtime_error);
+}
+
+TEST_CASE("set_state rejects a wrong-sized status_global on the hvdc lines", "[check_grid][state_poisoning]")
+{
+    LSGrid grid = exotic();
+    LSGrid::StateRes st = grid.get_state();
+    REQUIRE(!hvdc_status_global(st).empty());
+    hvdc_status_global(st).push_back(true);            // one too many
+
+    LSGrid restored;
+    CHECK_THROWS_AS(restored.set_state(st), std::runtime_error);
+}
+
+// ---------------------------------------------------------------------------
+// pos_topo_vect on an element that is not in the grid2op topology vector
+// ---------------------------------------------------------------------------
+// check_grid() proves the collected positions are a permutation of [0, K) where
+// K is how many it collected. update_topo() sizes its caller arrays as
+// `nb loads + nb gens + nb storages + 2 * nb lines + 2 * nb trafos` and indexes
+// them with those very positions. Letting a shunt / sgen / svc / hvdc position
+// into the same pot makes K bigger than that, so a *validated* position could
+// still be past the end of the arrays update_topo() reads.
+
+TEST_CASE("check_grid rejects a pos_topo_vect on a shunt", "[check_grid][state_poisoning]")
+{
+    LSGrid grid = exotic();
+    LSGrid::StateRes st = grid.get_state();
+    const std::size_t nb_shunt = std::get<1>(std::get<0>(std::get<0>(std::get<LSGrid::SHUNT_ID>(st)))).size();
+    REQUIRE(nb_shunt > 0u);
+    shunt_has_pos_topo_vect(st) = true;
+    std::vector<int> pos(nb_shunt);
+    for(std::size_t i = 0; i < nb_shunt; ++i) pos[i] = static_cast<int>(i);
+    shunt_pos_topo_vect(st) = pos;
+
+    LSGrid restored;
+    CHECK_THROWS_AS(restored.set_state(st), std::runtime_error);
+}


### PR DESCRIPTION
Follow-up to the audit merged in #155 / #156, over the channels `docs/security.rst` covers: pickle, the fast binary format, and the python bindings including the grid loaders.

## Memory-safety holes (commit `ac5399f`)

Five issues, each **reproduced as a segfault or as heap corruption** before the fix:

| Where | Reachable from | Effect |
|---|---|---|
| `TrafoContainer::set_state` — the two per-transformer `alpha -> r/x correction` tables copied with no check, then `_update_model_coeffs()` indexes them per transformer with an unchecked `operator[]` | pickle, `.lsb` | builds a `std::vector` out of heap memory past the end of the array and dereferences its pointers → **segfault**. Runs *inside* `set_state`, before `check_grid()` sees the grid |
| `TwoSidesContainer::set_tsc_state` never checked `status_global_`'s length (`nb()` is `side_1_.nb()`) | pickle, `.lsb` | that vector is indexed with element ids bounded by `nb()` throughout the class and the batch solvers → **segfault**. Affects powerlines, transformers and hvdc lines |
| `check_grid()` did not range-check `SvcContainer::regulated_bus_id_` | pickle, `.lsb`, **and `init_svcs` / `init_from_pypowsybl`** | it is a gridmodel bus id used directly as an index — `id_grid_to_solver[...]` in `SvcContainer::set_vm`, followed by a **write into `V`** → **segfault on `ac_pf`**. The generator field of the same name was already validated |
| `check_grid()` collected `pos_topo_vect` from every container, so the `dim_topo` it proved the permutation against could exceed the one `update_topo()` sizes its caller arrays with (which excludes shunts, sgens, svcs, hvdc) | pickle, `.lsb` | a *validated* load position could still be past the end of the array `update_topo()` indexes with it → **segfault** |
| `PandaPowerConverter` never checked that its inputs have the same length (there was a `TODO check all vectors have the same size` where the check belonged) | **plain python + `init_from_pandapower`** | element count comes from the first argument, the rest are read with unchecked accessors and combined in Eigen expressions sized from one of them → writes past the end of the shorter arrays, reproducible as `free(): invalid next size (fast)` |

The last one is reachable from `init_from_pandapower` on a net with a **duplicated bus label**: the loader resolves branch end voltages with `pp_net.bus.loc[pp_net.trafo["hv_bus"]]`, which then returns more rows than there are branches.

## Silent wrong answers (commit `4f339bd`)

A second pass over the Ybus / Sbus construction, looking for divisions by zero and degenerate physical parameters.

**No memory-safety problem there.** Every division by a physical parameter (`1/(r+jx)`, `1/x`, `1/tau`, `/sn_mva`) is floating point, so it yields Inf/NaN rather than a signal, and none of those values is used as an index. 30+ degenerate cases (`r`/`x`/`ratio`/`vn_kv` = 0, negative, NaN, Inf) produced no crash and no hang.

What it did find is a *silent* failure mode, in the one place the solvers' guards cannot see. `sn_mva` is the base power of the whole per-unit system, and it was validated **nowhere** — not by `set_sn_mva`, not by `check_grid()`, and the loaders take it verbatim from their source file (`init_from_powermodels` / `init_from_matpower` do `set_sn_mva(float(network["baseMVA"]))`):

* `sn_mva = NaN` or `Inf` → the **DC powerflow reports CONVERGENCE and returns NaN branch flows**. The built-in solvers' finiteness guards cannot catch it: they inspect `Va`, which is perfectly finite (`Bbus` does not involve `sn_mva`), and the NaN only appears afterwards when results are scaled back to MW. The size/finiteness check at the solver→grid seam is deliberately reserved for external solvers.
* `sn_mva < 0` → a plausible-looking but sign-inverted per-unit system.

`sn_mva` and `init_vm_pu` must now be finite and strictly positive, checked by their setters and re-checked by `check_grid()` (which is what covers pickle, the binary format and every loader, since `set_state` bypasses the setters). `PandaPowerConverter::_check_init` had the same shape of bug for its own `sn_mva` / `f_hz`: it tested `<= 0.`, and every comparison with NaN is false, so a NaN sailed through both — and they are divisors in every method of that class.

## Deliberately *not* changed

`check_grid()` still does not validate the *values* of `r` / `x` / `h` / tap ratio. #156 reverted exactly such a check over false positives, and that reasoning still holds — pypowsybl encodes "no thermal limit" as a non-finite `limit_a_ka`, unbounded reactive limits are ±Inf. Two further invariants were tried, implemented, and **reverted after the test suite disproved them**:

* **`r, x >= 0`** — no. A negative reactance is a series capacitor, and negative r/x also fall out of 3-winding-transformer star equivalents. pandapower's own `case300` has 1 line with negative x; `case9241pegase` has 14 with r < 0 and 16 with x < 0.
* **`r == x == 0` rejected on a connected branch** — a real degenerate case (DC reports convergence with non-finite flows), but not rejectable: `test_bus_fusion_pypowsybl` asserts that an ideal 225/90 kV transformer *must stay connected*, and that with `fuse_zero_impedance_branches=False` the grid **loads** and the powerflow then fails. A NaN check on `h` was also wrong — a zero-impedance line's per-unit conversion legitimately yields `g = NaN` in pypowsybl data.

The zero-impedance case is documented as a known limitation in `docs/security.rst` instead, with the guidance to check that returned flows are finite.

## How it was found

Reading, plus four mechanical sweeps run per-case in a subprocess so a crash is a signal rather than a lost run:

* **pickle-state structural sweep** — every leaf of the nested `StateRes` truncated / extended / poisoned (640 cases).
* **paired sweep** — every boolean flag flipped *and* a sibling array poisoned (415 cases), since feature flags gate whole code paths.
* **`.lsb` byte-level sweep** — 14 443 single-byte pokes, truncations and random corruption. **0 crashes**: the byte-level reader is solid.
* **degenerate-physics probe** — the r/x/ratio/vn_kv/sn_mva matrix above.

All sweeps come back clean after the fixes.

## Tests

`src/tests/test_state_poisoning.cpp` (17 cases, in the suite that also runs under valgrind/ASan in `cpp_unit_tests`) and `lightsim2grid/tests/test_state_poisoning.py` (28 cases).

## Verification

* **C++ suite: 127 cases / 1433 assertions green.**
* **Python suite: 1226 passed, 0 failed.**

Excluded from that python run are `test_LightSimBackend.py`, `test_Runner.py` and `test_RedispatchEnv.py` — all 99 of their failures in this sandbox are environmental (grid2op's `data_test/` fixtures are absent from the pip wheel, and `grid2op.make` cannot reach `api.github.com`), and they fail during env construction before a lightsim2grid backend is built. Worth confirming on real CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019K1jRmqbpB4JUsuHHy4t9A

---
_Generated by [Claude Code](https://claude.ai/code/session_019K1jRmqbpB4JUsuHHy4t9A)_