### PR TITLE
Fix remote voltage control being silently dropped by the batch algorithms

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -174,6 +174,40 @@ TODO: Levenberg-Marquardt damping (a.k.a. Tikhonov-regularized Newton) : adding 
   generators on either end of the line), the ones that must stay refused, and regression guards that
   several purely local regulators on one bus -- and a lone voltage-regulating station -- still take
   the classical PV path and produce bit-identical voltages.
+- [FIXED] remote voltage control (remote-regulating generators and voltage-mode SVCs) and the free
+  ``Vm`` unknown of a distributed-slack participant were **silently ignored** by every batch
+  algorithm -- ``TimeSeriesCPP``, ``ContingencyAnalysisCPP`` and ``SecurityAnalysis``, ie everything
+  going through ``BaseBatchSolverSynch``. The powerflow still converged and still returned plausible
+  voltages, they were just the voltages of a grid with no such regulation: a silent wrong answer, not
+  an error. ``LSGrid::ac_pf`` was unaffected.
+  The NR extensions do not receive their data as solver arguments; they reach back into the
+  ``LSGrid`` through the algorithm's ``lsgrid_ptr`` and read its *member* solver-side labelling
+  (``LSGrid::get_free_vm_slack_solver_buses`` for ``Base``,
+  ``LSGrid::fill_hvdc_droop_solver_data`` for ``Hvdc``,
+  ``LSGrid::fill_voltage_control_solver_data`` for ``VoltageControl``).
+  ``ac_pf``/``dc_pf``/``check_solution`` pass those members straight to ``pre_process_solver``, so
+  they are always current there; the batch algorithms own local mapping vectors and pass those
+  instead, against a private *copy* of the grid whose copy constructor ``reset()`` all of it to
+  empty. ``_pre_process_solver_impl`` wrote only the FORWARD map (``id_me_to_ac_solver_``) back onto
+  the grid, so ``id_ac_solver_to_me_`` and ``slack_bus_id_ac_solver_`` stayed empty -- and empty is
+  indistinguishable from "this grid has no controller": ``fill_voltage_control_solver_data`` returns
+  on its ``nb_bus_solver == 0`` guard and ``get_free_vm_slack_solver_buses`` on its ``slack.empty()``
+  one, both without a word. The sync now covers the reverse map and both slack vectors, AC and DC.
+  The ``Hvdc`` angle-droop extension was never affected: it only ever read the forward map, the one
+  that was already synced (there is now a regression test pinning that too).
+  Two consequences worth knowing about. A grid whose voltage-control configuration is not supported
+  in v1 (eg a remote-regulating generator whose own bus carries no reactive equation) now raises from
+  ``fill_voltage_control_solver_data`` in the batch path as it always did in the single-shot one,
+  where before it was quietly accepted and solved without the regulation. And under
+  ``ContingencyAnalysis``'s ``handle_disconnected_grid`` mode, a contingency that strands a regulated
+  bus is now reported as a ``DIVERGENCE`` instead of converging with the regulation dropped: bus
+  masking is deliberately a value-only edit that must not touch the ``J`` pattern, so the bordered
+  voltage row survives against a bus the mask pins, and the system has no solution. An honest
+  non-result rather than a confident wrong one.
+- [ADDED] ``src/tests/test_batch_voltage_control.cpp``: solves the same grid single-shot through
+  ``LSGrid::ac_pf`` and through ``TimeSeries`` / ``ContingencyAnalysis``, and requires the voltages
+  to agree -- for a remote-regulating generator, a voltage-mode SVC (flat and sloped), a free-``Vm``
+  distributed-slack participant, and an hvdc angle droop.
 - [ADDED] ``TimeSeriesCPP`` / ``ContingencyAnalysisCPP`` (and so ``SecurityAnalysis``, which wraps the
   latter) gained a string-based ``change_algorithm(name)`` overload and a ``get_algo_name()`` accessor,
   matching what ``LSGrid`` already had (``AlgorithmSelector::change_algorithm(const std::string&)``) --

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -196,9 +196,13 @@ TODO: Levenberg-Marquardt damping (a.k.a. Tikhonov-regularized Newton) : adding 
   The ``Hvdc`` angle-droop extension was never affected: it only ever read the forward map, the one
   that was already synced (there is now a regression test pinning that too).
   Two consequences worth knowing about. A grid whose voltage-control configuration is not supported
-  in v1 (eg a remote-regulating generator whose own bus carries no reactive equation) now raises from
-  ``fill_voltage_control_solver_data`` in the batch path as it always did in the single-shot one,
-  where before it was quietly accepted and solved without the regulation. And under
+  in v1 now raises from ``fill_voltage_control_solver_data`` in the batch path as it always did in
+  the single-shot one, where before it was quietly accepted and solved without the regulation. The
+  restriction is on buses whose voltage magnitude is *already determined* -- a controller may not
+  regulate the slack, nor a PV bus pinned by a local regulator, since neither owns a ``Vm`` unknown
+  for the bordered row to act on; several controllers sharing one regulated bus is fine and always
+  was (one voltage row, one ``Q`` column each, plus a sharing row splitting ``Q`` by
+  ``qmax - qmin``). And under
   ``ContingencyAnalysis``'s ``handle_disconnected_grid`` mode, a contingency that strands a regulated
   bus is now reported as a ``DIVERGENCE`` instead of converging with the regulation dropped: bus
   masking is deliberately a value-only edit that must not touch the ``J`` pattern, so the bordered
@@ -206,8 +210,9 @@ TODO: Levenberg-Marquardt damping (a.k.a. Tikhonov-regularized Newton) : adding 
   non-result rather than a confident wrong one.
 - [ADDED] ``src/tests/test_batch_voltage_control.cpp``: solves the same grid single-shot through
   ``LSGrid::ac_pf`` and through ``TimeSeries`` / ``ContingencyAnalysis``, and requires the voltages
-  to agree -- for a remote-regulating generator, a voltage-mode SVC (flat and sloped), a free-``Vm``
-  distributed-slack participant, and an hvdc angle droop.
+  to agree -- for a remote-regulating generator, two generators sharing one regulated bus, a
+  voltage-mode SVC (flat and sloped), a free-``Vm`` distributed-slack participant, and an hvdc angle
+  droop.
 - [ADDED] ``TimeSeriesCPP`` / ``ContingencyAnalysisCPP`` (and so ``SecurityAnalysis``, which wraps the
   latter) gained a string-based ``change_algorithm(name)`` overload and a ``get_algo_name()`` accessor,
   matching what ``LSGrid`` already had (``AlgorithmSelector::change_algorithm(const std::string&)``) --

