### PR TITLE
Classify voltage-controlled buses by group before PV, and let stations join a group

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -123,6 +123,50 @@ TODO: Levenberg-Marquardt damping (a.k.a. Tikhonov-regularized Newton) : adding 
 
 [1.0.0] 2026-xx-yy
 --------------------
+- [FIXED] a generator could not remotely regulate a bus that another generator already
+  regulated *locally* -- the grid was refused outright with
+  ``LSGrid::fill_voltage_control_solver_data: generator N regulates bus X which has no voltage (Vm)
+  unknown`` -- even though the configuration is perfectly well posed. Two machines holding one bus
+  simply form a control group: one bordered voltage row, one reactive unknown each, and a sharing
+  row splitting the reactive duty in proportion to their ``qmax - qmin`` ranges, exactly as two
+  *remote* controllers on one bus already did.
+  The cause was the order in which buses are classified. ``GeneratorContainer::fillpv`` knew how to
+  keep a controller's OWN bus out of the PV set (a remote regulator leaves its own bus PQ), but
+  nothing stopped a LOCAL regulator from claiming a bus that somebody else regulated remotely. That
+  bus then had no ``Vm`` unknown, so ``VoltageControl::register_in`` got ``vm_col == -1`` for it, the
+  group's voltage row was never given its ``+1`` entry, and the row came out structurally EMPTY --
+  a singular Jacobian. The check that refused the grid was really reporting the misclassification,
+  not a property of the configuration.
+  Bus classification now runs the other way round: ``LSGrid::get_group_controlled_buses`` collects
+  every bus an active *remote* generator or an active voltage-mode SVC aims at, ``LSGrid::fillpv_pq``
+  keeps those out of PV, and ``fill_voltage_control_solver_data`` enrols the local regulators sitting
+  on them as members of the group. Buses regulated only by generators standing on them are
+  deliberately untouched: several machines sharing a bus and all regulating it locally remains the
+  ordinary PV case, with the per-bus reactive redistribution of ``GeneratorContainer::set_q``.
+  Three configurations start working as a result: a remote controller onto a locally regulated bus,
+  a remote controller onto a slack bus pinned by its own generator (the slack generator joins the
+  group and MultiSlack grants the free ``Vm``), and -- separately, by giving the regulated-bus check
+  the ``has_free_q`` escape hatch the controller-bus check already had -- a remote controller onto a
+  slack bus that nothing pins. Disagreeing setpoints between a local and a remote regulator of one
+  bus are now reported by the group's own check (``conflicting voltage setpoints``) rather than as a
+  bus-classification error.
+  Two things stay refused, on purpose. A remote regulator SHARING ITS OWN BUS with a local regulator
+  has no solution at all: whatever reactive power it injects there is absorbed one-for-one by the
+  machine holding that bus' magnitude, so it has no influence on its remote target -- no
+  reclassification can help, and the "its OWN bus has no reactive (Q) equation" error still fires.
+  And an hvdc converter station cannot join a control group (the group only knows ``GEN`` and ``SVC``
+  kinds), so a bus a station voltage-pins while a group also regulates it is rejected with an
+  explicit message from ``fillpv_pq`` rather than silently losing the station's regulation.
+  Note for voltage-mode SVCs: their regulated bus now leaves the PV path as well, which is what makes
+  the classification uniform, but an SVC still has to be the only controller of its bus in v1 (its
+  sharing key is a susceptance range, not a reactive range, so mixed SVC/generator sharing has no
+  defined semantics yet). Such a grid is therefore still refused -- now by that restriction, which
+  names the real limitation.
+- [ADDED] ``src/tests/test_voltage_control_reclassify.cpp`` and
+  ``lightsim2grid/tests/test_voltage_control_reclassify.py``: the classification rule itself, the
+  three newly-supported configurations (including the reactive split), the two that must stay
+  refused, and a regression guard that several purely local regulators on one bus still take the
+  classical PV path and produce bit-identical voltages.
 - [ADDED] ``TimeSeriesCPP`` / ``ContingencyAnalysisCPP`` (and so ``SecurityAnalysis``, which wraps the
   latter) gained a string-based ``change_algorithm(name)`` overload and a ``get_algo_name()`` accessor,
   matching what ``LSGrid`` already had (``AlgorithmSelector::change_algorithm(const std::string&)``) --

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -140,9 +140,10 @@ TODO: Levenberg-Marquardt damping (a.k.a. Tikhonov-regularized Newton) : adding 
   Bus classification now runs the other way round: ``LSGrid::get_group_controlled_buses`` collects
   every bus an active *remote* generator or an active voltage-mode SVC aims at, ``LSGrid::fillpv_pq``
   keeps those out of PV, and ``fill_voltage_control_solver_data`` enrols the local regulators sitting
-  on them as members of the group. Buses regulated only by generators standing on them are
-  deliberately untouched: several machines sharing a bus and all regulating it locally remains the
-  ordinary PV case, with the per-bus reactive redistribution of ``GeneratorContainer::set_q``.
+  on them -- generators and voltage-regulating hvdc converter stations alike -- as members of the
+  group. Buses regulated only by things standing on them are deliberately untouched: several machines
+  sharing a bus and all regulating it locally remains the ordinary PV case, with the per-bus reactive
+  redistribution of ``GeneratorContainer::set_q``.
   Three configurations start working as a result: a remote controller onto a locally regulated bus,
   a remote controller onto a slack bus pinned by its own generator (the slack generator joins the
   group and MultiSlack grants the free ``Vm``), and -- separately, by giving the regulated-bus check
@@ -154,9 +155,14 @@ TODO: Levenberg-Marquardt damping (a.k.a. Tikhonov-regularized Newton) : adding 
   has no solution at all: whatever reactive power it injects there is absorbed one-for-one by the
   machine holding that bus' magnitude, so it has no influence on its remote target -- no
   reclassification can help, and the "its OWN bus has no reactive (Q) equation" error still fires.
