### PR TITLE
ci: flatten package job artifact download to fix PyPI publish

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -930,6 +930,18 @@ jobs:
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
         with:
           path: download
+          # Without this, each per-leg artifact (lightsim2grid-wheel-linux-...,
+          # lightsim2grid-sources, ...) lands in its own download/<artifact-name>/
+          # subdirectory. The "Upload wheels" step below then preserves that
+          # nesting inside the single lightsim2grid-wheels artifact it produces,
+          # which publish.yml's "Download wheels from CI run" step in turn
+          # reproduces under dist/ -- e.g. dist/lightsim2grid-sources/*.tar.gz
+          # instead of dist/*.tar.gz. pypa/gh-action-pypi-publish only looks
+          # directly in dist/, not recursively, so it finds nothing to publish
+          # (the wheel-count check above/in publish.yml still passes either way,
+          # since `find` is recursive). Flatten everything into download/ here
+          # instead so the final artifact -- and dist/ -- end up flat.
+          merge-multiple: true
 
       - name: Verify wheel and sdist count
         run: |


### PR DESCRIPTION
## Summary
- With the CircleCI gate gone (#167), the next `v1.0.0.rc2` attempt ([run 30944503824](https://github.com/Grid2op/lightsim2grid/actions/runs/30944503824)) got all the way to the real `pypa/gh-action-pypi-publish` step for the first time — and failed there with:
  ```
  It looks like there are no Python distribution packages to publish in the directory 'dist/'.
  Checking dist/lightsim2grid-sources: ERROR InvalidDistribution: Unknown distribution format: 'lightsim2grid-sources'
  ```
- Root cause: `main.yml`'s `package` job downloads every per-leg artifact (`lightsim2grid-wheel-linux-...`, `lightsim2grid-sources`, ...) into `download/` without flattening — `actions/download-artifact` nests each one under its own `download/<artifact-name>/` subdirectory when multiple artifacts are pulled without a `name:`. The subsequent "Upload wheels" step's globs (`download/**/*.whl`, `download/**/*.tar.gz`) preserve that nesting inside the single `lightsim2grid-wheels` artifact it produces. `publish.yml`'s own "Download wheels from CI run" step reproduces the same nesting under `dist/` — e.g. `dist/lightsim2grid-sources/*.tar.gz` instead of `dist/*.tar.gz`.
- The wheel-count re-verification step (both in `main.yml` and `publish.yml`) passed throughout every previous attempt, masking this — it uses `find`, which is recursive. The actual publish step only looks directly in `dist/` and doesn't recurse, so it found nothing.
- Fix: add `merge-multiple: true` to the initial "Download wheels" step so everything lands flat in `download/` (and stays flat all the way through to `dist/`) from the start.

## Test plan
- [ ] YAML validated locally (`yaml.safe_load` — passes)
- [ ] Re-cut `v1.0.0.rc2` and confirm the actual PyPI upload succeeds this time


---
_Generated by [Claude Code](https://claude.ai/code/session_01HDmyV8UU1whdv1p3sogaRV)_