--- a/lightsim2grid/tests/test_LSGrid_out_of_bounds.py
+++ b/lightsim2grid/tests/test_LSGrid_out_of_bounds.py
@@ -227,13 +227,18 @@ class TestOutOfBoundsBindings(unittest.TestCase):
         self.grid.change_ratio_trafo(0, 1.0)
         self.grid.change_shift_trafo(0, 0.0)
         # gen 0 sits on bus 1; bus 9 is a PQ load bus, so this is a voltage-control
-        # configuration v1 actually supports. Bus 0 would ALSO be an in-range id --
-        # what this method bounds-checks -- but it already carries a generator, so
-        # regulating it leaves the controller with no Vm unknown to solve for and
-        # LSGrid::fill_voltage_control_solver_data rejects the whole grid. That is
-        # not the argument check under test here, and it makes the compute_Vs call
-        # below raise (it used to slip through only because the batch algorithms
-        # silently dropped voltage control entirely).
+        # configuration v1 actually supports.
+        #
+        # Bus 0 would ALSO be an in-range id -- which is all this method itself
+        # bounds-checks -- but it is case14's slack (the pandapower ext_grid), so it
+        # owns no Vm unknown and LSGrid::fill_voltage_control_solver_data rejects the
+        # grid on its `is_pq[reg_solver]` check. Note the criterion is whether the
+        # regulated bus' magnitude is already DETERMINED (slack, or a PV bus pinned by
+        # a local regulator), not whether a generator happens to sit there: several
+        # generators may perfectly well share one regulated bus, each with its own Q
+        # unknown plus a sharing row. Either way it is not the argument check under
+        # test here, and it makes the compute_Vs call below raise -- which used to slip
+        # through only because the batch algorithms silently dropped voltage control.
         self.grid.set_gen_regulated_bus(0, 9)
 
         has_changed = np.zeros(self.n_gen, dtype=bool)

--- a/lightsim2grid/tests/test_LSGrid_out_of_bounds.py
+++ b/lightsim2grid/tests/test_LSGrid_out_of_bounds.py
@@ -226,7 +226,15 @@ class TestOutOfBoundsBindings(unittest.TestCase):
         self.grid.reactivate_load(0)
         self.grid.change_ratio_trafo(0, 1.0)
         self.grid.change_shift_trafo(0, 0.0)
-        self.grid.set_gen_regulated_bus(0, 0)
+        # gen 0 sits on bus 1; bus 9 is a PQ load bus, so this is a voltage-control
+        # configuration v1 actually supports. Bus 0 would ALSO be an in-range id --
+        # what this method bounds-checks -- but it already carries a generator, so
+        # regulating it leaves the controller with no Vm unknown to solve for and
+        # LSGrid::fill_voltage_control_solver_data rejects the whole grid. That is
+        # not the argument check under test here, and it makes the compute_Vs call
+        # below raise (it used to slip through only because the batch algorithms
+        # silently dropped voltage control entirely).
+        self.grid.set_gen_regulated_bus(0, 9)
 
         has_changed = np.zeros(self.n_gen, dtype=bool)
         new_values = np.zeros(self.n_gen, dtype=np.float32)