-  And an hvdc converter station cannot join a control group (the group only knows ``GEN`` and ``SVC``
-  kinds), so a bus a station voltage-pins while a group also regulates it is rejected with an
-  explicit message from ``fillpv_pq`` rather than silently losing the station's regulation.
+  Voltage-regulating hvdc converter stations take part on the same footing as generators. A VSC
+  station with ``voltage_regulator_on`` pins its own bus through the very same PV path, so it is
+  enrolled into the group whenever a controller claims that bus -- two new controller kinds,
+  ``VoltageControlSolverData::HVDC_SIDE_1`` / ``HVDC_SIDE_2``, with the hvdc LINE id as ``elem_id``
+  and the solved reactive output written back to the station. Its sharing key is a reactive range in
+  MVAr, the same currency as a generator's, so a mixed generator/station group shares reactive power
+  correctly (a group of a local generator, a remote generator and a station splits ``Q`` three ways
+  by range).
   Note for voltage-mode SVCs: their regulated bus now leaves the PV path as well, which is what makes
   the classification uniform, but an SVC still has to be the only controller of its bus in v1 (its
   sharing key is a susceptance range, not a reactive range, so mixed SVC/generator sharing has no
@@ -164,9 +170,10 @@ TODO: Levenberg-Marquardt damping (a.k.a. Tikhonov-regularized Newton) : adding 
   names the real limitation.
 - [ADDED] ``src/tests/test_voltage_control_reclassify.cpp`` and
   ``lightsim2grid/tests/test_voltage_control_reclassify.py``: the classification rule itself, the
-  three newly-supported configurations (including the reactive split), the two that must stay
-  refused, and a regression guard that several purely local regulators on one bus still take the
-  classical PV path and produce bit-identical voltages.
+  newly-supported configurations (including the reactive split, and hvdc stations sharing a bus with
+  generators on either end of the line), the ones that must stay refused, and regression guards that
+  several purely local regulators on one bus -- and a lone voltage-regulating station -- still take
+  the classical PV path and produce bit-identical voltages.
 - [ADDED] ``TimeSeriesCPP`` / ``ContingencyAnalysisCPP`` (and so ``SecurityAnalysis``, which wraps the
   latter) gained a string-based ``change_algorithm(name)`` overload and a ``get_algo_name()`` accessor,
   matching what ``LSGrid`` already had (``AlgorithmSelector::change_algorithm(const std::string&)``) --

--- a/lightsim2grid/tests/test_voltage_control_reclassify.py
+++ b/lightsim2grid/tests/test_voltage_control_reclassify.py
@@ -6,9 +6,10 @@
 # SPDX-License-Identifier: MPL-2.0
 # This file is part of LightSim2grid, LightSim2grid implements a c++ backend targeting the Grid2Op platform.
 
-"""A generator may remotely regulate a bus that another generator already regulates
-locally: the two simply form one control group, sharing the reactive duty in
-proportion to their ``qmax - qmin`` ranges.
+"""A generator may remotely regulate a bus that another generator -- or a
+voltage-regulating hvdc converter station -- already regulates locally: they simply
+form one control group, sharing the reactive duty in proportion to their
+``qmax - qmin`` ranges.
 
 That used to be refused. ``GeneratorContainer::fillpv`` only knew how to keep a
 controller's OWN bus out of the PV set; nothing stopped a local regulator from
@@ -25,12 +26,15 @@ it has no influence at all on its remote target.
 Companion C++ suite: ``src/tests/test_voltage_control_reclassify.cpp``.
 """
 
+import os
+import sys
 import warnings
 import unittest
 import numpy as np
 import pandapower as pp
 import pandapower.networks as pn
 
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 with warnings.catch_warnings():
     warnings.filterwarnings("ignore")
     from lightsim2grid.gridmodel import init_from_pandapower
@@ -147,6 +151,53 @@ class TestOrdinaryPVUnchanged(unittest.TestCase):
         # the added generator produces 0 MW and regulates the same bus to the same
         # value, so the operating point is unchanged
         self.assertLess(np.abs(V - Vref).max(), 1e-6)
+
+
+class TestHvdcStationInAGroup(unittest.TestCase):
+    """A voltage-regulating VSC converter station pins its bus through the very PV
+    path a local generator uses, so it belongs in the group machinery too: when a
+    remote controller claims that bus, the station has to be enrolled as a member
+    rather than quietly losing its regulation."""
+
+    # side-1 station goes on bus 2, which already carries gen 1 (a local regulator);
+    # gen 0 (bus 1) then aims at bus 2 remotely. All three must agree on the setpoint,
+    # otherwise the group's own setpoint check fires first.
+    REG_BUS = 2
+
+    def _make(self, with_remote_gen):
+        from _aux_make_hvdc import make_case14_hvdc
+        _, probe = _case14()
+        vset = probe.get_generators()[GEN_AT_BUS2].target_vm_pu   # gen 1's own setpoint
+        net, model = make_case14_hvdc(self.REG_BUS, 9, vreg1=True, vm1=vset,
+                                      droop_enabled=False, p_setpoint=0.0)
+        if with_remote_gen:
+            model.change_v_gen(GEN_AT_BUS1, vset)
+            model.set_gen_regulated_bus(GEN_AT_BUS1, self.REG_BUS)
+        model.tell_solver_need_reset()
+        return net, model, vset
+
+    def test_station_joins_the_group_and_carries_reactive_power(self):
+        net, model, vset = self._make(with_remote_gen=True)
+        V = _solve(model, net.bus.shape[0])
+        self.assertGreater(V.shape[0], 0, "ac_pf diverged")
+        self.assertLess(abs(abs(V[self.REG_BUS]) - vset), 1e-6,
+                        f"|V[{self.REG_BUS}]|={abs(V[self.REG_BUS]):.8f} != {vset:.8f}")
+
+        # the station carries reactive power, i.e. it was enrolled in the group and
+        # not silently stripped of its regulation
+        station_q = model.get_dclines()[0].res_q1_mvar
+        self.assertGreater(abs(station_q), 1e-6,
+                           "the hvdc station carries no reactive power: not enrolled")
+        # so does the remote generator, and so does the local one
+        self.assertGreater(abs(_gen_q_mvar(model, GEN_AT_BUS1)), 1e-6)
+
+    def test_station_alone_on_its_bus_keeps_the_pv_path(self):
+        # the control: no remote controller anywhere, so the station pins its bus
+        # exactly as it did before the reclassification existed
+        net, model, vset = self._make(with_remote_gen=False)
+        V = _solve(model, net.bus.shape[0])
+        self.assertGreater(V.shape[0], 0, "ac_pf diverged")
+        self.assertLess(abs(abs(V[self.REG_BUS]) - vset), 1e-6)
 
 
 if __name__ == "__main__":

--- a/lightsim2grid/tests/test_voltage_control_reclassify.py
+++ b/lightsim2grid/tests/test_voltage_control_reclassify.py
@@ -1,0 +1,153 @@
+# Copyright (c) 2026, RTE (https://www.rte-france.com)
+# See AUTHORS.txt
+# This Source Code Form is subject to the terms of the Mozilla Public License, version 2.0.
+# If a copy of the Mozilla Public License, version 2.0 was not distributed with this file,
+# you can obtain one at http://mozilla.org/MPL/2.0/.
+# SPDX-License-Identifier: MPL-2.0
+# This file is part of LightSim2grid, LightSim2grid implements a c++ backend targeting the Grid2Op platform.
+
+"""A generator may remotely regulate a bus that another generator already regulates
+locally: the two simply form one control group, sharing the reactive duty in
+proportion to their ``qmax - qmin`` ranges.
+
+That used to be refused. ``GeneratorContainer::fillpv`` only knew how to keep a
+controller's OWN bus out of the PV set; nothing stopped a local regulator from
+claiming a bus that somebody else regulated remotely, and the group's bordered
+voltage row was then left with no ``Vm`` column to act on. The configuration came
+back as "regulates bus X which has no voltage (Vm) unknown" even though it is
+perfectly well posed.
+
+What must still be refused is the genuinely unsolvable arrangement: a remote
+regulator sharing its own bus with a local regulator. Whatever reactive power it
+injects there is absorbed one-for-one by the machine holding that bus' magnitude, so
+it has no influence at all on its remote target.
+
+Companion C++ suite: ``src/tests/test_voltage_control_reclassify.cpp``.
+"""
+
+import warnings
+import unittest
+import numpy as np
+import pandapower as pp
+import pandapower.networks as pn
+
+with warnings.catch_warnings():
+    warnings.filterwarnings("ignore")
+    from lightsim2grid.gridmodel import init_from_pandapower
+
+MAX_IT = 30
+TOL = 1e-11
+# case14 as lightsim sees it: gens 0..3 on buses 1, 2, 5, 7 and the ext_grid as gen 4
+# on bus 0 (the slack).
+GEN_AT_BUS1 = 0
+GEN_AT_BUS2 = 1
+SLACK_BUS = 0
+
+
+def _case14(extra_gen_bus=None):
+    with warnings.catch_warnings():
+        warnings.filterwarnings("ignore")
+        net = pn.case14()
+        if extra_gen_bus is not None:
+            pp.create_gen(net, bus=extra_gen_bus, p_mw=0.0, vm_pu=1.01,
+                          min_q_mvar=-100., max_q_mvar=100., controllable=True)
+        model = init_from_pandapower(net)
+    return net, model
+
+
+def _solve(model, nb_bus):
+    return model.ac_pf(np.ones(nb_bus, dtype=np.complex128), MAX_IT, TOL)
+
+
+def _gen_q_mvar(model, gen_id):
+    return model.get_generators()[gen_id].res_q_mvar
+
+
+class TestRemoteOntoLocallyRegulatedBus(unittest.TestCase):
+    def test_remote_may_target_a_locally_regulated_bus(self):
+        # gen 1 sits on bus 2 and regulates it locally; gen 0 (bus 1) aims at bus 2
+        # remotely, with the same setpoint.
+        net, model = _case14()
+        vset = model.get_generators()[GEN_AT_BUS2].target_vm_pu
+        model.change_v_gen(GEN_AT_BUS1, vset)
+        model.set_gen_regulated_bus(GEN_AT_BUS1, 2)
+        model.tell_solver_need_reset()
+
+        V = _solve(model, net.bus.shape[0])
+        self.assertGreater(V.shape[0], 0, "ac_pf diverged")
+        self.assertLess(abs(abs(V[2]) - vset), 1e-6,
+                        f"|V[2]|={abs(V[2]):.8f} != setpoint {vset:.8f}")
+
+        # both machines carry reactive power, split by their qmax - qmin ranges
+        gens = model.get_generators()
+        w_remote = gens[GEN_AT_BUS1].max_q_mvar - gens[GEN_AT_BUS1].min_q_mvar
+        w_local = gens[GEN_AT_BUS2].max_q_mvar - gens[GEN_AT_BUS2].min_q_mvar
+        q_remote = _gen_q_mvar(model, GEN_AT_BUS1)
+        q_local = _gen_q_mvar(model, GEN_AT_BUS2)
+        self.assertGreater(abs(q_remote), 1e-6, "the remote controller carries no Q")
+        self.assertLess(abs(q_remote / w_remote - q_local / w_local), 1e-6,
+                        f"Q not shared by range: {q_remote}/{w_remote} vs {q_local}/{w_local}")
+
+    def test_conflicting_setpoints_are_named_as_such(self):
+        # same shape but disagreeing setpoints: both are in one group now, so the
+        # error is about the setpoints rather than about the bus classification
+        net, model = _case14()
+        vset = model.get_generators()[GEN_AT_BUS2].target_vm_pu
+        model.change_v_gen(GEN_AT_BUS1, vset + 0.02)
+        model.set_gen_regulated_bus(GEN_AT_BUS1, 2)
+        model.tell_solver_need_reset()
+        with self.assertRaises(RuntimeError) as ctx:
+            _solve(model, net.bus.shape[0])
+        self.assertIn("conflicting voltage setpoints", str(ctx.exception))
+
+    def test_remote_may_target_the_slack_bus(self):
+        # the slack (bus 0) is pinned by the ext_grid generator, so this used to be
+        # refused; that generator now joins the group and MultiSlack grants the
+        # free Vm the bordered row needs
+        net, model = _case14()
+        slack_gen = [i for i, g in enumerate(model.get_generators()) if g.is_slack][0]
+        vset = model.get_generators()[slack_gen].target_vm_pu
+        model.change_v_gen(GEN_AT_BUS1, vset)
+        model.set_gen_regulated_bus(GEN_AT_BUS1, SLACK_BUS)
+        model.tell_solver_need_reset()
+
+        V = _solve(model, net.bus.shape[0])
+        self.assertGreater(V.shape[0], 0, "ac_pf diverged")
+        self.assertLess(abs(abs(V[SLACK_BUS]) - vset), 1e-6)
+
+
+class TestStillRefused(unittest.TestCase):
+    def test_remote_sharing_its_bus_with_a_local_regulator(self):
+        # a SECOND generator on bus 2 (which gen 1 pins locally) aiming remotely at
+        # bus 9: its reactive injection is swallowed by gen 1, so it has no influence
+        # on bus 9 and there is no solution. Must stay refused.
+        net, model = _case14(extra_gen_bus=2)
+        on_bus2 = [i for i, g in enumerate(model.get_generators()) if g.bus_id == 2]
+        self.assertEqual(len(on_bus2), 2, "expected two generators on bus 2")
+        model.set_gen_regulated_bus(on_bus2[-1], 9)
+        model.tell_solver_need_reset()
+        with self.assertRaises(RuntimeError) as ctx:
+            _solve(model, net.bus.shape[0])
+        self.assertIn("OWN bus has no reactive (Q) equation", str(ctx.exception))
+
+
+class TestOrdinaryPVUnchanged(unittest.TestCase):
+    def test_several_local_generators_on_one_bus(self):
+        # the common configuration the reclassification must leave completely alone:
+        # two machines on one bus, both regulating it locally, no remote controller
+        # anywhere. Voltages must match plain case14 with the extra generator at 0 MW.
+        net, model = _case14(extra_gen_bus=2)
+        model.tell_solver_need_reset()
+        V = _solve(model, net.bus.shape[0])
+        self.assertGreater(V.shape[0], 0, "ac_pf diverged")
+
+        _, ref = _case14()
+        Vref = _solve(ref, net.bus.shape[0])
+        self.assertGreater(Vref.shape[0], 0)
+        # the added generator produces 0 MW and regulates the same bus to the same
+        # value, so the operating point is unchanged
+        self.assertLess(np.abs(V - Vref).max(), 1e-6)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/core/LSGrid.cpp
+++ b/src/core/LSGrid.cpp
@@ -961,6 +961,45 @@ void LSGrid::fill_voltage_control_solver_data(VoltageControlSolverData & data, b
         raws.push_back({ctrl_solver, reg_solver, svcs_.get_target_vm_pu(svc_id),
                         svcs_.get_slope_pu(svc_id), w, VoltageControlSolverData::SVC, svc_id});
     }
+
+    // ... and the voltage-regulating hvdc converter stations. A VSC station with
+    // voltage_regulator_on pins its own bus through the PV path, exactly like a local
+    // generator, so it is a controller only when a GROUP regulates that bus instead
+    // (fillpv_pq then kept the bus out of PV and it needs its members). Its sharing
+    // key is a reactive range in MVAr -- the same currency as a generator's -- so a
+    // mixed generator/station group shares reactive power correctly, unlike an SVC
+    // (whose key is a susceptance range; hence the SVC-alone restriction below).
+    const int nb_hvdc = static_cast<int>(hvdc_lines_.nb());
+    for(int hvdc_id = 0; hvdc_id < nb_hvdc; ++hvdc_id){
+        for(int side = 1; side <= 2; ++side){
+            if(!hvdc_lines_.station_is_voltage_controller(hvdc_id, side)) continue;
+            const int ctrl_grid = hvdc_lines_.get_station_bus(hvdc_id, side).cast_int();
+            // not group-controlled: the station keeps pinning its bus the classical way
+            if(!group_reg.count(ctrl_grid)) continue;
+            if(ctrl_grid == GenericContainer::_deactivated_bus_id) continue;
+            const int ctrl_solver = id_me_to_solver[ctrl_grid].cast_int();
+            if(ctrl_solver == GenericContainer::_deactivated_bus_id){
+                std::ostringstream exc_;
+                exc_ << "LSGrid::fill_voltage_control_solver_data: hvdc line " << hvdc_id
+                     << " side " << side << " regulates voltage but its bus is disconnected.";
+                throw std::runtime_error(exc_.str());
+            }
+            if(!is_pq[ctrl_solver] && !has_free_q[ctrl_solver]){
+                std::ostringstream exc_;
+                exc_ << "LSGrid::fill_voltage_control_solver_data: hvdc line " << hvdc_id
+                     << " side " << side << " takes part in a voltage-control group but its"
+                        " bus has no reactive (Q) equation. This is not supported in v1.";
+                throw std::runtime_error(exc_.str());
+            }
+            const int kind = (side == 1) ? VoltageControlSolverData::HVDC_SIDE_1
+                                         : VoltageControlSolverData::HVDC_SIDE_2;
+            raws.push_back({ctrl_solver, ctrl_solver,   // a station regulates its OWN bus
+                            hvdc_lines_.get_station_target_vm_pu(hvdc_id, side),
+                            static_cast<real_type>(0.),
+                            hvdc_lines_.get_station_q_range_mvar(hvdc_id, side),
+                            kind, hvdc_id});
+        }
+    }
     if(raws.empty()) return;
 
     // 2. group by regulated solver bus (merge gens that share a regulated bus),
@@ -1731,20 +1770,9 @@ void LSGrid::fillpv_pq(const SolverBusIdVect& id_me_to_solver,
                 bus_pv_kept.push_back(bus_id_solver);
                 continue;
             }
-            // An hvdc converter station pins voltage through the same PV path but is
-            // NOT a VoltageControl controller (the group only knows GEN and SVC
-            // kinds), so it cannot be enrolled and its regulation would be silently
-            // discarded by the reclassification. Refuse loudly instead.
-            if(hvdc_lines_.pins_bus_voltage(GlobalBusId(bus_id_me))){
-                std::ostringstream exc_;
-                exc_ << "LSGrid::fillpv_pq: bus " << bus_id_me << " is regulated by a"
-                        " voltage-control group (a remote-regulating generator or a"
-                        " voltage-mode SVC aims at it) while also being voltage-pinned by"
-                        " an hvdc converter station. A converter station cannot join a"
-                        " control group, so this is not supported: either disable the"
-                        " station's voltage regulation or retarget the controller.";
-                throw std::runtime_error(exc_.str());
-            }
+            // Whatever pinned this bus through the PV path -- a local generator or a
+            // voltage-regulating hvdc converter station -- is enrolled as a member of
+            // the group by fill_voltage_control_solver_data instead.
             has_bus_been_added[bus_id_solver] = false;  // let the PQ loop take it
         }
         bus_pv.swap(bus_pv_kept);
@@ -1827,7 +1855,7 @@ void LSGrid::compute_results(bool ac){
     hvdc_lines_.set_q(reactive_mismatch, id_me_to_solver, ac,
                     total_gen_per_bus_, total_q_min_per_bus_, total_q_max_per_bus_);
 
-    // VoltageControl (remote gen + SVC) write-back: the reactive output of the
+    // VoltageControl (gen / SVC / hvdc converter station) write-back: the reactive output of the
     // voltage-mode controllers is solved inside the NR system (not by the per-bus
     // redistribution above, which skips them). Pull it from the AC algorithm and
     // store it (pu -> MVAr). Empty for DC / non-NR algorithms.
@@ -1837,10 +1865,26 @@ void LSGrid::compute_results(bool ac){
         const IntVect  ctrl_elem = _algo.get_controller_elem_id();
         for(int i = 0; i < static_cast<int>(ctrl_q.size()); ++i){
             const real_type q_mvar = ctrl_q(i) * sn_mva_;
-            if(ctrl_kind(i) == VoltageControlSolverData::GEN){
-                generators_.set_voltage_control_q(ctrl_elem(i), q_mvar);
-            } else {  // VoltageControlSolverData::SVC
-                svcs_.set_voltage_control_q(ctrl_elem(i), q_mvar);
+            switch(ctrl_kind(i)){
+                case VoltageControlSolverData::GEN:
+                    generators_.set_voltage_control_q(ctrl_elem(i), q_mvar);
+                    break;
+                case VoltageControlSolverData::SVC:
+                    svcs_.set_voltage_control_q(ctrl_elem(i), q_mvar);
+                    break;
+                case VoltageControlSolverData::HVDC_SIDE_1:
+                    // elem_id is the hvdc LINE id for both station kinds
+                    hvdc_lines_.set_station_voltage_control_q(ctrl_elem(i), 1, q_mvar);
+                    break;
+                case VoltageControlSolverData::HVDC_SIDE_2:
+                    hvdc_lines_.set_station_voltage_control_q(ctrl_elem(i), 2, q_mvar);
+                    break;
+                default: {
+                    std::ostringstream exc_;
+                    exc_ << "LSGrid::compute_results: unknown voltage controller kind "
+                         << ctrl_kind(i) << ".";
+                    throw std::runtime_error(exc_.str());
+                }
             }
         }
     }

--- a/src/core/LSGrid.cpp
+++ b/src/core/LSGrid.cpp
@@ -854,15 +854,24 @@ void LSGrid::fill_voltage_control_solver_data(VoltageControlSolverData & data, b
         if(b >= 0 && b < nb_bus_solver) has_free_q[b] = true;
     }
 
-    // 1. collect the active voltage-mode controllers (remote-regulating gens for
-    //    now; voltage-mode SVCs are added with the SvcContainer). Per controller:
-    //    solver bus, regulated solver bus, v_set (pu), sharing key, kind, elem id.
+    // 1. collect the active voltage-mode controllers (generators and voltage-mode
+    //    SVCs). Per controller: solver bus, regulated solver bus, v_set (pu),
+    //    sharing key, kind, elem id.
     struct Raw { int bus; int reg_bus; real_type v_set; real_type slope; real_type weight; int kind; int elem_id; };
     std::vector<Raw> raws;
+    // Buses whose magnitude a group sets rather than the PV path. Every ACTIVE
+    // voltage regulator aiming at one of them is a member of its group -- including
+    // a LOCAL one, which fillpv_pq consequently did not let pin its own bus.
+    const std::set<int> group_reg = get_group_controlled_buses();
     const int nb_gen = static_cast<int>(generators_.nb());
     const GlobalBusIdVect & gen_buses = generators_.get_buses();
     for(int gen_id = 0; gen_id < nb_gen; ++gen_id){
-        if(!generators_.gen_is_voltage_controller(gen_id)) continue;
+        // remote regulators are always controllers; a local one only when the bus it
+        // regulates is group-controlled (something else remote/an SVC aims at it too)
+        if(!generators_.gen_is_voltage_controller(gen_id)){
+            if(!generators_.gen_is_local_voltage_controller(gen_id)) continue;
+            if(!group_reg.count(generators_.get_regulated_bus_id(gen_id))) continue;
+        }
         const int ctrl_grid = gen_buses(gen_id).cast_int();
         const int reg_grid  = generators_.get_regulated_bus_id(gen_id);
         const int ctrl_solver = id_me_to_solver[ctrl_grid].cast_int();
@@ -889,11 +898,18 @@ void LSGrid::fill_voltage_control_solver_data(VoltageControlSolverData & data, b
                     " in v1.";
             throw std::runtime_error(exc_.str());
         }
-        if(!is_pq[reg_solver]){
+        // The regulated bus needs a Vm unknown for the bordered row to act on. An
+        // ordinary PQ bus has one; so does a slack bus that nothing pins locally,
+        // courtesy of the MultiSlack extension (same escape hatch as the controller
+        // bus just above -- `has_free_q`). A bus that is PV despite being
+        // group-controlled cannot occur any more (fillpv_pq reclassifies it), so
+        // what is left here is a bus pinned by something that cannot be enrolled.
+        if(!is_pq[reg_solver] && !has_free_q[reg_solver]){
             std::ostringstream exc_;
             exc_ << "LSGrid::fill_voltage_control_solver_data: generator " << gen_id
                  << " regulates bus " << reg_grid << " which has no voltage (Vm) unknown"
-                    " (it is a slack or an already-PV bus). This is not supported in v1.";
+                    " (its magnitude is pinned by something that cannot join a control"
+                    " group). This is not supported in v1.";
             throw std::runtime_error(exc_.str());
         }
         const real_type w = generators_.get_max_q(gen_id) - generators_.get_min_q(gen_id);
@@ -923,18 +939,22 @@ void LSGrid::fill_voltage_control_solver_data(VoltageControlSolverData & data, b
                  << " regulates a disconnected bus.";
             throw std::runtime_error(exc_.str());
         }
-        if(!is_pq[ctrl_solver]){
+        // same two escape hatches as the generator branch above: a slack bus that
+        // nothing pins locally owns a Q equation and a free Vm (MultiSlack)
+        if(!is_pq[ctrl_solver] && !has_free_q[ctrl_solver]){
             std::ostringstream exc_;
             exc_ << "LSGrid::fill_voltage_control_solver_data: SVC " << svc_id
-                 << " is at a bus with no reactive (Q) equation (it is a slack or PV bus)."
+                 << " is at a bus with no reactive (Q) equation (it is a PV bus, or a slack"
+                    " bus pinned by a local voltage-regulating generator)."
                     " This is not supported in v1.";
             throw std::runtime_error(exc_.str());
         }
-        if(!is_pq[reg_solver]){
+        if(!is_pq[reg_solver] && !has_free_q[reg_solver]){
             std::ostringstream exc_;
             exc_ << "LSGrid::fill_voltage_control_solver_data: SVC " << svc_id
                  << " regulates bus " << reg_grid << " which has no voltage (Vm) unknown"
-                    " (it is a slack or an already-PV bus). This is not supported in v1.";
+                    " (its magnitude is pinned by something that cannot join a control"
+                    " group). This is not supported in v1.";
             throw std::runtime_error(exc_.str());
         }
         const real_type w = svcs_.get_b_max(svc_id) - svcs_.get_b_min(svc_id);
@@ -1016,6 +1036,30 @@ void LSGrid::fill_voltage_control_solver_data(VoltageControlSolverData & data, b
     }
 }
 
+std::set<int> LSGrid::get_group_controlled_buses() const
+{
+    std::set<int> res;
+    // an ACTIVE remote-regulating generator: gen_is_voltage_controller() already
+    // means "connected, regulator on, not pseudo-off, and regulating a bus that is
+    // NOT its own". A purely local regulator therefore never lands here, which is
+    // what keeps the ordinary (possibly multi-generator) PV bus untouched.
+    const int nb_gen = static_cast<int>(generators_.nb());
+    for(int gen_id = 0; gen_id < nb_gen; ++gen_id){
+        if(!generators_.gen_is_voltage_controller(gen_id)) continue;
+        const int reg = generators_.get_regulated_bus_id(gen_id);
+        if(reg >= 0) res.insert(reg);
+    }
+    // a voltage-mode SVC is ALWAYS a group controller (even local and non-sloped),
+    // so the bus it regulates always needs the bordered treatment
+    const int nb_svc = static_cast<int>(svcs_.nb());
+    for(int svc_id = 0; svc_id < nb_svc; ++svc_id){
+        if(!svcs_.svc_is_voltage_controller(svc_id)) continue;
+        const int reg = svcs_.get_regulated_bus_id(svc_id);
+        if(reg >= 0) res.insert(reg);
+    }
+    return res;
+}
+
 std::set<int> LSGrid::get_free_vm_slack_solver_buses() const
 {
     std::set<int> res;
@@ -1030,11 +1074,17 @@ std::set<int> LSGrid::get_free_vm_slack_solver_buses() const
     // voltage-regulating generator pins its magnitude. Collect those buses.
     std::set<int> locally_vfixed;
     const SolverBusIdVect & id_me_to_solver = id_me_to_ac_solver_;
+    // ... except that a local regulator on a bus a control GROUP regulates does not
+    // pin it: it is enrolled as a member of that group instead (see
+    // get_group_controlled_buses and the reclassification in fillpv_pq), and the
+    // group's voltage row needs the free Vm this function grants.
+    const std::set<int> group_reg = get_group_controlled_buses();
     const int nb_gen = static_cast<int>(generators_.nb());
     const GlobalBusIdVect & gen_buses = generators_.get_buses();
     for(int gen_id = 0; gen_id < nb_gen; ++gen_id){
         if(!generators_.gen_is_local_voltage_controller(gen_id)) continue;
         const int ctrl_grid = gen_buses(gen_id).cast_int();
+        if(group_reg.count(ctrl_grid)) continue;
         const int ctrl_solver = id_me_to_solver[ctrl_grid].cast_int();
         if(ctrl_solver == GenericContainer::_deactivated_bus_id) continue;
         locally_vfixed.insert(ctrl_solver);
@@ -1657,6 +1707,48 @@ void LSGrid::fillpv_pq(const SolverBusIdVect& id_me_to_solver,
     sgens_.fillpv(bus_pv, has_bus_been_added, slack_bus_id_solver, id_me_to_solver);
     generators_.fillpv(bus_pv, has_bus_been_added, slack_bus_id_solver, id_me_to_solver);
     hvdc_lines_.fillpv(bus_pv, has_bus_been_added, slack_bus_id_solver, id_me_to_solver);
+
+    // A bus regulated by a VoltageControl group must keep its OWN Vm unknown (and
+    // hence its Q equation): the group's bordered voltage row `Vm(reg) - v_set = 0`
+    // is what sets its magnitude. The per-container fillpv above only knows how to
+    // keep a controller's own bus out of PV (GeneratorContainer::fillpv skips a gen
+    // that regulates remotely); nothing there stops a LOCAL regulator sitting on the
+    // regulated bus from claiming it as PV. When that happened the group's voltage
+    // row found no Vm column to write its +1 into -- a structurally empty row, i.e.
+    // a singular Jacobian -- so fill_voltage_control_solver_data had to reject the
+    // whole configuration ("regulates bus X which has no voltage (Vm) unknown"),
+    // even though it is perfectly well posed: the local regulator simply belongs in
+    // the group, and the sharing row then supplies the equation that fixes the
+    // reactive split. Drop those buses from PV here (the PQ loop just below picks
+    // them up) and fill_voltage_control_solver_data enrols the local regulators.
+    const std::set<int> group_reg = get_group_controlled_buses();
+    if(!group_reg.empty()){
+        std::vector<int> bus_pv_kept;
+        bus_pv_kept.reserve(bus_pv.size());
+        for(int bus_id_solver : bus_pv){
+            const int bus_id_me = id_solver_to_me[bus_id_solver].cast_int();
+            if(bus_id_me < 0 || !group_reg.count(bus_id_me)){
+                bus_pv_kept.push_back(bus_id_solver);
+                continue;
+            }
+            // An hvdc converter station pins voltage through the same PV path but is
+            // NOT a VoltageControl controller (the group only knows GEN and SVC
+            // kinds), so it cannot be enrolled and its regulation would be silently
+            // discarded by the reclassification. Refuse loudly instead.
+            if(hvdc_lines_.pins_bus_voltage(GlobalBusId(bus_id_me))){
+                std::ostringstream exc_;
+                exc_ << "LSGrid::fillpv_pq: bus " << bus_id_me << " is regulated by a"
+                        " voltage-control group (a remote-regulating generator or a"
+                        " voltage-mode SVC aims at it) while also being voltage-pinned by"
+                        " an hvdc converter station. A converter station cannot join a"
+                        " control group, so this is not supported: either disable the"
+                        " station's voltage regulation or retarget the controller.";
+                throw std::runtime_error(exc_.str());
+            }
+            has_bus_been_added[bus_id_solver] = false;  // let the PQ loop take it
+        }
+        bus_pv.swap(bus_pv_kept);
+    }
 
     for(int bus_id = 0; bus_id< nb_bus; ++bus_id){
         if(GenericContainer::is_in_vect(bus_id, slack_bus_id_solver.to_int_vector())) continue;  // slack bus is not PQ either

--- a/src/core/LSGrid.hpp
+++ b/src/core/LSGrid.hpp
@@ -1089,6 +1089,27 @@ class LS2G_API LSGrid final
          */
         std::set<int> get_free_vm_slack_solver_buses() const;
         /**
+         * GRID-bus ids whose voltage magnitude is set by a VoltageControl group
+         * rather than by the classical PV treatment. A bus lands here as soon as
+         * an ACTIVE remote-regulating generator or an active voltage-mode SVC aims
+         * at it, because the group's bordered voltage row needs that bus to keep a
+         * Vm unknown (and hence a Q equation).
+         *
+         * Buses regulated ONLY by local generators are deliberately NOT included:
+         * several machines sharing a bus and all regulating it locally is the
+         * ordinary PV case, handled exactly as before by the per-bus reactive
+         * redistribution (`GeneratorContainer::set_q`). It is the arrival of a
+         * remote controller (or an SVC, which is always a group controller) that
+         * switches the bus over to the bordered formulation -- and then any local
+         * regulator on that bus joins the group as a co-controller instead of
+         * pinning it.
+         *
+         * Works in grid ids and reads only input data, so unlike the solver-side
+         * accessors it is valid before / independently of `pre_process_solver`
+         * (`fillpv_pq` needs it while it is still building that very labelling).
+         */
+        std::set<int> get_group_controlled_buses() const;
+        /**
          * Set the grid bus whose voltage generator `gen_id` regulates (remote
          * voltage control). `bus_id` == the generator's own bus restores ordinary
          * local PV control.

--- a/src/core/LSGrid.hpp
+++ b/src/core/LSGrid.hpp
@@ -1095,14 +1095,15 @@ class LS2G_API LSGrid final
          * at it, because the group's bordered voltage row needs that bus to keep a
          * Vm unknown (and hence a Q equation).
          *
-         * Buses regulated ONLY by local generators are deliberately NOT included:
-         * several machines sharing a bus and all regulating it locally is the
-         * ordinary PV case, handled exactly as before by the per-bus reactive
+         * Buses regulated ONLY by things standing on them -- local generators, or
+         * voltage-regulating hvdc converter stations -- are deliberately NOT
+         * included: several machines sharing a bus and all regulating it locally is
+         * the ordinary PV case, handled exactly as before by the per-bus reactive
          * redistribution (`GeneratorContainer::set_q`). It is the arrival of a
          * remote controller (or an SVC, which is always a group controller) that
-         * switches the bus over to the bordered formulation -- and then any local
-         * regulator on that bus joins the group as a co-controller instead of
-         * pinning it.
+         * switches the bus over to the bordered formulation -- and then every local
+         * regulator on that bus, generator or converter station, joins the group as
+         * a co-controller instead of pinning it.
          *
          * Works in grid ids and reads only input data, so unlike the solver-side
          * accessors it is valid before / independently of `pre_process_solver`
@@ -1626,7 +1627,7 @@ class LS2G_API LSGrid final
         // is the ground-truth state after convergence -- NOT the 0 initial
         // guess an external solver's own linearized derivation starts from.
         [[nodiscard]] real_type get_slack_absorbed_solver() const { return _algo.get_slack_absorbed(); }
-        // VoltageControl (remote gen + SVC) converged reactive injection per
+        // VoltageControl (gen / SVC / hvdc station) converged reactive injection per
         // controller (pu), + its (kind: 0=GEN,1=SVC; element id) identity, in
         // controller registration order (empty when the extension is inactive).
         // Ground truth for external solvers deriving their own controller_q.

--- a/src/core/VoltageControlData.hpp
+++ b/src/core/VoltageControlData.hpp
@@ -16,7 +16,8 @@ namespace ls2g {
 
 /**
  * Per-solve data of the ACTIVE voltage-mode controllers (remote-regulating
- * generators and voltage-mode SVCs), in SOLVER bus labelling and per-unit, as
+ * generators, voltage-mode SVCs, and voltage-regulating hvdc converter stations
+ * whose bus a group claims), in SOLVER bus labelling and per-unit, as
  * consumed by the `VoltageControl` extension of the Newton-Raphson system.
  * Built by LSGrid::fill_voltage_control_solver_data; AC only (DC ignores it).
  *
@@ -41,8 +42,12 @@ namespace ls2g {
  */
 struct LS2G_API VoltageControlSolverData
 {
-    // controller kind tag (stored per controller, used for result write-back)
-    enum Kind { GEN = 0, SVC = 1 };
+    // Controller kind tag (stored per controller, used for result write-back).
+    // HVDC_SIDE_1 / HVDC_SIDE_2 are the two converter stations of an hvdc line;
+    // `elem_id` carries the hvdc LINE id for both, the kind saying which end. A
+    // station is a controller only when a group regulates its bus -- on its own it
+    // pins that bus through the ordinary PV path, like a local generator.
+    enum Kind { GEN = 0, SVC = 1, HVDC_SIDE_1 = 2, HVDC_SIDE_2 = 3 };
 
     // ---- per controller (flat, grouped contiguously) ------------------------
     Eigen::VectorXi bus;       // controller solver bus (must own a Q equation)

--- a/src/core/element_container/ConverterStationContainer.hpp
+++ b/src/core/element_container/ConverterStationContainer.hpp
@@ -127,21 +127,19 @@ class LS2G_API ConverterStationContainer final : public OneSideContainer_PQ, pub
         real_type get_qmax(int station_id) const {return max_q_.coeff(station_id);}
         real_type get_target_p(int station_id) const {return target_p_mw_(station_id);}
         real_type get_target_vm_pu(int station_id) const {return target_vm_pu_(station_id);}
-        // true iff an ACTIVE voltage-regulating station of this container sits on
-        // `bus` and therefore pins its magnitude -- exactly the gating `fillpv`
-        // below uses. Read by LSGrid::fillpv_pq: a converter station is NOT a
-        // VoltageControl controller (only GEN / SVC are), so a bus it pins cannot
-        // be handed over to a control group, and the configuration has to be
-        // rejected rather than silently stripped of the station's regulation.
-        bool pins_bus_voltage(GlobalBusId bus) const {
-            const int nb_station = nb();
-            for(int station_id = 0; station_id < nb_station; ++station_id){
-                if(!status_[station_id]) continue;
-                if(!voltage_regulator_on_[station_id]) continue;
-                if(bus_id_(station_id).cast_int() == bus.cast_int()) return true;
-            }
-            return false;
+        // true iff this station is an ACTIVE voltage regulator, i.e. it pins the
+        // magnitude of its own bus -- exactly the gating `fillpv` below uses. When a
+        // control group regulates that bus instead, the station is enrolled as a
+        // member of the group (LSGrid::fill_voltage_control_solver_data) rather than
+        // pinning it, just like a generator in the same position.
+        bool is_voltage_controller(int station_id) const {
+            if(!status_[station_id]) return false;
+            if(!voltage_regulator_on_[station_id]) return false;
+            return true;
         }
+        // write the converged reactive output (MVAr) of a station that took part in a
+        // VoltageControl group, supplied by the extension (LSGrid::compute_results)
+        void set_voltage_control_q(int station_id, real_type q_mvar) {res_q_(station_id) = q_mvar;}
 
         /**
          * Set the (derived) station active power, generator convention.

--- a/src/core/element_container/ConverterStationContainer.hpp
+++ b/src/core/element_container/ConverterStationContainer.hpp
@@ -127,6 +127,21 @@ class LS2G_API ConverterStationContainer final : public OneSideContainer_PQ, pub
         real_type get_qmax(int station_id) const {return max_q_.coeff(station_id);}
         real_type get_target_p(int station_id) const {return target_p_mw_(station_id);}
         real_type get_target_vm_pu(int station_id) const {return target_vm_pu_(station_id);}
+        // true iff an ACTIVE voltage-regulating station of this container sits on
+        // `bus` and therefore pins its magnitude -- exactly the gating `fillpv`
+        // below uses. Read by LSGrid::fillpv_pq: a converter station is NOT a
+        // VoltageControl controller (only GEN / SVC are), so a bus it pins cannot
+        // be handed over to a control group, and the configuration has to be
+        // rejected rather than silently stripped of the station's regulation.
+        bool pins_bus_voltage(GlobalBusId bus) const {
+            const int nb_station = nb();
+            for(int station_id = 0; station_id < nb_station; ++station_id){
+                if(!status_[station_id]) continue;
+                if(!voltage_regulator_on_[station_id]) continue;
+                if(bus_id_(station_id).cast_int() == bus.cast_int()) return true;
+            }
+            return false;
+        }
 
         /**
          * Set the (derived) station active power, generator convention.

--- a/src/core/element_container/HvdcLineContainer.hpp
+++ b/src/core/element_container/HvdcLineContainer.hpp
@@ -355,6 +355,11 @@ class LS2G_API HvdcLineContainer final : public TwoSidesContainer<ConverterStati
             side_2_.fillpv(bus_pv, has_bus_been_added, slack_bus_id_solver, id_grid_to_solver);
         }
 
+        // see ConverterStationContainer::pins_bus_voltage
+        bool pins_bus_voltage(GlobalBusId bus) const {
+            return side_1_.pins_bus_voltage(bus) || side_2_.pins_bus_voltage(bus);
+        }
+
         void fillBp_Bpp(std::vector<Eigen::Triplet<real_type> > & /*Bp*/,
                         std::vector<Eigen::Triplet<real_type> > & /*Bpp*/,
                         const SolverBusIdVect & /*id_grid_to_solver*/,

--- a/src/core/element_container/HvdcLineContainer.hpp
+++ b/src/core/element_container/HvdcLineContainer.hpp
@@ -355,9 +355,31 @@ class LS2G_API HvdcLineContainer final : public TwoSidesContainer<ConverterStati
             side_2_.fillpv(bus_pv, has_bus_been_added, slack_bus_id_solver, id_grid_to_solver);
         }
 
-        // see ConverterStationContainer::pins_bus_voltage
-        bool pins_bus_voltage(GlobalBusId bus) const {
-            return side_1_.pins_bus_voltage(bus) || side_2_.pins_bus_voltage(bus);
+        // ---- voltage-regulating converter stations as VoltageControl controllers ----
+        // A VSC station with voltage_regulator_on pins its own bus through the PV
+        // path, exactly like a local generator. When a control group regulates that
+        // bus instead, the station joins the group; its sharing key is a reactive
+        // range in MVAr, the same currency as a generator's, so a mixed
+        // generator/station group shares reactive power correctly.
+        // `side` is 1 or 2 (see VoltageControlSolverData::HVDC_SIDE_1 / _SIDE_2).
+        bool station_is_voltage_controller(int hvdc_id, int side) const {
+            return side == 1 ? side_1_.is_voltage_controller(hvdc_id)
+                             : side_2_.is_voltage_controller(hvdc_id);
+        }
+        GlobalBusId get_station_bus(int hvdc_id, int side) const {
+            return side == 1 ? get_bus_side_1(hvdc_id) : get_bus_side_2(hvdc_id);
+        }
+        real_type get_station_target_vm_pu(int hvdc_id, int side) const {
+            return side == 1 ? side_1_.get_target_vm_pu(hvdc_id)
+                             : side_2_.get_target_vm_pu(hvdc_id);
+        }
+        real_type get_station_q_range_mvar(int hvdc_id, int side) const {
+            return side == 1 ? side_1_.get_qmax(hvdc_id) - side_1_.get_qmin(hvdc_id)
+                             : side_2_.get_qmax(hvdc_id) - side_2_.get_qmin(hvdc_id);
+        }
+        void set_station_voltage_control_q(int hvdc_id, int side, real_type q_mvar) {
+            if(side == 1) side_1_.set_voltage_control_q(hvdc_id, q_mvar);
+            else          side_2_.set_voltage_control_q(hvdc_id, q_mvar);
         }
 
         void fillBp_Bpp(std::vector<Eigen::Triplet<real_type> > & /*Bp*/,

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -72,6 +72,7 @@ add_executable(lightsim2grid_unit_tests
     test_check_grid.cpp
     test_state_poisoning.cpp
     test_powerflow_algorithm.cpp
+    test_voltage_control_reclassify.cpp
 )
 target_link_libraries(lightsim2grid_unit_tests PRIVATE lightsim2grid_core Catch2::Catch2WithMain)
 

--- a/src/tests/test_voltage_control_reclassify.cpp
+++ b/src/tests/test_voltage_control_reclassify.cpp
@@ -1,0 +1,304 @@
+// Copyright (c) 2026, RTE (https://www.rte-france.com)
+// See AUTHORS.txt
+// This Source Code Form is subject to the terms of the Mozilla Public License, version 2.0.
+// If a copy of the Mozilla Public License, version 2.0 was not distributed with this file,
+// you can obtain one at http://mozilla.org/MPL/2.0/.
+// SPDX-License-Identifier: MPL-2.0
+// This file is part of LightSim2grid, LightSim2grid implements a c++ backend targeting the Grid2Op platform.
+
+// Which mechanism sets a bus' voltage magnitude: the classical PV treatment, or a
+// bordered VoltageControl group?
+//
+// The rule (LSGrid::get_group_controlled_buses, applied in LSGrid::fillpv_pq): a bus
+// keeps the PV treatment as long as the only things regulating it are generators
+// sitting ON it. As soon as an ACTIVE REMOTE regulator -- or any voltage-mode SVC,
+// which is always a group controller -- aims at the bus, the bus keeps its own Vm
+// unknown and every regulator of it, local ones included, becomes a member of the
+// group.
+//
+// The bug this pins: fillpv only knew how to keep a controller's OWN bus out of PV.
+// A local regulator standing on somebody else's regulated bus still claimed it as
+// PV, which left the group's voltage row with no Vm column to write into -- a
+// structurally empty row, hence a singular Jacobian -- so the configuration had to
+// be refused outright even though it is well posed (the local machine belongs in the
+// group, and the sharing row then fixes the reactive split).
+
+#include <cmath>
+#include <set>
+#include <string>
+#include <vector>
+
+#include <catch2/catch_approx.hpp>
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_string.hpp>
+
+#include "LSGrid.hpp"
+
+using Catch::Approx;
+using ls2g::AlgorithmType;
+using ls2g::CplxVect;
+using ls2g::IntVect;
+using ls2g::LSGrid;
+using ls2g::RealVect;
+using ls2g::cplx_type;
+using ls2g::real_type;
+
+namespace {
+
+const real_type V_SET = 1.03;
+const real_type LOAD_P = 50.;
+const real_type LOAD_Q = 10.;
+const int NB_BUS = 4;
+
+// 4-bus radial feeder 0-1-2-3, 50 MW / 10 MVAr at bus 3, sn_mva = 100
+LSGrid make_skeleton()
+{
+    LSGrid grid;
+    grid.set_sn_mva(100.);
+    grid.set_init_vm_pu(1.0);
+    const RealVect vn = RealVect::Constant(NB_BUS, 138.);
+    grid.init_bus(static_cast<unsigned int>(NB_BUS), 1, vn, 0, 0);
+    const RealVect r = RealVect::Constant(NB_BUS - 1, 0.01);
+    const RealVect x = RealVect::Constant(NB_BUS - 1, 0.1);
+    const CplxVect h = CplxVect::Zero(NB_BUS - 1);
+    Eigen::VectorXi f(NB_BUS - 1), t(NB_BUS - 1);
+    for (int i = 0; i < NB_BUS - 1; ++i) { f(i) = i; t(i) = i + 1; }
+    grid.init_powerlines(r, x, h, f, t);
+    RealVect lp(1), lq(1); lp << LOAD_P; lq << LOAD_Q;
+    Eigen::VectorXi lb(1); lb << NB_BUS - 1;
+    grid.init_loads(lp, lq, lb);
+    return grid;
+}
+
+void add_gens(LSGrid & grid,
+              const std::vector<int> & buses,
+              const std::vector<real_type> & v_pu,
+              const std::vector<real_type> & q_range_mvar,
+              const std::vector<bool> & vreg_on = std::vector<bool>())
+{
+    const int nb = static_cast<int>(buses.size());
+    RealVect p(nb), v(nb), q(nb), qmin(nb), qmax(nb);
+    Eigen::VectorXi b(nb);
+    for (int i = 0; i < nb; ++i) {
+        p(i) = 0.; v(i) = v_pu[i]; q(i) = 0.;
+        qmin(i) = -0.5 * q_range_mvar[i];
+        qmax(i) =  0.5 * q_range_mvar[i];
+        b(i) = buses[i];
+    }
+    if (vreg_on.empty()) grid.init_generators(p, v, qmin, qmax, b);
+    else                 grid.init_generators_full(p, v, q, vreg_on, qmin, qmax, b);
+}
+
+void add_voltage_svc(LSGrid & grid, int svc_bus, int reg_bus,
+                     real_type target_vm_pu, real_type slope_pu)
+{
+    RealVect tv(1), qs(1), sl(1), bmin(1), bmax(1);
+    tv << target_vm_pu; qs << 0.; sl << slope_pu; bmin << -100.; bmax << 100.;
+    Eigen::VectorXi reg(1), bus(1);
+    reg << reg_bus; bus << svc_bus;
+    grid.init_svcs({1}, tv, qs, sl, bmin, bmax, reg, bus);   // RegulationMode::VOLTAGE
+}
+
+CplxVect flat(const LSGrid & g)
+{
+    return CplxVect::Constant(static_cast<Eigen::Index>(g.total_bus()), cplx_type(1., 0.));
+}
+
+CplxVect solve(LSGrid & g)
+{
+    g.change_algorithm(AlgorithmType::NR_SparseLU);
+    return g.ac_pf(flat(g), 30, 1e-10);
+}
+
+// per-controller reactive output (pu), keyed by generator id
+real_type gen_ctrl_q(const LSGrid & g, int gen_id)
+{
+    const RealVect q = g.get_algo().get_controller_q();
+    const IntVect kind = g.get_algo().get_controller_kind();
+    const IntVect elem = g.get_algo().get_controller_elem_id();
+    for (int c = 0; c < q.size(); ++c)
+        if (kind(c) == ls2g::VoltageControlSolverData::GEN && elem(c) == gen_id) return q(c);
+    return std::nan("");
+}
+
+}  // namespace
+
+
+TEST_CASE("a locally regulated bus stays PV unless a group claims it", "[reclassify]")
+{
+    // the classification rule itself, on grid ids, before any solve
+    SECTION("one local generator: PV, no group") {
+        LSGrid g = make_skeleton();
+        add_gens(g, {0, 1}, {1.02, V_SET}, {2000., 2000.});
+        g.add_gen_slackbus(0, 1.);
+        CHECK(g.get_group_controlled_buses().empty());
+    }
+    SECTION("SEVERAL local generators on one bus: still PV, still no group") {
+        // the common case that must not change: two machines on bus 1, both
+        // regulating it locally, share Q through the per-bus redistribution
+        LSGrid g = make_skeleton();
+        add_gens(g, {0, 1, 1}, {1.02, V_SET, V_SET}, {2000., 2000., 500.});
+        g.add_gen_slackbus(0, 1.);
+        CHECK(g.get_group_controlled_buses().empty());
+    }
+    SECTION("a remote regulator claims its target") {
+        LSGrid g = make_skeleton();
+        add_gens(g, {0, 1}, {1.02, V_SET}, {2000., 2000.});
+        g.add_gen_slackbus(0, 1.);
+        g.set_gen_regulated_bus(1, 3);
+        const std::set<int> grp = g.get_group_controlled_buses();
+        REQUIRE(grp.size() == 1);
+        CHECK(*grp.begin() == 3);
+    }
+    SECTION("a voltage-mode SVC always claims its target") {
+        LSGrid g = make_skeleton();
+        add_gens(g, {0}, {1.02}, {2000.});
+        g.add_gen_slackbus(0, 1.);
+        add_voltage_svc(g, 2, 3, V_SET, 0.);
+        const std::set<int> grp = g.get_group_controlled_buses();
+        REQUIRE(grp.size() == 1);
+        CHECK(*grp.begin() == 3);
+    }
+}
+
+TEST_CASE("several local generators on one bus keep the classical PV treatment", "[reclassify]")
+{
+    // regression guard for the rule above: this is the ordinary configuration, it
+    // must solve exactly as it did before any reclassification existed
+    LSGrid g = make_skeleton();
+    add_gens(g, {0, 1, 1}, {1.02, V_SET, V_SET}, {2000., 2000., 500.});
+    g.add_gen_slackbus(0, 1.);
+    g.tell_solver_need_reset();
+    const CplxVect V = solve(g);
+    REQUIRE(V.size() == NB_BUS);
+    CHECK(std::abs(V(1)) == Approx(V_SET).epsilon(1e-8));
+    // no VoltageControl group was built: the PV path handled it
+    CHECK(g.get_algo().get_controller_q().size() == 0);
+}
+
+TEST_CASE("a remote regulator may target a locally regulated bus", "[reclassify]")
+{
+    // THE BUG. gen 2 sits on bus 2 and regulates it locally; gen 1 (bus 1) aims at
+    // bus 2 remotely with the same setpoint. Before the reclassification bus 2 was
+    // taken as PV and the whole grid was refused.
+    LSGrid g = make_skeleton();
+    add_gens(g, {0, 1, 2}, {1.02, V_SET, V_SET}, {2000., 2000., 500.});
+    g.add_gen_slackbus(0, 1.);
+    g.set_gen_regulated_bus(1, 2);
+    g.tell_solver_need_reset();
+
+    const CplxVect V = solve(g);
+    REQUIRE(V.size() == NB_BUS);
+    CHECK(std::abs(V(2)) == Approx(V_SET).epsilon(1e-8));
+
+    // both machines are group members, and the sharing row split their reactive
+    // output proportionally to (qmax - qmin): 2000 MVAr against 500 MVAr
+    const real_type q_remote = gen_ctrl_q(g, 1);
+    const real_type q_local  = gen_ctrl_q(g, 2);
+    REQUIRE(std::isfinite(q_remote));
+    REQUIRE(std::isfinite(q_local));
+    REQUIRE(std::abs(q_remote) > 1e-6);
+    CHECK(q_remote / 2000. == Approx(q_local / 500.).epsilon(1e-8));
+}
+
+TEST_CASE("a remote regulator disagreeing with the local one is rejected on setpoints", "[reclassify]")
+{
+    // same shape, conflicting setpoints: now that both are in one group this is
+    // caught by the group's own setpoint check, which names the real problem
+    // instead of complaining about the bus classification
+    LSGrid g = make_skeleton();
+    add_gens(g, {0, 1, 2}, {1.02, V_SET + 0.02, V_SET}, {2000., 2000., 500.});
+    g.add_gen_slackbus(0, 1.);
+    g.set_gen_regulated_bus(1, 2);
+    g.tell_solver_need_reset();
+
+    REQUIRE_THROWS_WITH(solve(g), Catch::Matchers::ContainsSubstring("conflicting voltage setpoints"));
+}
+
+TEST_CASE("a remote regulator may target a locally pinned slack bus", "[reclassify]")
+{
+    // the slack's own generator pins it, so before the reclassification the slack
+    // had no Vm unknown and a remote controller aiming at it was refused. Now the
+    // slack generator joins the group and MultiSlack grants the free Vm.
+    LSGrid g = make_skeleton();
+    add_gens(g, {0, 1}, {V_SET, V_SET}, {2000., 500.});
+    g.add_gen_slackbus(0, 1.);
+    g.set_gen_regulated_bus(1, 0);   // -> the slack bus
+    g.tell_solver_need_reset();
+
+    const CplxVect V = solve(g);
+    REQUIRE(V.size() == NB_BUS);
+    CHECK(std::abs(V(0)) == Approx(V_SET).epsilon(1e-8));
+    const real_type q_remote = gen_ctrl_q(g, 1);
+    const real_type q_slack  = gen_ctrl_q(g, 0);
+    REQUIRE(std::isfinite(q_remote));
+    REQUIRE(std::isfinite(q_slack));
+    CHECK(q_remote / 500. == Approx(q_slack / 2000.).epsilon(1e-8));
+}
+
+TEST_CASE("a remote regulator may target an unpinned slack bus", "[reclassify]")
+{
+    // the slack generator has voltage_regulator_on == false, so nothing pins the
+    // slack: MultiSlack gives it a free Vm + Q equation and the remote controller
+    // can hold it. Previously refused because a slack bus is never in `bus_pq_`,
+    // the regulated-bus check having no `has_free_q` escape hatch.
+    LSGrid g = make_skeleton();
+    add_gens(g, {0, 1}, {1.02, V_SET}, {2000., 2000.}, {false, true});
+    g.add_gen_slackbus(0, 1.);
+    g.set_gen_regulated_bus(1, 0);
+    g.tell_solver_need_reset();
+
+    const CplxVect V = solve(g);
+    REQUIRE(V.size() == NB_BUS);
+    CHECK(std::abs(V(0)) == Approx(V_SET).epsilon(1e-8));
+}
+
+TEST_CASE("a remote regulator on a bus pinned by another machine is still rejected", "[reclassify]")
+{
+    // The configuration that genuinely has NO solution, and must stay refused: gen 2
+    // sits on bus 1 and pins it locally; gen 1, ALSO on bus 1, aims remotely at bus
+    // 3. Whatever reactive gen 1 injects at bus 1 is absorbed one-for-one by gen 2
+    // holding Vm(bus 1) with free Q, so gen 1 has no influence whatsoever on bus 3.
+    // Nothing about bus classification can fix that.
+    LSGrid g = make_skeleton();
+    add_gens(g, {0, 1, 1}, {1.02, V_SET, V_SET}, {2000., 2000., 500.});
+    g.add_gen_slackbus(0, 1.);
+    g.set_gen_regulated_bus(1, 3);
+    g.tell_solver_need_reset();
+
+    REQUIRE_THROWS_WITH(solve(g),
+                        Catch::Matchers::ContainsSubstring("OWN bus has no reactive (Q) equation"));
+}
+
+TEST_CASE("an SVC-regulated bus is taken off the PV path too", "[reclassify][svc]")
+{
+    // An SVC is always a group controller, so its regulated bus must leave the PV
+    // path even when a local generator sits on it. Sharing an SVC with another
+    // controller is a separate v1 restriction (the sharing key of an SVC is a
+    // susceptance range, not a reactive range), so the outcome is still a refusal --
+    // but now it is the SVC-sharing restriction that says so, not a bus-class error.
+    LSGrid g = make_skeleton();
+    add_gens(g, {0, 2}, {1.02, V_SET}, {2000., 500.});
+    g.add_gen_slackbus(0, 1.);
+    add_voltage_svc(g, 1, 2, V_SET, 0.);   // SVC at bus 1 regulating bus 2
+    g.tell_solver_need_reset();
+
+    CHECK(g.get_group_controlled_buses().count(2) == 1);
+    REQUIRE_THROWS_WITH(solve(g),
+                        Catch::Matchers::ContainsSubstring("shares a regulated bus with other controllers"));
+}
+
+TEST_CASE("an SVC alone on a locally-free bus still works", "[reclassify][svc]")
+{
+    // the control: no generator on the regulated bus, so the SVC is alone in its
+    // group and the reclassification changes nothing
+    LSGrid g = make_skeleton();
+    add_gens(g, {0}, {1.02}, {2000.});
+    g.add_gen_slackbus(0, 1.);
+    add_voltage_svc(g, 2, 3, V_SET, 0.);
+    g.tell_solver_need_reset();
+
+    const CplxVect V = solve(g);
+    REQUIRE(V.size() == NB_BUS);
+    CHECK(std::abs(V(3)) == Approx(V_SET).epsilon(1e-8));
+}

--- a/src/tests/test_voltage_control_reclassify.cpp
+++ b/src/tests/test_voltage_control_reclassify.cpp
@@ -10,11 +10,13 @@
 // bordered VoltageControl group?
 //
 // The rule (LSGrid::get_group_controlled_buses, applied in LSGrid::fillpv_pq): a bus
-// keeps the PV treatment as long as the only things regulating it are generators
-// sitting ON it. As soon as an ACTIVE REMOTE regulator -- or any voltage-mode SVC,
-// which is always a group controller -- aims at the bus, the bus keeps its own Vm
-// unknown and every regulator of it, local ones included, becomes a member of the
-// group.
+// keeps the PV treatment as long as the only things regulating it stand ON it --
+// generators, or voltage-regulating hvdc converter stations. As soon as an ACTIVE
+// REMOTE regulator -- or any voltage-mode SVC, which is always a group controller --
+// aims at the bus, the bus keeps its own Vm unknown and every regulator of it, the
+// local ones included, becomes a member of the group. Generators and converter
+// stations share on the same key (a reactive range in MVAr); an SVC's key is a
+// susceptance range, which is why an SVC must still be alone in its group.
 //
 // The bug this pins: fillpv only knew how to keep a controller's OWN bus out of PV.
 // A local regulator standing on somebody else's regulated bus still claimed it as
@@ -99,6 +101,36 @@ void add_voltage_svc(LSGrid & grid, int svc_bus, int reg_bus,
     grid.init_svcs({1}, tv, qs, sl, bmin, bmax, reg, bus);   // RegulationMode::VOLTAGE
 }
 
+// One VSC-VSC hvdc line between `bus_1` and `bus_2`, fixed active setpoint (no
+// droop). `vreg_1` / `vreg_2` say whether each station regulates the magnitude of
+// its own bus, at `target_vm_pu`, with +/- q_range/2 MVAr of reactive capability.
+void add_vreg_hvdc(LSGrid & grid, int bus_1, int bus_2,
+                   bool vreg_1, bool vreg_2,
+                   real_type target_vm_pu, real_type q_range_mvar,
+                   real_type p_setpoint_mw = 0.)
+{
+    Eigen::VectorXi b1(1), b2(1);
+    b1 << bus_1;
+    b2 << bus_2;
+    const std::vector<int> type1{0}, type2{0}, mode{0};   // VSC / VSC, side 1 rectifier
+    const std::vector<bool> vr1{vreg_1}, vr2{vreg_2}, droop_off{false};
+    const RealVect zero = RealVect::Zero(1);
+    RealVect vm1(1), vm2(1), qmin(1), qmax(1), pf1(1), pf2(1), pset(1), pmax(1);
+    vm1 << target_vm_pu;
+    vm2 << target_vm_pu;
+    qmin << -0.5 * q_range_mvar;
+    qmax << 0.5 * q_range_mvar;
+    pf1 << 1.;
+    pf2 << 1.;
+    pset << p_setpoint_mw;
+    pmax << 300.;
+    grid.init_hvdc_lines(b1, b2, type1, type2, zero, zero,
+                         vr1, vr2, vm1, vm2, zero, zero,
+                         qmin, qmax, qmin, qmax, pf1, pf2, mode, pset,
+                         zero, zero, droop_off, zero, zero, pmax, pmax);
+    grid.tell_solver_need_reset();
+}
+
 CplxVect flat(const LSGrid & g)
 {
     return CplxVect::Constant(static_cast<Eigen::Index>(g.total_bus()), cplx_type(1., 0.));
@@ -118,6 +150,17 @@ real_type gen_ctrl_q(const LSGrid & g, int gen_id)
     const IntVect elem = g.get_algo().get_controller_elem_id();
     for (int c = 0; c < q.size(); ++c)
         if (kind(c) == ls2g::VoltageControlSolverData::GEN && elem(c) == gen_id) return q(c);
+    return std::nan("");
+}
+
+// reactive output (pu) of the controller of the given kind and element id
+real_type ctrl_q_of(const LSGrid & g, int want_kind, int want_elem)
+{
+    const RealVect q = g.get_algo().get_controller_q();
+    const IntVect kind = g.get_algo().get_controller_kind();
+    const IntVect elem = g.get_algo().get_controller_elem_id();
+    for (int c = 0; c < q.size(); ++c)
+        if (kind(c) == want_kind && elem(c) == want_elem) return q(c);
     return std::nan("");
 }
 
@@ -301,4 +344,101 @@ TEST_CASE("an SVC alone on a locally-free bus still works", "[reclassify][svc]")
     const CplxVect V = solve(g);
     REQUIRE(V.size() == NB_BUS);
     CHECK(std::abs(V(3)) == Approx(V_SET).epsilon(1e-8));
+}
+
+TEST_CASE("a voltage-regulating hvdc station keeps the PV path when nothing else claims its bus",
+          "[reclassify][hvdc]")
+{
+    // the control: an hvdc station regulating its own bus, with no group anywhere.
+    // It pins the bus exactly as before -- no controller is built for it.
+    LSGrid g = make_skeleton();
+    add_gens(g, {0}, {1.02}, {2000.});
+    g.add_gen_slackbus(0, 1.);
+    add_vreg_hvdc(g, /*bus_1=*/1, /*bus_2=*/3, /*vreg_1=*/true, /*vreg_2=*/false,
+                  V_SET, /*q_range_mvar=*/600.);
+
+    CHECK(g.get_group_controlled_buses().empty());
+    const CplxVect V = solve(g);
+    REQUIRE(V.size() == NB_BUS);
+    CHECK(std::abs(V(1)) == Approx(V_SET).epsilon(1e-8));
+    CHECK(g.get_algo().get_controller_q().size() == 0);  // PV path, no group
+}
+
+TEST_CASE("a voltage-regulating hvdc station joins the group that claims its bus",
+          "[reclassify][hvdc]")
+{
+    // hvdc side 1 sits on bus 1 and regulates it; gen 1 (bus 2) aims at bus 1
+    // remotely with the same setpoint. Bus 1 leaves the PV path, and the station is
+    // enrolled alongside the generator instead of having its regulation dropped.
+    LSGrid g = make_skeleton();
+    add_gens(g, {0, 2}, {1.02, V_SET}, {2000., 500.});
+    g.add_gen_slackbus(0, 1.);
+    g.set_gen_regulated_bus(1, 1);          // gen 1 -> bus 1, where the station is
+    add_vreg_hvdc(g, 1, 3, true, false, V_SET, /*q_range_mvar=*/2000.);
+
+    CHECK(g.get_group_controlled_buses().count(1) == 1);
+    const CplxVect V = solve(g);
+    REQUIRE(V.size() == NB_BUS);
+    CHECK(std::abs(V(1)) == Approx(V_SET).epsilon(1e-8));
+
+    // two controllers in the group: the generator and the side-1 station, sharing
+    // reactive power in proportion to their MVAr ranges (500 against 2000)
+    REQUIRE(g.get_algo().get_controller_q().size() == 2);
+    const real_type q_gen = ctrl_q_of(g, ls2g::VoltageControlSolverData::GEN, 1);
+    const real_type q_sta = ctrl_q_of(g, ls2g::VoltageControlSolverData::HVDC_SIDE_1, 0);
+    REQUIRE(std::isfinite(q_gen));
+    REQUIRE(std::isfinite(q_sta));
+    REQUIRE(std::abs(q_gen) > 1e-6);
+    CHECK(q_gen / 500. == Approx(q_sta / 2000.).epsilon(1e-8));
+
+    // and the write-back reached the station's own result, in MVAr
+    const real_type res_q_mvar = g.get_dclines()[0].station_side_1.res_q_mvar;
+    CHECK(res_q_mvar == Approx(q_sta * 100.).epsilon(1e-8));   // sn_mva == 100
+}
+
+TEST_CASE("the far hvdc station may be the one in the group", "[reclassify][hvdc]")
+{
+    // same, on side 2, so the HVDC_SIDE_2 kind and its write-back are exercised too
+    LSGrid g = make_skeleton();
+    add_gens(g, {0, 1}, {1.02, V_SET}, {2000., 500.});
+    g.add_gen_slackbus(0, 1.);
+    g.set_gen_regulated_bus(1, 2);          // gen 1 -> bus 2, the side-2 station bus
+    add_vreg_hvdc(g, 1, 2, false, true, V_SET, /*q_range_mvar=*/2000.);
+
+    CHECK(g.get_group_controlled_buses().count(2) == 1);
+    const CplxVect V = solve(g);
+    REQUIRE(V.size() == NB_BUS);
+    CHECK(std::abs(V(2)) == Approx(V_SET).epsilon(1e-8));
+
+    REQUIRE(g.get_algo().get_controller_q().size() == 2);
+    const real_type q_sta = ctrl_q_of(g, ls2g::VoltageControlSolverData::HVDC_SIDE_2, 0);
+    REQUIRE(std::isfinite(q_sta));
+    CHECK(g.get_dclines()[0].station_side_2.res_q_mvar == Approx(q_sta * 100.).epsilon(1e-8));
+}
+
+TEST_CASE("a generator, an hvdc station and one regulated bus share it three ways",
+          "[reclassify][hvdc]")
+{
+    // a local generator AND an hvdc station on bus 1, plus a remote generator aiming
+    // at bus 1: one group of three, all keyed on MVAr ranges
+    LSGrid g = make_skeleton();
+    add_gens(g, {0, 1, 2}, {1.02, V_SET, V_SET}, {2000., 1000., 500.});
+    g.add_gen_slackbus(0, 1.);
+    g.set_gen_regulated_bus(2, 1);          // gen 2 (bus 2) -> bus 1
+    add_vreg_hvdc(g, 1, 3, true, false, V_SET, /*q_range_mvar=*/2000.);
+
+    const CplxVect V = solve(g);
+    REQUIRE(V.size() == NB_BUS);
+    CHECK(std::abs(V(1)) == Approx(V_SET).epsilon(1e-8));
+
+    REQUIRE(g.get_algo().get_controller_q().size() == 3);
+    const real_type q_local  = ctrl_q_of(g, ls2g::VoltageControlSolverData::GEN, 1);
+    const real_type q_remote = ctrl_q_of(g, ls2g::VoltageControlSolverData::GEN, 2);
+    const real_type q_sta    = ctrl_q_of(g, ls2g::VoltageControlSolverData::HVDC_SIDE_1, 0);
+    REQUIRE(std::isfinite(q_local));
+    REQUIRE(std::isfinite(q_remote));
+    REQUIRE(std::isfinite(q_sta));
+    REQUIRE(std::abs(q_remote) > 1e-6);
+    CHECK(q_local / 1000. == Approx(q_remote / 500.).epsilon(1e-8));
+    CHECK(q_sta / 2000.   == Approx(q_remote / 500.).epsilon(1e-8));
 }


### PR DESCRIPTION
## The bug

A generator could not remotely regulate a bus that another generator already regulated **locally**. The grid was refused outright:

```
LSGrid::fill_voltage_control_solver_data: generator N regulates bus X
which has no voltage (Vm) unknown (it is a slack or an already-PV bus).
```

…even though the configuration is perfectly well posed. Two machines holding one bus simply form a control group: one bordered voltage row, one reactive unknown each, and a sharing row splitting the reactive duty by `qmax - qmin` — exactly what two *remote* controllers on one bus already did.

## Root cause: the order of bus classification

`GeneratorContainer::fillpv` implements only half the rule. It knows how to keep a controller's **own** bus out of PV (a remote regulator leaves its own bus PQ, `GeneratorContainer.cpp:279`), but nothing stopped a **local** regulator from claiming a bus somebody else regulated remotely.

That bus then had no `Vm` unknown, so `VoltageControl::register_in` got `vm_col == -1`, `declare_feature_entries` never declared `h_vm_[g]`, and for a GEN controller (no slope entry) the group's voltage row came out **structurally empty** — a singular Jacobian. Verified directly: relaxing the check *without* fixing the classification gives `ErrorType::SolverFactor`, not divergence. The check that refused the grid was reporting the misclassification, not a property of the configuration.

## The fix

Classification now runs the other way round:

- `LSGrid::get_group_controlled_buses()` collects every bus an active **remote** generator or an active voltage-mode SVC aims at. Works in grid ids and reads only input data, so it is valid while `fillpv_pq` is still building the solver labelling.
- `LSGrid::fillpv_pq` keeps those buses out of PV; the PQ loop picks them up.
- `fill_voltage_control_solver_data` enrols the local regulators standing on them as group members.
- `get_free_vm_slack_solver_buses` follows the same rule, so a local regulator on a group-controlled slack no longer counts as pinning it.

**The safety constraint worth reviewing closely:** buses regulated *only* by things standing on them are deliberately excluded. Several machines on one bus all regulating it locally is the common configuration, handled by the per-bus reactive redistribution in `GeneratorContainer::set_q`, and sweeping it into the bordered formulation would have been a large unintended behaviour change. The trigger is specifically the arrival of a *remote* controller (or an SVC, which is always a group controller). There are regression tests pinning that the multi-local-generator case still takes the PV path, builds no group, and gives bit-identical voltages.

## Second commit: HVDC converter stations

A VSC station with `voltage_regulator_on` pins its bus through the very same `fillpv` path, so it belongs in the group machinery on the same footing. The first commit could not express that (the group only knew `GEN` and `SVC`) and had to refuse such grids from `fillpv_pq` to avoid silently discarding the station's regulation. That exception is gone:

- `VoltageControlSolverData::Kind` gains `HVDC_SIDE_1` / `HVDC_SIDE_2`, carrying the hvdc **line** id in `elem_id` and the side in the kind.
- `fill_voltage_control_solver_data` enrols an active voltage-regulating station whose bus is group-controlled.
- `compute_results` writes the solved reactive output back to the station; the write-back switch now *rejects* an unknown kind rather than falling through to the SVC branch.

This composes cleanly because a station's sharing key is a reactive range in **MVAr**, the same currency as a generator's — so mixed groups are well defined. A group of a local generator, a remote generator and a station splits `Q` three ways by range (tested).

## Now working

- a remote controller onto a locally regulated bus;
- a remote controller onto a slack bus pinned by its own generator (the slack generator joins the group, MultiSlack grants the free `Vm`);
- a remote controller onto a slack bus that nothing pins — separately, by giving the regulated-bus check the `has_free_q` escape hatch the controller-bus check already had;
- an HVDC station sharing a regulated bus with generators, on either end of the line.

Disagreeing setpoints between a local and a remote regulator of one bus now surface as `conflicting voltage setpoints` rather than a bus-classification error.

## Still refused, on purpose

- **A remote regulator sharing its own bus with a local regulator.** This genuinely has no solution: whatever reactive power it injects at that bus is absorbed one-for-one by the machine holding the magnitude with free `Q`, so it has zero influence on its remote target. No reclassification can help; the "its OWN bus has no reactive (Q) equation" error still fires.
- **A voltage-mode SVC sharing a group.** Its key is a *susceptance* range, not a reactive range, and `NRSystem.hpp:591` records that the Phase 0 probes deliberately did not pin OLF's behaviour for mixed sharing. So for SVCs this PR delivers uniform classification and a better error, not new capability — worth stating plainly.

## Not covered

A converter station regulating a **remote** bus. Stations have no regulated-bus field at all today, so that would mean a new container member plus changes to `init_hvdc_lines`, the binary state, and the python bindings — a public API extension rather than a fix, so it is left out. Generators remain the only element that can target a remote bus.

## Tests

`src/tests/test_voltage_control_reclassify.cpp` (13 cases) and `lightsim2grid/tests/test_voltage_control_reclassify.py` (7 cases): the classification rule itself, each newly-supported configuration including the reactive split, the ones that must stay refused, and the regression guards for the ordinary PV path.

With the reclassification neutralised, 5 of 9 original cases fail and the 4 that pass are exactly the ones that should (multi-local-gen, the no-solution rejection, the SVC control, and the independent unpinned-slack relaxation). With station enrolment neutralised, the 3 station cases fail — on the *controller-count* assertion, i.e. the station gets silently dropped, which is the failure mode being guarded.

## Verification

Full C++ suite green (4850 assertions / 161 cases) in Release, under `__DEBUG_ASSERTS=1`, and pinned to C++14. Python: `test_hvdc_batch`, `test_voltage_control_{reclassify,remote_gen,svc}`, `test_multi_slack`, `test_ACPF`, `test_DCPF`, `test_SecurityAnlysis_cpp`, `test_LSGrid_out_of_bounds` all green.

Independent of #176: disjoint code, either merge order works.

---
_Generated by [Claude Code](https://claude.ai/code/session_015FU3fCG8p2dj3h6rRkTeyH)_