### PR TITLE
ci: drop the CircleCI gate from publish.yml

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -59,28 +59,6 @@ jobs:
           fi
           echo "✓ Tag matches lightsim2grid/__init__.py version."
 
-      # ── Wait for CircleCI to be green on this commit ─────────────────────
-      # Pinned to a full commit SHA to prevent supply-chain attacks via tag
-      # mutation. Check https://github.com/lewagon/wait-on-check-action for
-      # the latest SHA if you need to upgrade.
-      - name: Wait for CircleCI checks to pass
-        uses: lewagon/wait-on-check-action@fa4138d3af36e4cf9d254075350fa0cc29fa56cb  # v1.9.0
-        with:
-          ref: ${{ github.sha }}
-          check-regexp: 'ci/circleci:.*'
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-          wait-interval: 30
-          allowed-conclusions: success
-          # Default is 60s: how long the action waits for the FIRST matching
-          # check to even appear before giving up with "the requested check
-          # was never run against this ref" -- separate from the actual wait
-          # for it to finish. CircleCI's ~10-job matrix can take longer than
-          # that to post its first status on a tag push (rarer/colder-start
-          # than a branch push), so 60s was failing the publish job before
-          # CircleCI had a chance to start, even though it does run. Give it
-          # more room to be discovered.
-          checks-discovery-timeout: 600
-
       # ── Download pre-built wheels from the main.yml run ──────────────────
       # The artifact was created (and its count validated) by the `package`
       # job in main.yml when the tag was pushed. If that job failed, the


### PR DESCRIPTION
## Summary
- Two consecutive `v1.0.0.rc2` release attempts (runs [30914157957](https://github.com/Grid2op/lightsim2grid/actions/runs/30914157957) and [30931107338](https://github.com/Grid2op/lightsim2grid/actions/runs/30931107338)) failed at "Wait for CircleCI checks to pass" — not because CircleCI's tests failed, but because CircleCI's classic GitHub OAuth integration never posts a status back to GitHub for merge commits landing on `dev_0.13.2`. That's exactly the case this release process always hits, since tags are always cut from a post-merge commit.
- Confirmed directly on GitHub's own checks page for the merge commit (`2e320e4`): every GitHub Actions workflow shows up, zero `ci/circleci:*` entries. CircleCI's own dashboard shows the pipeline for that same commit ran and passed — it just never reports back for this trigger context, even after bumping `checks-discovery-timeout` to 600s in #166 (which correctly waited the full 10 minutes and still found nothing to wait for).
- Root-causing further requires access to CircleCI's own project settings/support, not anything fixable in this repo. Meanwhile this gate has blocked two green releases in a row for a reason unrelated to code quality, and `main.yml` already runs a much larger GitHub Actions matrix (~40 jobs) against the tag before `publish.yml` even starts.
- Drops the "Wait for CircleCI checks to pass" step entirely. Everything else (version guard, wheel-count re-verification, PyPI publish) is unchanged.

## Test plan
- [ ] YAML validated locally (`yaml.safe_load` — passes)
- [ ] Re-cut `v1.0.0.rc2` (delete + retag/release) and confirm `publish.yml` now runs straight through to PyPI


---
_Generated by [Claude Code](https://claude.ai/code/session_01HDmyV8UU1whdv1p3sogaRV)_