--- a/lightsim2grid/tests/test_voltage_control_batch.py
+++ b/lightsim2grid/tests/test_voltage_control_batch.py
@@ -1,0 +1,204 @@
+# Copyright (c) 2026, RTE (https://www.rte-france.com)
+# See AUTHORS.txt
+# This Source Code Form is subject to the terms of the Mozilla Public License, version 2.0.
+# If a copy of the Mozilla Public License, version 2.0 was not distributed with this file,
+# you can obtain one at http://mozilla.org/MPL/2.0/.
+# SPDX-License-Identifier: MPL-2.0
+# This file is part of LightSim2grid, LightSim2grid implements a c++ backend targeting the Grid2Op platform.
+
+"""The batch algorithms (``TimeSeriesCPP`` / ``ContingencyAnalysisCPP``) must apply
+remote voltage control -- a remote-regulating generator or a voltage-mode SVC --
+exactly as ``ac_pf`` does.
+
+They used not to. The ``VoltageControl`` NR extension is not built from the solver's
+arguments: it reaches back into the ``LSGrid`` through the algorithm's ``lsgrid_ptr``
+and reads that grid's member solver-side bus labelling. ``ac_pf`` passes its own
+members to ``pre_process_solver`` so they are always current, but the batch classes
+work on a private copy of the grid and pass their own local mapping vectors, and
+only the FORWARD map was written back. With the reverse map left empty,
+``fill_voltage_control_solver_data`` returned on its ``nb_bus_solver == 0`` guard --
+so the batch solved a grid with no regulation at all, converged, and returned
+plausible wrong voltages instead of raising.
+
+Companion C++ suite: ``src/tests/test_batch_voltage_control.cpp``.
+"""
+
+import warnings
+import unittest
+import numpy as np
+import pandapower.networks as pn
+
+with warnings.catch_warnings():
+    warnings.filterwarnings("ignore")
+    from lightsim2grid.gridmodel import init_from_pandapower
+from lightsim2grid.lightsim2grid_cpp import TimeSeriesCPP, ContingencyAnalysisCPP  # noqa: E402
+
+MAX_IT = 30
+TOL = 1e-11
+# SvcContainer.RegulationMode
+SVC_VOLTAGE_MODE = 1
+# gen 3 sits on bus 7; bus 9 is a PQ load bus no generator regulates locally.
+GEN_ID = 3
+REG_BUS = 9
+SVC_BUS = 4       # a PQ bus, so the SVC's own bus carries a reactive equation
+SVC_V_SET = 1.06
+
+
+def _case14():
+    with warnings.catch_warnings():
+        warnings.filterwarnings("ignore")
+        net = pn.case14()
+        model = init_from_pandapower(net)
+    return net, model
+
+
+def _make(kind):
+    """case14 plus one remote voltage controller; ``kind`` selects which."""
+    net, model = _case14()
+    if kind == "remote_gen":
+        model.set_gen_regulated_bus(GEN_ID, REG_BUS)
+    elif kind in ("svc_flat", "svc_sloped"):
+        slope_pu = 0.02 if kind == "svc_sloped" else 0.
+        model.init_svcs([SVC_VOLTAGE_MODE], np.array([SVC_V_SET]), np.array([0.]),
+                        np.array([slope_pu]), np.array([-100.]), np.array([100.]),
+                        np.array([REG_BUS], dtype=np.int32),
+                        np.array([SVC_BUS], dtype=np.int32))
+    else:
+        raise ValueError(kind)
+    model.tell_solver_need_reset()
+    return net, model
+
+
+KINDS = ["remote_gen", "svc_flat", "svc_sloped"]
+
+
+def _base_injections(model):
+    gen_p = np.array(model.get_gen_target_p(), dtype=np.float64)
+    load_p = np.array(model.get_load_target_p(), dtype=np.float64)
+    load_q = np.array([ld.target_q_mvar for ld in model.get_loads()], dtype=np.float64)
+    return gen_p, load_p, load_q
+
+
+def _single_shot(model, gen_p, load_p, load_q, nb_bus):
+    for i, p in enumerate(gen_p):
+        model.change_p_gen(i, float(p))
+    for i, p in enumerate(load_p):
+        model.change_p_load(i, float(p))
+    for i, q in enumerate(load_q):
+        model.change_q_load(i, float(q))
+    return model.ac_pf(np.ones(nb_bus, dtype=np.complex128), MAX_IT, TOL)
+
+
+class TestVoltageControlIsActuallyOn(unittest.TestCase):
+    """Guard the guard: if these setups did not regulate anything even single-shot,
+    every comparison below would pass vacuously."""
+
+    def test_single_shot_regulates(self):
+        for kind in KINDS:
+            with self.subTest(kind=kind):
+                net, model = _make(kind)
+                nb_bus = net.bus.shape[0]
+                V = model.ac_pf(np.ones(nb_bus, dtype=np.complex128), MAX_IT, TOL)
+                self.assertGreater(V.shape[0], 0, f"ac_pf diverged ({kind})")
+
+                _, plain = _case14()
+                Vplain = plain.ac_pf(np.ones(nb_bus, dtype=np.complex128), MAX_IT, TOL)
+                self.assertGreater(np.abs(abs(V[REG_BUS]) - abs(Vplain[REG_BUS])), 1e-4,
+                                   f"{kind} does not move the regulated bus at all")
+
+                if kind in ("remote_gen", "svc_flat"):
+                    vset = (model.get_generators()[GEN_ID].target_vm_pu
+                            if kind == "remote_gen" else SVC_V_SET)
+                    self.assertLess(abs(abs(V[REG_BUS]) - vset), 1e-6,
+                                    f"{kind}: |V[{REG_BUS}]| != setpoint")
+
+
+class TestVoltageControlTimeSeries(unittest.TestCase):
+    def test_timeseries_matches_single_shot(self):
+        for kind in KINDS:
+            with self.subTest(kind=kind):
+                net, model = _make(kind)
+                nb_bus = net.bus.shape[0]
+                gen_p, load_p, load_q = _base_injections(model)
+
+                # two distinct steps (base and a +8% load / +8% gen scaling)
+                scales = np.array([1.0, 1.08])
+                gen_mat = np.outer(scales, gen_p)
+                lp_mat = np.outer(scales, load_p)
+                lq_mat = np.outer(scales, load_q)
+                sgen_mat = np.zeros((len(scales), 0))
+
+                ts = TimeSeriesCPP(model)
+                status = ts.compute_Vs(gen_mat, sgen_mat, lp_mat, lq_mat,
+                                       np.ones(nb_bus, dtype=np.complex128), MAX_IT, TOL)
+                self.assertEqual(status, 1, f"time series diverged ({kind})")
+                Vs = np.array(ts.get_voltages())
+
+                for step in range(len(scales)):
+                    _, ref_model = _make(kind)
+                    Vref = _single_shot(ref_model, gen_mat[step], lp_mat[step],
+                                        lq_mat[step], nb_bus)
+                    self.assertGreater(Vref.shape[0], 0, f"{kind} ref step {step} diverged")
+                    self.assertLess(np.abs(Vs[step] - Vref).max(), 1e-7,
+                                    f"{kind} step {step}")
+
+
+class TestVoltageControlContingencyAnalysis(unittest.TestCase):
+    def test_contingency_matches_single_shot(self):
+        # powerlines away from the controller / regulated buses, so every
+        # contingency leaves the control problem itself well posed
+        cont_lines = [0, 5, 10]
+        for kind in KINDS:
+            with self.subTest(kind=kind):
+                net, model = _make(kind)
+                nb_bus = net.bus.shape[0]
+
+                ca = ContingencyAnalysisCPP(model)
+                for line_id in cont_lines:
+                    ca.add_n1(line_id)
+                ca.compute(np.ones(nb_bus, dtype=np.complex128), MAX_IT, TOL)
+                Vs = np.array(ca.get_voltages())
+
+                for k, line_id in enumerate(cont_lines):
+                    if np.abs(Vs[k]).max() == 0.0:
+                        # this contingency diverged / islanded: nothing to compare
+                        continue
+                    _, ref_model = _make(kind)
+                    ref_model.deactivate_powerline(line_id)
+                    Vref = ref_model.ac_pf(np.ones(nb_bus, dtype=np.complex128), MAX_IT, TOL)
+                    self.assertGreater(Vref.shape[0], 0,
+                                       f"{kind} ref cont {line_id} diverged")
+                    mask = np.abs(Vs[k]) > 0.0
+                    self.assertLess(np.abs(Vs[k][mask] - Vref[mask]).max(), 1e-6,
+                                    f"{kind} contingency line {line_id}")
+
+    def test_regulated_bus_is_held_in_every_contingency(self):
+        # the substantive claim, independent of the single-shot reference: with a
+        # flat (slope-free) controller the regulated bus sits on the setpoint in
+        # every contingency the analysis actually solves.
+        for kind, vset in (("remote_gen", None), ("svc_flat", SVC_V_SET)):
+            with self.subTest(kind=kind):
+                net, model = _make(kind)
+                nb_bus = net.bus.shape[0]
+                if vset is None:
+                    vset = model.get_generators()[GEN_ID].target_vm_pu
+
+                ca = ContingencyAnalysisCPP(model)
+                for line_id in [0, 5, 10]:
+                    ca.add_n1(line_id)
+                ca.compute(np.ones(nb_bus, dtype=np.complex128), MAX_IT, TOL)
+                Vs = np.array(ca.get_voltages())
+
+                nb_checked = 0
+                for k in range(Vs.shape[0]):
+                    if np.abs(Vs[k]).max() == 0.0:
+                        continue
+                    self.assertLess(abs(abs(Vs[k][REG_BUS]) - vset), 1e-6,
+                                    f"{kind}: contingency {k} left bus {REG_BUS} at "
+                                    f"{abs(Vs[k][REG_BUS]):.6f} instead of {vset:.6f}")
+                    nb_checked += 1
+                self.assertGreater(nb_checked, 0, "no contingency was actually solved")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/core/LSGrid.cpp
+++ b/src/core/LSGrid.cpp
@@ -1452,15 +1452,33 @@ CplxVect LSGrid::_pre_process_solver_impl(
     if(is_ac) _algo.tell_solver_control(solver_control);
     else _dc_algo.tell_solver_control(solver_control);
 
-    // keep the member bus mapping in sync with the one we just built. The single-shot
-    // ac_pf / dc_pf pass the member itself as `id_me_to_solver` (self-assign, skipped
-    // below), but the batch algorithms (TimeSeries / ContingencyAnalysis) pass their own
-    // local vector. The hvdc droop extension reads the member through
-    // fill_hvdc_droop_solver_data(), so it must reflect the active mapping in every path.
+    // Keep the member solver-side labelling in sync with the vectors we just built.
+    // The single-shot ac_pf / dc_pf pass the members themselves (self-assign, skipped
+    // below), but the batch algorithms (TimeSeries / ContingencyAnalysis, through
+    // BaseBatchSolverSynch) own their local vectors and pass those -- while the solver
+    // still reaches back into this LSGrid through `lsgrid_ptr` to build its NR
+    // extensions:
+    //   Base           -> get_free_vm_slack_solver_buses()    (slack_bus_id_*_solver_)
+    //   Hvdc           -> fill_hvdc_droop_solver_data()       (id_me_to_*_solver_)
+    //   VoltageControl -> fill_voltage_control_solver_data()  (id_*_solver_to_me_,
+    //                       id_me_to_*_solver_, and the two above)
+    // A member left stale there does not read as an error, it reads as "nothing to
+    // do": the controller list comes back empty and the solve SILENTLY drops remote
+    // voltage control / the free Vm unknown of a distributed-slack participant. Note
+    // that the batch classes hold a *copy* of the grid, and LSGrid's copy constructor
+    // reset()s all of this, so stale here always means empty. Every member the
+    // extensions read must therefore reflect the active mapping in every path -- not
+    // just the forward map.
     if(is_ac){
         if(&id_me_to_solver != &id_me_to_ac_solver_) id_me_to_ac_solver_ = id_me_to_solver;
+        if(&id_solver_to_me != &id_ac_solver_to_me_) id_ac_solver_to_me_ = id_solver_to_me;
+        if(&slack_bus_id_me != &slack_bus_id_ac_me_) slack_bus_id_ac_me_ = slack_bus_id_me;
+        if(&slack_bus_id_solver != &slack_bus_id_ac_solver_) slack_bus_id_ac_solver_ = slack_bus_id_solver;
     } else {
         if(&id_me_to_solver != &id_me_to_dc_solver_) id_me_to_dc_solver_ = id_me_to_solver;
+        if(&id_solver_to_me != &id_dc_solver_to_me_) id_dc_solver_to_me_ = id_solver_to_me;
+        if(&slack_bus_id_me != &slack_bus_id_dc_me_) slack_bus_id_dc_me_ = slack_bus_id_me;
+        if(&slack_bus_id_solver != &slack_bus_id_dc_solver_) slack_bus_id_dc_solver_ = slack_bus_id_solver;
     }
     return V;
 }

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -73,6 +73,7 @@ add_executable(lightsim2grid_unit_tests
     test_state_poisoning.cpp
     test_powerflow_algorithm.cpp
     test_voltage_control_reclassify.cpp
+    test_batch_voltage_control.cpp
 )
 target_link_libraries(lightsim2grid_unit_tests PRIVATE lightsim2grid_core Catch2::Catch2WithMain)
 

