### PR TITLE
ci: pin all GitHub Actions to full commit SHAs

### DIFF
--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -25,7 +25,7 @@ jobs:
     name: performance / readability checks (src/core)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
           # eigen (transitive include of the core headers), Catch2 (needed to
           # configure src/tests, even though test files are not analyzed) and
@@ -76,7 +76,7 @@ jobs:
           } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Upload full report
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
           name: clang-tidy-report
           path: clang-tidy-report.txt

--- a/.github/workflows/cpp-standards.yml
+++ b/.github/workflows/cpp-standards.yml
@@ -43,12 +43,12 @@ jobs:
       CC: ${{ matrix.standard.cc }}
       CXX: ${{ matrix.standard.cxx }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
           # eigen, Catch2 (C++ test suite) and pybind11 headers
           submodules: true
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97  # v7.0.0
         with:
           python-version: '3.12'
 

--- a/.github/workflows/cpp_unit_tests.yml
+++ b/.github/workflows/cpp_unit_tests.yml
@@ -22,7 +22,7 @@ jobs:
     name: Catch2 + valgrind
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
           # eigen (transitive include of the core headers) and Catch2
           submodules: true

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -102,7 +102,7 @@ jobs:
       #     platforms: arm64
 
       - name: Checkout sources
-        uses: actions/checkout@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
           submodules: true
 
@@ -190,13 +190,13 @@ jobs:
           python3 -v -c "from lightsim2grid import LightSimBackend; import grid2op; env = grid2op.make('l2rpn_case14_sandbox', test=True, backend=LightSimBackend())"
 
       - name: Upload wheel
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
           name: lightsim2grid-wheel-linux-${{ matrix.python.name }}-${{ matrix.cont.name }}
           path: wheelhouse/*.whl
 
       - name: Upload source archive
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         if: matrix.python.name == 'cp312'
         with:
           name: lightsim2grid-sources
@@ -257,18 +257,18 @@ jobs:
     steps:
 
       - name: Checkout sources
-        uses: actions/checkout@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
           submodules: true
 
       - name: Setup Python ${{ matrix.python.version }} ${{ matrix.win_arch.msvc}}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97  # v7.0.0
         with:
           python-version: ${{ matrix.python.version }}
           architecture: ${{ matrix.win_arch.msvc}}
 
       - name: Setup MSVC ${{ matrix.win_arch.msvc}}
-        uses: bus1/cabuild/action/msdevshell@e22aba57d6e74891d059d66501b6b5aed8123c4d # v1
+        uses: bus1/cabuild/action/msdevshell@06ea2833eef61e9b0d0ce0d728416e617e4fb1fe  # v1 (no tagged releases; pinned to latest v1 branch commit)
         with:
           architecture: ${{ matrix.win_arch.msvc}}
 
@@ -335,7 +335,7 @@ jobs:
       #     python -m unittest lightsim2grid.tests.test_n1contingencyrewards.TestN1ContingencyReward_Base.test_do_nothing
 
       - name: Upload wheel
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
           name: lightsim2grid-wheel-win-${{ matrix.python.name }}-${{ matrix.win_arch.msvc}}
           path: dist/*.whl
@@ -409,12 +409,12 @@ jobs:
     steps:
 
       - name: Checkout sources
-        uses: actions/checkout@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
           submodules: true
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97  # v7.0.0
         with:
           python-version: ${{ matrix.python.version }}
 
@@ -497,7 +497,7 @@ jobs:
           python -v -c "from lightsim2grid import LightSimBackend; import grid2op; env = grid2op.make('l2rpn_case14_sandbox', test=True, backend=LightSimBackend())"
 
       - name: Upload wheel
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
           name: lightsim2grid-wheel-darwin-${{ matrix.python.name }}-${{ matrix.runner.arch}}
           path: dist/*.whl
@@ -585,18 +585,18 @@ jobs:
 
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
           submodules: true
 
       - name: Set up QEMU
         if: runner.os == 'Linux'
-        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130  # v3.7.0
+        uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8  # v4.2.0
         with:
           platforms: all
 
       - name: Compile with cibuildwheel
-        uses: pypa/cibuildwheel@63fd63b352a9a8bdcc24791c9dbee952ee9a8abc  # v3.3.0
+        uses: pypa/cibuildwheel@4726cd35bb13f7bde50cf2761f2499ac7b3aa32c  # v4.1.1
         env:
           CIBW_PLATFORM: "${{ matrix.runner.cibuildwheel}}"
           CIBW_BUILD: "${{ matrix.python.name}}-*"
@@ -617,7 +617,7 @@ jobs:
             python -c "from lightsim2grid import LightSimBackend" &&
             python -c "from lightsim2grid.physical_law_checker import PhysicalLawChecker"
       - name: Upload wheel
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
           name: lightsim2grid-wheel-exotic-${{ matrix.runner.whl_nm}}-${{ matrix.python.name }}
           path: ./wheelhouse/*.whl
@@ -629,13 +629,13 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-2022, macos-14]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
           submodules: true
 
       - name: Setup MSVC (windows)
         if: runner.os == 'Windows'
-        uses: bus1/cabuild/action/msdevshell@e22aba57d6e74891d059d66501b6b5aed8123c4d
+        uses: bus1/cabuild/action/msdevshell@06ea2833eef61e9b0d0ce0d728416e617e4fb1fe  # v1 (no tagged releases; pinned to latest v1 branch commit)
         with:
           architecture: x64
 
@@ -690,17 +690,17 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-2022, macos-14]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
           submodules: true
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97  # v7.0.0
         with:
           python-version: '3.12'
 
       - name: Setup MSVC (windows)
         if: runner.os == 'Windows'
-        uses: bus1/cabuild/action/msdevshell@e22aba57d6e74891d059d66501b6b5aed8123c4d
+        uses: bus1/cabuild/action/msdevshell@06ea2833eef61e9b0d0ce0d728416e617e4fb1fe  # v1 (no tagged releases; pinned to latest v1 branch commit)
         with:
           architecture: x64
 
@@ -741,11 +741,11 @@ jobs:
     name: Test KLU detection strategies (Ubuntu)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
           submodules: true
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97  # v7.0.0
         with:
           python-version: '3.12'
 
@@ -830,11 +830,11 @@ jobs:
     name: Test -march=native build (Ubuntu)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
           submodules: true
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97  # v7.0.0
         with:
           python-version: '3.12'
 
@@ -873,7 +873,7 @@ jobs:
 
     steps:
       - name: Download wheels
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
         with:
           path: download
 
@@ -905,7 +905,7 @@ jobs:
           echo "✓ All ${{ env.EXPECTED_WHEELS }} wheels and ${{ env.EXPECTED_SDIST }} sdist accounted for."
 
       - name: Upload wheels
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
           name: lightsim2grid-wheels
           retention-days: 90

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -26,7 +26,7 @@ jobs:
     steps:
       # Checkout is needed to read setup.py for the version consistency check.
       - name: Checkout sources
-        uses: actions/checkout@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
 
       # ── GUARD 1: version in setup.py must match the release tag ──────────
       - name: Check version consistency (tag vs setup.py)
@@ -60,7 +60,7 @@ jobs:
       # mutation. Check https://github.com/lewagon/wait-on-check-action for
       # the latest SHA if you need to upgrade.
       - name: Wait for CircleCI checks to pass
-        uses: lewagon/wait-on-check-action@9312864dfbc9fd208e9c0417843430751c042800
+        uses: lewagon/wait-on-check-action@fa4138d3af36e4cf9d254075350fa0cc29fa56cb  # v1.9.0
         with:
           ref: ${{ github.sha }}
           check-regexp: 'ci/circleci:.*'
@@ -75,7 +75,7 @@ jobs:
       # Pinned to a full commit SHA. Check https://github.com/dawidd6/action-download-artifact
       # for the latest SHA if you need to upgrade.
       - name: Download wheels from CI run
-        uses: dawidd6/action-download-artifact@09f2f74827fd3a8607589e5ad7f9398816f540fe
+        uses: dawidd6/action-download-artifact@b6e2e70617bc3265edd6dab6c906732b2f1ae151  # v21
         with:
           workflow: main.yml
           commit: ${{ github.sha }}
@@ -126,6 +126,6 @@ jobs:
       #   Env name:  pypi
       # Uncomment `password` below if you prefer a token instead of OIDC.
       - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@release/cef221092ed1bacb1cc03d23a2d87d1d172e277b
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33  # v1.14.2 (release/v1 branch head)
         # with:
         #   password: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/sanitizers.yml
+++ b/.github/workflows/sanitizers.yml
@@ -23,11 +23,11 @@ jobs:
     name: ASan + UBSan tests
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
           submodules: true
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97  # v7.0.0
         with:
           python-version: '3.12'
 
@@ -79,11 +79,11 @@ jobs:
     name: Eigen/libstdc++ assertions tests
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
           submodules: true
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97  # v7.0.0
         with:
           python-version: '3.12'
 


### PR DESCRIPTION
## Summary
- Pin every `uses:` action reference across all workflow files (`main.yml`, `publish.yml`, `clang-tidy.yml`, `cpp-standards.yml`, `cpp_unit_tests.yml`, `sanitizers.yml`) to a full commit SHA with a trailing version comment, e.g. `actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1`, instead of a floating major-version tag (`@v4`) — hardens CI against supply-chain attacks via tag mutation.
- Upgraded every pinned action to its current latest release (`actions/checkout` v4→v7.0.1, `actions/setup-python` v5→v7.0.0, `actions/upload-artifact` v4→v7.0.1, `actions/download-artifact` v4→v8.0.1, `docker/setup-qemu-action` v3.7.0→v4.2.0, `pypa/cibuildwheel` v3.3.0→v4.1.1, `lewagon/wait-on-check-action`→v1.9.0, `dawidd6/action-download-artifact`→v21, `pypa/gh-action-pypi-publish`→v1.14.2, `bus1/cabuild/action/msdevshell`→latest `v1` branch commit, no tagged releases upstream).
- Fixed a broken action reference already on this branch: `pypa/gh-action-pypi-publish@release/cef221092ed1bacb1cc03d23a2d87d1d172e277b` was not a valid git ref (invalid branch name) and would have failed the publish job; replaced with the correct pinned SHA for v1.14.2.

## Notes / things to watch when testing CI
- `pypa/cibuildwheel` jumped a major version (v3.3.0 → v4.1.1) — worth watching the `exotic_build` job on the first CI run for behavior changes.
- `pypa/gh-action-pypi-publish` is normally left on the floating `@release/v1` branch per PyPA's own guidance (it's an intentionally-tracked branch tied to their OIDC trusted-publishing security model), but was SHA-pinned here for consistency with the rest of this PR. Happy to revert that one specifically if preferred.

## Test plan
- [ ] YAML validated locally (`yaml.safe_load` on all workflow files — passes)
- [ ] Trigger CI on this branch/PR and confirm all jobs (manylinux/windows/macos/exotic builds, cmake standalone, plugin, KLU strategies, march-native, sanitizers, clang-tidy, cpp-standards) still pass with the upgraded action versions
- [ ] Verify the release-candidate publish flow once tested (per branch owner)


---
_Generated by [Claude Code](https://claude.ai/code/session_01HDmyV8UU1whdv1p3sogaRV)_