### PR TITLE
ci: give CircleCI more time to be discovered in publish.yml

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -71,6 +71,15 @@ jobs:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           wait-interval: 30
           allowed-conclusions: success
+          # Default is 60s: how long the action waits for the FIRST matching
+          # check to even appear before giving up with "the requested check
+          # was never run against this ref" -- separate from the actual wait
+          # for it to finish. CircleCI's ~10-job matrix can take longer than
+          # that to post its first status on a tag push (rarer/colder-start
+          # than a branch push), so 60s was failing the publish job before
+          # CircleCI had a chance to start, even though it does run. Give it
+          # more room to be discovered.
+          checks-discovery-timeout: 600
 
       # ── Download pre-built wheels from the main.yml run ──────────────────
       # The artifact was created (and its count validated) by the `package`


### PR DESCRIPTION
## Summary
- The real `v1.0.0.rc2` release run (https://github.com/Grid2op/lightsim2grid/actions/runs/30914157957) failed at the "Wait for CircleCI checks to pass" step with `The requested check was never run against this ref, exiting...` after ~66s — even though the CircleCI pipeline did run for the tag (confirmed on CircleCI's own dashboard).
- Checked `lewagon/wait-on-check-action`'s source directly (its Ruby implementation, `app/services/github_checks_verifier.rb` / `check_never_run_error.rb`): `CHECKS_DISCOVERY_TIMEOUT` (default 60s, not overridden in our config) is a *separate* timer from the actual "wait for it to pass" loop — it's how long the action waits for the **first** matching check to even show up on GitHub's API before concluding it will never run and raising `CheckNeverRunError`.
- CircleCI's ~10-job matrix (`test_legacy_grid2op`, `test_legacy_pandapower`, `test_legacy_pypowsybl`, `compile_and_test_windows`, `compile_and_test_clang_latest`, `compile_and_test_gcc_latest`, `compile_gcc_earliest`, `compile_gcc_prev_latest`, `compile_clang_earliest`, `compile_clang_prev_latest`) apparently took longer than 60s to post its first status against this tag — tag pushes are rarer than branch pushes and likely start colder — so the action gave up before CircleCI had a chance to be discovered at all, not because CircleCI failed to run.
- Sets `checks-discovery-timeout: 600` (10 minutes) to give it enough room.

## Test plan
- [ ] YAML validated locally (`yaml.safe_load` — passes)
- [ ] Re-trigger the publish flow (re-run `publish.yml` on the existing `v1.0.0.rc2` release, or a future tag) and confirm the CircleCI wait step now succeeds instead of bailing early


---
_Generated by [Claude Code](https://claude.ai/code/session_01HDmyV8UU1whdv1p3sogaRV)_