--- a/src/tests/test_batch_voltage_control.cpp
+++ b/src/tests/test_batch_voltage_control.cpp
@@ -1,0 +1,366 @@
+// Copyright (c) 2026, RTE (https://www.rte-france.com)
+// See AUTHORS.txt
+// This Source Code Form is subject to the terms of the Mozilla Public License, version 2.0.
+// If a copy of the Mozilla Public License, version 2.0 was not distributed with this file,
+// you can obtain one at http://mozilla.org/MPL/2.0/.
+// SPDX-License-Identifier: MPL-2.0
+// This file is part of LightSim2grid, LightSim2grid implements a c++ backend targeting the Grid2Op platform.
+
+// The NR extensions (Base's free-Vm slack unknowns, Hvdc's angle droop,
+// VoltageControl's remote regulation) are not built from the arguments handed to
+// the solver: they are pulled out of the LSGrid itself, through the `lsgrid_ptr`
+// the algorithm holds, by LSGrid::get_free_vm_slack_solver_buses /
+// fill_hvdc_droop_solver_data / fill_voltage_control_solver_data. Those three read
+// the grid's *member* solver-side labelling (id_me_to_ac_solver_,
+// id_ac_solver_to_me_, slack_bus_id_ac_solver_).
+//
+// LSGrid::ac_pf passes those very members to pre_process_solver, so they are always
+// current there. The batch algorithms (TimeSeries / ContingencyAnalysis /
+// SecurityAnalysis, through BaseBatchSolverSynch) do not: they own local mapping
+// vectors and hand those over instead, on a private COPY of the grid whose copy
+// constructor reset() the members to empty. A member left empty is indistinguishable
+// from "this grid has no such controller", so the extension quietly builds nothing
+// and the batch returns a converged, plausible, WRONG answer -- remote voltage
+// control simply not applied.
+//
+// Every test here therefore compares a batch solve against the single-shot ac_pf of
+// the same grid: they must agree to solver tolerance.
+
+#include <cmath>
+#include <complex>
+#include <vector>
+
+#include <catch2/catch_approx.hpp>
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/generators/catch_generators.hpp>
+
+#include "LSGrid.hpp"
+#include "batch_algorithm/ContingencyAnalysis.hpp"
+#include "batch_algorithm/TimeSeries.hpp"
+
+using Catch::Approx;
+using ls2g::AlgorithmType;
+using ls2g::ContingencyAnalysis;
+using ls2g::CplxVect;
+using ls2g::LSGrid;
+using ls2g::RealVect;
+using ls2g::TimeSeries;
+using ls2g::cplx_type;
+using ls2g::real_type;
+
+namespace {
+
+using RealMat = Eigen::Matrix<real_type, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor>;
+
+const real_type V_SET = 1.04;
+const real_type LOAD_P = 50.;
+const real_type LOAD_Q = 10.;
+const int NB_BUS = 4;
+
+// 4-bus radial feeder 0-1-2-3 (r = 0.01, x = 0.1 pu per line), one
+// 50 MW / 10 MVAr load at bus 3, sn_mva = 100. Generation is added per grid.
+LSGrid make_skeleton()
+{
+    LSGrid grid;
+    grid.set_sn_mva(100.);
+    grid.set_init_vm_pu(1.0);
+
+    const RealVect bus_vn_kv = RealVect::Constant(NB_BUS, 138.);
+    grid.init_bus(static_cast<unsigned int>(NB_BUS), 1, bus_vn_kv, 0, 0);
+
+    const int n_line = NB_BUS - 1;
+    const RealVect branch_r = RealVect::Constant(n_line, 0.01);
+    const RealVect branch_x = RealVect::Constant(n_line, 0.1);
+    const CplxVect branch_h = CplxVect::Zero(n_line);
+    Eigen::VectorXi from_id(n_line), to_id(n_line);
+    for (int i = 0; i < n_line; ++i) { from_id(i) = i; to_id(i) = i + 1; }
+    grid.init_powerlines(branch_r, branch_x, branch_h, from_id, to_id);
+
+    RealVect load_p(1), load_q(1);
+    load_p << LOAD_P;
+    load_q << LOAD_Q;
+    Eigen::VectorXi load_bus(1);
+    load_bus << NB_BUS - 1;
+    grid.init_loads(load_p, load_q, load_bus);
+    return grid;
+}
+
+// slack generator at bus 0, plus a generator at bus 1 REMOTELY regulating bus 3
+// (the load bus) at V_SET -- the VoltageControl extension.
+LSGrid make_remote_gen_grid()
+{
+    LSGrid grid = make_skeleton();
+    RealVect gen_p(2), gen_v(2), gen_min_q(2), gen_max_q(2);
+    Eigen::VectorXi gen_bus(2);
+    gen_p << 0., 0.;
+    gen_v << 1.02, V_SET;
+    gen_min_q << -1000., -1000.;
+    gen_max_q << 1000., 1000.;
+    gen_bus << 0, 1;
+    grid.init_generators(gen_p, gen_v, gen_min_q, gen_max_q, gen_bus);
+
+    grid.add_gen_slackbus(0, 1.);
+    grid.set_gen_regulated_bus(1, 3);
+    grid.tell_solver_need_reset();
+    return grid;
+}
+
+// slack generator at bus 0, plus a voltage-mode SVC at bus 2 regulating bus 3
+LSGrid make_remote_svc_grid(real_type slope_pu)
+{
+    LSGrid grid = make_skeleton();
+    RealVect gen_p(1), gen_v(1), gen_min_q(1), gen_max_q(1);
+    Eigen::VectorXi gen_bus(1);
+    gen_p << 0.;
+    gen_v << 1.02;
+    gen_min_q << -1000.;
+    gen_max_q << 1000.;
+    gen_bus << 0;
+    grid.init_generators(gen_p, gen_v, gen_min_q, gen_max_q, gen_bus);
+    grid.add_gen_slackbus(0, 1.);
+
+    RealVect target_vm(1), q_set(1), slope(1), b_min(1), b_max(1);
+    target_vm << V_SET;
+    q_set << 0.;
+    slope << slope_pu;
+    b_min << -100.;
+    b_max << 100.;
+    Eigen::VectorXi reg(1), bus(1);
+    reg << 3;
+    bus << 2;
+    // SvcContainer::RegulationMode: VOLTAGE = 1
+    grid.init_svcs({1}, target_vm, q_set, slope, b_min, b_max, reg, bus);
+    grid.tell_solver_need_reset();
+    return grid;
+}
+
+// NO voltage control at all: two DISTRIBUTED-SLACK generators, gen 0 (bus 0) a
+// local voltage regulator, gen 1 (bus 1) with voltage_regulator_on == false. Bus 1
+// is a slack participant that no local generator voltage-pins, so
+// LSGrid::get_free_vm_slack_solver_buses must give it a free Vm unknown + Q
+// equation -- the `Base` extension, which reads slack_bus_id_ac_solver_. Without
+// it bus 1 stays frozen at init_vm_pu.
+LSGrid make_free_vm_slack_grid()
+{
+    LSGrid grid = make_skeleton();
+    RealVect gen_p(2), gen_v(2), gen_q(2), gen_min_q(2), gen_max_q(2);
+    Eigen::VectorXi gen_bus(2);
+    gen_p << 0., 0.;
+    gen_v << 1.02, 1.02;
+    gen_q << 0., 0.;
+    gen_min_q << -1000., -1000.;
+    gen_max_q << 1000., 1000.;
+    gen_bus << 0, 1;
+    const std::vector<bool> vreg_on{true, false};
+    grid.init_generators_full(gen_p, gen_v, gen_q, vreg_on, gen_min_q, gen_max_q, gen_bus);
+
+    grid.add_gen_slackbus(0, 0.5);
+    grid.add_gen_slackbus(1, 0.5);
+    grid.tell_solver_need_reset();
+    return grid;
+}
+
+// slack generator at bus 0 and an angle-droop hvdc line bus 1 -- bus 3. The Hvdc
+// extension reads the FORWARD map only, the one that was already kept in sync, so
+// this is the control that must have been right all along.
+LSGrid make_droop_hvdc_grid()
+{
+    LSGrid grid = make_skeleton();
+    RealVect gen_p(1), gen_v(1), gen_min_q(1), gen_max_q(1);
+    Eigen::VectorXi gen_bus(1);
+    gen_p << 0.;
+    gen_v << 1.02;
+    gen_min_q << -1000.;
+    gen_max_q << 1000.;
+    gen_bus << 0;
+    grid.init_generators(gen_p, gen_v, gen_min_q, gen_max_q, gen_bus);
+    grid.add_gen_slackbus(0, 1.);
+
+    Eigen::VectorXi bus1(1), bus2(1);
+    bus1 << 1;
+    bus2 << 3;
+    // ConverterStationContainer::ConverterType: VSC = 0
+    // HvdcLineContainer::ConvertersMode: SIDE_1_RECTIFIER = 0
+    const std::vector<int> type1{0}, type2{0}, mode{0};
+    const std::vector<bool> vreg1{false}, vreg2{false}, droop_on{true};
+    const RealVect zero = RealVect::Zero(1);
+    RealVect vm1_pu(1), vm2_pu(1), q_min(1), q_max(1);
+    RealVect pf1(1), pf2(1), p_set(1), p_max(1), p0(1), k_deg(1);
+    vm1_pu << 1.0;
+    vm2_pu << 1.0;
+    q_min << -1e6;
+    q_max << 1e6;
+    pf1 << 1.;
+    pf2 << 1.;
+    p_set << 0.;
+    p_max << 300.;
+    p0 << 10.;
+    k_deg << 5.;
+    grid.init_hvdc_lines(bus1, bus2, type1, type2, zero, zero,
+                         vreg1, vreg2, vm1_pu, vm2_pu, zero, zero,
+                         q_min, q_max, q_min, q_max, pf1, pf2, mode, p_set,
+                         zero, zero, droop_on, p0, k_deg, p_max, p_max);
+    grid.tell_solver_need_reset();
+    return grid;
+}
+
+CplxVect flat_start(const LSGrid & grid)
+{
+    return CplxVect::Constant(static_cast<Eigen::Index>(grid.total_bus()), cplx_type(1., 0.));
+}
+
+CplxVect single_shot(LSGrid & grid)
+{
+    grid.change_algorithm(AlgorithmType::NR_SparseLU);
+    const CplxVect V = grid.ac_pf(flat_start(grid), 30, 1e-10);
+    REQUIRE(V.size() == NB_BUS);
+    return V;
+}
+
+// one TimeSeries step carrying the grid's own (unchanged) injections
+CplxVect one_step_timeseries(LSGrid & grid, int nb_gen)
+{
+    grid.change_algorithm(AlgorithmType::NR_SparseLU);
+    TimeSeries ts(grid);
+    RealMat gen_p(1, nb_gen), sgen_p(1, 0), load_p(1, 1), load_q(1, 1);
+    gen_p.setZero();
+    load_p << LOAD_P;
+    load_q << LOAD_Q;
+    REQUIRE(ts.compute_Vs(gen_p, sgen_p, load_p, load_q, flat_start(grid), 30, 1e-10) == 1);
+    return ts.get_voltages().row(0);
+}
+
+// one ContingencyAnalysis "contingency" that disconnects nothing: the base case,
+// solved through the whole ContingencyAnalysis machinery
+CplxVect empty_contingency(LSGrid & grid)
+{
+    grid.change_algorithm(AlgorithmType::NR_SparseLU);
+    ContingencyAnalysis ca(grid);
+    ca.add_nk(std::vector<int>());
+    ca.compute(flat_start(grid), 30, 1e-10);
+    REQUIRE(ca.get_voltages().rows() == 1);
+    return ca.get_voltages().row(0);
+}
+
+void check_same_voltages(const CplxVect & batch, const CplxVect & ref)
+{
+    REQUIRE(batch.size() == ref.size());
+    for (int b = 0; b < ref.size(); ++b) {
+        INFO("bus " << b);
+        CHECK(std::abs(batch(b)) == Approx(std::abs(ref(b))).epsilon(1e-8));
+        CHECK(std::arg(batch(b)) == Approx(std::arg(ref(b))).margin(1e-9));
+    }
+}
+
+}  // namespace
+
+
+TEST_CASE("a remote-regulating generator holds its bus through TimeSeries", "[batch][vctrl]")
+{
+    LSGrid ref_grid = make_remote_gen_grid();
+    const CplxVect ref = single_shot(ref_grid);
+    // the point of the setup: the single shot really does regulate bus 3
+    REQUIRE(std::abs(ref(3)) == Approx(V_SET).epsilon(1e-8));
+
+    LSGrid grid = make_remote_gen_grid();
+    check_same_voltages(one_step_timeseries(grid, 2), ref);
+}
+
+TEST_CASE("a remote-regulating generator holds its bus through ContingencyAnalysis", "[batch][vctrl]")
+{
+    LSGrid ref_grid = make_remote_gen_grid();
+    const CplxVect ref = single_shot(ref_grid);
+    REQUIRE(std::abs(ref(3)) == Approx(V_SET).epsilon(1e-8));
+
+    LSGrid grid = make_remote_gen_grid();
+    check_same_voltages(empty_contingency(grid), ref);
+}
+
+TEST_CASE("a batch on an already-solved grid regulates too", "[batch][vctrl]")
+{
+    // BaseBatchSolverSynch copies the grid, and LSGrid's copy constructor
+    // reset()s the solver-side labelling -- so pre-solving the source grid does
+    // NOT hand the batch a usable mapping. It has to be rebuilt by
+    // pre_process_solver and written back, on every path.
+    LSGrid ref_grid = make_remote_gen_grid();
+    const CplxVect ref = single_shot(ref_grid);
+
+    LSGrid grid = make_remote_gen_grid();
+    single_shot(grid);   // solved BEFORE the batch copies it
+    check_same_voltages(one_step_timeseries(grid, 2), ref);
+}
+
+TEST_CASE("a voltage-mode SVC regulates through the batch algorithms", "[batch][vctrl][svc]")
+{
+    const real_type slope_pu = GENERATE(static_cast<real_type>(0.), static_cast<real_type>(0.02));
+    LSGrid ref_grid = make_remote_svc_grid(slope_pu);
+    const CplxVect ref = single_shot(ref_grid);
+    // a flat SVC lands exactly on the setpoint, a sloped one strictly below it
+    // (V = v_set - s.Q with Q > 0) -- either way it must be raised well above the
+    // ~0.96 pu the same grid settles at with the SVC ignored
+    REQUIRE(std::abs(ref(3)) > 1.);
+
+    LSGrid ts_grid = make_remote_svc_grid(slope_pu);
+    check_same_voltages(one_step_timeseries(ts_grid, 1), ref);
+
+    LSGrid ca_grid = make_remote_svc_grid(slope_pu);
+    check_same_voltages(empty_contingency(ca_grid), ref);
+}
+
+TEST_CASE("a free-Vm distributed-slack participant keeps its Vm unknown in a batch", "[batch][slack]")
+{
+    // Same root cause as the voltage-control tests, different extension: `Base`
+    // reads slack_bus_id_ac_solver_ through get_free_vm_slack_solver_buses().
+    LSGrid ref_grid = make_free_vm_slack_grid();
+    const CplxVect ref = single_shot(ref_grid);
+    // bus 1 is NOT pinned: it must have moved off the 1.0 pu flat start
+    REQUIRE(std::abs(std::abs(ref(1)) - 1.0) > 1e-4);
+
+    LSGrid ts_grid = make_free_vm_slack_grid();
+    check_same_voltages(one_step_timeseries(ts_grid, 2), ref);
+
+    LSGrid ca_grid = make_free_vm_slack_grid();
+    check_same_voltages(empty_contingency(ca_grid), ref);
+}
+
+TEST_CASE("an hvdc angle droop survives the batch algorithms", "[batch][hvdc]")
+{
+    // The control: the Hvdc extension only ever needed the FORWARD map, which was
+    // already synced, so this passed before the reverse map / slack sync too.
+    LSGrid ref_grid = make_droop_hvdc_grid();
+    const CplxVect ref = single_shot(ref_grid);
+
+    LSGrid ts_grid = make_droop_hvdc_grid();
+    check_same_voltages(one_step_timeseries(ts_grid, 1), ref);
+
+    LSGrid ca_grid = make_droop_hvdc_grid();
+    check_same_voltages(empty_contingency(ca_grid), ref);
+}
+
+TEST_CASE("a contingency stranding a regulated bus is reported, not silently wrong", "[batch][vctrl]")
+{
+    // Line 2 is bus2--bus3, and bus 3 is the REGULATED bus: removing it strands
+    // the very bus the generator controls.
+    //
+    // In the default mode such a contingency is skipped outright (zero voltages).
+    // In "handle disconnected grid" mode the stranded bus is masked -- its P/Q
+    // rows are replaced by identity rows -- but masking is deliberately a
+    // value-only change that must not touch the J pattern, so the VoltageControl
+    // extension keeps its bordered row `Vm(3) - v_set = 0` against a bus whose Vm
+    // the mask pins. That system has no solution and the contingency comes back as
+    // a DIVERGENCE. Not a good answer, but an honest one: what must never happen
+    // is a converged row computed with the regulation quietly dropped.
+    for (bool handle_disconnected : {false, true}) {
+        INFO("handle_disconnected_grid = " << handle_disconnected);
+        LSGrid grid = make_remote_gen_grid();
+        grid.change_algorithm(AlgorithmType::NR_SparseLU);
+        ContingencyAnalysis ca(grid, /*compute_limit_violations=*/true);
+        ca.set_handle_disconnected_grid(handle_disconnected);
+        ca.add_n1(2);
+        ca.compute(flat_start(grid), 30, 1e-10);
+        REQUIRE(ca.get_voltages().rows() == 1);
+        REQUIRE(ca.converged().size() == 1);
+        CHECK(ca.converged()[0] == 0);
+        for (int b = 0; b < NB_BUS; ++b) CHECK(std::abs(ca.get_voltages()(0, b)) == 0.);
+    }
+}

--- a/src/tests/test_batch_voltage_control.cpp
+++ b/src/tests/test_batch_voltage_control.cpp
@@ -42,6 +42,7 @@ using Catch::Approx;
 using ls2g::AlgorithmType;
 using ls2g::ContingencyAnalysis;
 using ls2g::CplxVect;
+using ls2g::IntVect;
 using ls2g::LSGrid;
 using ls2g::RealVect;
 using ls2g::TimeSeries;
@@ -101,6 +102,31 @@ LSGrid make_remote_gen_grid()
 
     grid.add_gen_slackbus(0, 1.);
     grid.set_gen_regulated_bus(1, 3);
+    grid.tell_solver_need_reset();
+    return grid;
+}
+
+// slack generator at bus 0, plus TWO generators (buses 1 and 2, deliberately
+// different reactive ranges) both remotely regulating bus 3 at the same setpoint.
+// One control group of two controllers: two Q columns against one voltage row plus
+// one sharing row, splitting Q by the (qmax - qmin) key. Sharing a regulated bus is
+// supported -- what is not is regulating a bus whose magnitude is already
+// determined (the slack, or a PV bus pinned by a LOCAL regulator).
+LSGrid make_shared_reg_bus_grid()
+{
+    LSGrid grid = make_skeleton();
+    RealVect gen_p(3), gen_v(3), gen_min_q(3), gen_max_q(3);
+    Eigen::VectorXi gen_bus(3);
+    gen_p << 0., 0., 0.;
+    gen_v << 1.02, V_SET, V_SET;
+    gen_min_q << -1000., -1000., -250.;
+    gen_max_q << 1000., 1000., 250.;
+    gen_bus << 0, 1, 2;
+    grid.init_generators(gen_p, gen_v, gen_min_q, gen_max_q, gen_bus);
+
+    grid.add_gen_slackbus(0, 1.);
+    grid.set_gen_regulated_bus(1, 3);
+    grid.set_gen_regulated_bus(2, 3);
     grid.tell_solver_need_reset();
     return grid;
 }
@@ -288,6 +314,34 @@ TEST_CASE("a batch on an already-solved grid regulates too", "[batch][vctrl]")
     LSGrid grid = make_remote_gen_grid();
     single_shot(grid);   // solved BEFORE the batch copies it
     check_same_voltages(one_step_timeseries(grid, 2), ref);
+}
+
+TEST_CASE("two generators sharing one regulated bus share it in a batch too", "[batch][vctrl]")
+{
+    // Sharing is the supported multi-controller case (test_powerflow_algorithm.cpp
+    // pins the Q split itself, single-shot). Here: the whole group has to survive the
+    // batch path, which before the mapping sync got no controllers at all.
+    LSGrid ref_grid = make_shared_reg_bus_grid();
+    const CplxVect ref = single_shot(ref_grid);
+    REQUIRE(std::abs(ref(3)) == Approx(V_SET).epsilon(1e-8));
+    // and the sharing really is active: both controllers inject, in proportion to
+    // their (qmax - qmin) keys, 2000 MVAr against 500 MVAr
+    const RealVect q = ref_grid.get_algo().get_controller_q();
+    const IntVect elem = ref_grid.get_algo().get_controller_elem_id();
+    REQUIRE(q.size() == 2);
+    real_type q1 = 0., q2 = 0.;
+    for (int c = 0; c < q.size(); ++c) {
+        if (elem(c) == 1) q1 = q(c);
+        if (elem(c) == 2) q2 = q(c);
+    }
+    REQUIRE(std::abs(q1) > 1e-6);
+    CHECK(q1 / 2000. == Approx(q2 / 500.).epsilon(1e-8));
+
+    LSGrid ts_grid = make_shared_reg_bus_grid();
+    check_same_voltages(one_step_timeseries(ts_grid, 3), ref);
+
+    LSGrid ca_grid = make_shared_reg_bus_grid();
+    check_same_voltages(empty_contingency(ca_grid), ref);
 }
 
 TEST_CASE("a voltage-mode SVC regulates through the batch algorithms", "[batch][vctrl][svc]")


### PR DESCRIPTION
## The bug

Remote voltage control (remote-regulating generators, voltage-mode SVCs) **and** the free `Vm` unknown of a distributed-slack participant were silently inactive in every batch algorithm — `TimeSeriesCPP`, `ContingencyAnalysisCPP`, `SecurityAnalysis`, i.e. everything going through `BaseBatchSolverSynch`. The powerflow still converged and still returned plausible voltages; they were just the voltages of a grid with no such regulation. A silent wrong answer, not an error. `LSGrid::ac_pf` was unaffected.

On a 4-bus feeder with a generator remotely regulating the load bus at 1.04 pu:

| path | \|V(reg bus)\| |
|---|---|
| `LSGrid::ac_pf` | **1.040000** |
| `TimeSeries`, 1 step, same injections | 0.961689 |
| `ContingencyAnalysis`, empty contingency | 0.961689 |

## Root cause

The NR extensions do not receive their data as solver arguments. They reach back into the `LSGrid` through the algorithm's `lsgrid_ptr` and read its **member** solver-side labelling:

| extension | entry point | member read |
|---|---|---|
| `Base` | `get_free_vm_slack_solver_buses()` | `slack_bus_id_ac_solver_` |
| `Hvdc` | `fill_hvdc_droop_solver_data()` | `id_me_to_ac_solver_` |
| `VoltageControl` | `fill_voltage_control_solver_data()` | `id_ac_solver_to_me_`, + the two above |

`ac_pf` / `dc_pf` / `check_solution` pass those members straight to `pre_process_solver`, so they are always current there. The batch algorithms own local mapping vectors and pass those instead, against a private **copy** of the grid whose copy constructor `reset()`s all of it. `_pre_process_solver_impl` wrote only the **forward** map back onto the grid.

So `id_ac_solver_to_me_` and `slack_bus_id_ac_solver_` stayed empty — and empty is indistinguishable from *"this grid has no controller"*: `fill_voltage_control_solver_data` returned on its `nb_bus_solver == 0` guard and `get_free_vm_slack_solver_buses` on its `slack.empty()` one, both without a word. Confirmed by instrumentation:

```
batch:       id_ac_solver_to_me_.size()=0   id_me_to_ac_solver_.size()=4  slack_bus_id_ac_solver_.size()=0
single-shot: id_ac_solver_to_me_.size()=4   id_me_to_ac_solver_.size()=4  slack_bus_id_ac_solver_.size()=1
```

Note this is deterministic, not order-dependent: because the copy constructor resets the solver-side state, pre-solving the source grid does not help.

## The fix

`_pre_process_solver_impl` now syncs the reverse map and both slack vectors as well, AC and DC — completing an invariant the existing comment already claimed but implemented for one quarter of the state.

The `Hvdc` angle-droop extension was never affected: it only ever read the forward map, the one already synced. There is now a regression test pinning that too.

## Behaviour changes to be aware of

Both trade a silent wrong answer for an explicit one:

- A voltage-control configuration unsupported in v1 now **raises** in the batch path, as it always did single-shot. This is what broke `test_LSGrid_out_of_bounds.test_valid_calls_still_work`, fixed in its own commit: it used `set_gen_regulated_bus(0, 0)` as a stand-in for "a valid in-range id", but bus 0 of case14 is the slack, so the configuration is genuinely unsupported — `ac_pf` has always raised on it, and the `compute_Vs` call only passed because the batch discarded voltage control entirely. The test was asserting the bug. It now uses bus 9, a PQ load bus.
- Under `ContingencyAnalysis`'s `handle_disconnected_grid` mode, a contingency stranding a regulated bus is reported as a `DIVERGENCE` instead of converging with the regulation dropped. Bus masking is deliberately a value-only edit that must not touch the `J` pattern, so the bordered voltage row survives against a bus the mask pins and the system has no solution. I did **not** filter masked controllers out: that changes the system dimension and would break the symbolic-factorization reuse masking exists to provide. An honest non-result rather than a confident wrong one.

## Tests

- `src/tests/test_batch_voltage_control.cpp` — 7 cases: remote generator through `TimeSeries` and `ContingencyAnalysis`, a pre-solved source grid, two generators sharing one regulated bus, a voltage-mode SVC (flat and sloped), a free-`Vm` distributed-slack participant, an HVDC angle droop (the control), and a stranded-bus contingency. **6 of 7 fail without the fix**; the HVDC control passes both ways.
- `lightsim2grid/tests/test_voltage_control_batch.py` — case14, modelled on `test_hvdc_batch.py`. 8 assertion failures without the fix.

Each test solves the same grid single-shot and through the batch classes and requires the voltages to agree.

## Verification

- Full C++ suite green (4956 assertions / 156 cases) in Release, pinned to C++14, and under the `__DEBUG_ASSERTS=1` build CI uses.
- Full python suite run twice (1293 tests). All 133 remaining failures were attributed individually to this container's missing grid2op `data_test/`, `pypowsybl`, and KLU; the diff between the two runs is a single line — `test_valid_calls_still_work` disappearing.

Independent of #(the bus-reclassification PR): disjoint code, either merge order works.

---
_Generated by [Claude Code](https://claude.ai/code/session_015FU3fCG8p2dj3h6rRkTeyH)_