### PR TITLE
Take the whole injection from the grid in TimeSeries, not a subset

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -123,6 +123,32 @@ TODO: Levenberg-Marquardt damping (a.k.a. Tikhonov-regularized Newton) : adding 
 
 [1.0.0] 2026-xx-yy
 --------------------
+- [FIXED] ``TimeSeriesCPP`` solved each step against an **incomplete injection vector**. It does not
+  use the ``Sbus`` the gridmodel builds: it rebuilds its own, per step, out of the four matrices the
+  caller passes to ``compute_Vs`` -- generator and static-generator ACTIVE power, and load active +
+  reactive power -- plus the hvdc term taken from the grid. But ``LSGrid::fillSbus_me`` stamps rather
+  more than that, and everything else was silently dropped:
+  storage units (active AND reactive: absent altogether), REACTIVE_POWER-mode SVCs (absent
+  altogether), the reactive setpoint of a generator whose ``voltage_regulator_on`` is false, a static
+  generator's reactive setpoint, and -- in DC -- the phase-shifter term
+  ``TrafoContainer::hack_Sbus_for_dc_phase_shifter``. The powerflow converged happily on an injection
+  the caller never asked for; on a 4-bus feeder the individual omissions were worth 0.032, 0.052,
+  0.066 and 0.081 pu of voltage error respectively. DC was affected too, since
+  ``compute_one_powerflow`` falls back to the gridmodel's ``Pbus_`` only when NO complex ``Sbus`` is
+  supplied, which is not the ``TimeSeries`` case.
+  The remainder is now **derived rather than enumerated**: the complete per-unit injection the
+  gridmodel just built (``Sbus_`` in ac, ``Pbus_`` in dc) minus the same reconstruction ``compute_Vs``
+  performs, evaluated at the gridmodel's own target values. What is left over is by construction
+  everything the per-step matrices do not carry, so an element type added to ``fillSbus_me`` later is
+  picked up for free -- an enumeration falling behind is precisely what caused this bug.
+  ``ContingencyAnalysisCPP`` (and ``SecurityAnalysis``, which wraps it) was never affected: it passes
+  the gridmodel's own complete ``Sbus_`` straight to the solver.
+- [ADDED] ``src/tests/test_timeseries_sbus.cpp`` and ``lightsim2grid/tests/test_timeseries_sbus.py``:
+  a one-step time series fed the grid's OWN injections must reproduce ``ac_pf`` / ``dc_pf`` exactly.
+  Covers each dropped element kind separately and all of them together, in ac and in dc, plus a
+  multi-step case (the remainder is constant, so it has to reach every row) and a control grid whose
+  whole injection the per-step matrices already covered. Eight of the nine C++ cases fail without the
+  fix.
 - [FIXED] a generator could not remotely regulate a bus that another generator already
   regulated *locally* -- the grid was refused outright with
   ``LSGrid::fill_voltage_control_solver_data: generator N regulates bus X which has no voltage (Vm)

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -143,6 +143,16 @@ TODO: Levenberg-Marquardt damping (a.k.a. Tikhonov-regularized Newton) : adding 
   picked up for free -- an enumeration falling behind is precisely what caused this bug.
   ``ContingencyAnalysisCPP`` (and ``SecurityAnalysis``, which wraps it) was never affected: it passes
   the gridmodel's own complete ``Sbus_`` straight to the solver.
+- [ADDED] a stale-solver-state case to ``src/tests/test_batch_voltage_control.cpp``: run ``ac_pf``,
+  then change the grid so a bus leaves the solver (which makes the AC maps stale AND too long, worse
+  than merely empty), then ``dc_pf`` (which rebuilds only the DC maps), then a batch -- which inherits
+  the grid's AC algorithm, since ``LSGrid::change_algorithm`` routes a DC type to the separate
+  ``_dc_algo`` slot and so asking the GRID for DC never switches a batch over. The batch must still
+  reproduce a clean single-shot ``ac_pf``, which it does because it works on a copy of the grid whose
+  copy constructor ``reset()`` the solver state and whose ``prepare_solver_input_base`` rebuilds it
+  under ``tell_all_changed()``. Being a C++ test it runs under the valgrind pass of the C++ suite and
+  the ASan/UBSan + Eigen-assertion builds, where a too-long index that stays inside the heap would
+  still be caught.
 - [ADDED] ``src/tests/test_timeseries_sbus.cpp`` and ``lightsim2grid/tests/test_timeseries_sbus.py``:
   a one-step time series fed the grid's OWN injections must reproduce ``ac_pf`` / ``dc_pf`` exactly.
   Covers each dropped element kind separately and all of them together, in ac and in dc, plus a

--- a/lightsim2grid/tests/test_timeseries_sbus.py
+++ b/lightsim2grid/tests/test_timeseries_sbus.py
@@ -1,0 +1,113 @@
+# Copyright (c) 2026, RTE (https://www.rte-france.com)
+# See AUTHORS.txt
+# This Source Code Form is subject to the terms of the Mozilla Public License, version 2.0.
+# If a copy of the Mozilla Public License, version 2.0 was not distributed with this file,
+# you can obtain one at http://mozilla.org/MPL/2.0/.
+# SPDX-License-Identifier: MPL-2.0
+# This file is part of LightSim2grid, LightSim2grid implements a c++ backend targeting the Grid2Op platform.
+
+"""``TimeSeriesCPP.compute_Vs`` does not use the injection vector the gridmodel
+builds: it rebuilds its own, per step, from the four matrices the caller passes --
+generator and static-generator ACTIVE power, and load active + reactive power.
+
+``LSGrid::fillSbus_me`` stamps rather more than that: storage units,
+REACTIVE_POWER-mode SVCs, the reactive setpoint of a generator whose voltage
+regulation is off, and a static generator's reactive setpoint. None of those is a
+per-step input, so all are constant across the steps and must be taken from the grid.
+Only the HVDC term ever was, so the rest was silently dropped and the powerflow
+converged on an injection the caller never asked for.
+
+The invariant checked here: fed the grid's OWN injections, a one-step time series must
+reproduce ``ac_pf`` exactly.
+
+Companion C++ suite: ``src/tests/test_timeseries_sbus.cpp``.
+"""
+
+import warnings
+import unittest
+import numpy as np
+import pandapower as pp
+import pandapower.networks as pn
+
+with warnings.catch_warnings():
+    warnings.filterwarnings("ignore")
+    from lightsim2grid.gridmodel import init_from_pandapower
+from lightsim2grid.lightsim2grid_cpp import TimeSeriesCPP  # noqa: E402
+
+MAX_IT = 30
+TOL = 1e-11
+
+
+def _model(add_extras):
+    """case14, optionally with the element kinds whose injection used to be lost."""
+    with warnings.catch_warnings():
+        warnings.filterwarnings("ignore")
+        net = pn.case14()
+        if add_extras:
+            # a static generator carrying reactive power
+            pp.create_sgen(net, bus=4, p_mw=10.0, q_mvar=25.0)
+            # a storage unit (no per-step matrix at all)
+            pp.create_storage(net, bus=6, p_mw=15.0, max_e_mwh=100.0, q_mvar=20.0)
+            # a generator that does NOT regulate voltage, so its q_mvar is an input
+            pp.create_gen(net, bus=9, p_mw=20.0, vm_pu=1.0, q_mvar=30.0,
+                          min_q_mvar=-100.0, max_q_mvar=100.0, controllable=True)
+        model = init_from_pandapower(net)
+    if add_extras:
+        # pandapower's converter marks every gen as voltage-regulating; turn the last
+        # one off so its reactive setpoint is what Sbus carries
+        gens = model.get_generators()
+        model.change_v_gen(len(gens) - 1, 1.0)
+        model.turnedoff_no_pv()
+    model.tell_solver_need_reset()
+    return net, model
+
+
+def _own_injections(model):
+    gen_p = np.array(model.get_gen_target_p(), dtype=np.float64)[None, :]
+    sgen_p = np.array(model.get_sgen_target_p(), dtype=np.float64)[None, :]
+    load_p = np.array(model.get_load_target_p(), dtype=np.float64)[None, :]
+    load_q = np.array([ld.target_q_mvar for ld in model.get_loads()],
+                      dtype=np.float64)[None, :]
+    return gen_p, sgen_p, load_p, load_q
+
+
+class TestTimeSeriesSbusCompleteness(unittest.TestCase):
+    def _check(self, add_extras):
+        net, model = _model(add_extras)
+        nb_bus = net.bus.shape[0]
+        V = model.ac_pf(np.ones(nb_bus, dtype=np.complex128), MAX_IT, TOL)
+        self.assertGreater(V.shape[0], 0, "ac_pf diverged")
+
+        _, ts_model = _model(add_extras)
+        ts = TimeSeriesCPP(ts_model)
+        gen_p, sgen_p, load_p, load_q = _own_injections(ts_model)
+        status = ts.compute_Vs(gen_p, sgen_p, load_p, load_q,
+                               np.ones(nb_bus, dtype=np.complex128), MAX_IT, TOL)
+        self.assertEqual(status, 1, "time series diverged")
+        Vts = np.array(ts.get_voltages())[0]
+        self.assertLess(np.abs(Vts - V).max(), 1e-9,
+                        f"TimeSeries disagrees with ac_pf by {np.abs(Vts - V).max():.3e}")
+
+    def test_plain_case14(self):
+        # the control: case14 has no sgen, no storage and every generator regulates
+        # voltage, so all of its injection IS covered by the four per-step matrices
+        self._check(add_extras=False)
+
+    def test_case14_with_sgen_storage_and_a_q_mode_generator(self):
+        # the same grid plus the element kinds whose contribution used to vanish
+        self._check(add_extras=True)
+
+    def test_extras_actually_change_the_operating_point(self):
+        # guard the guard: if the added elements did not move the voltages, the
+        # comparison above would pass no matter what TimeSeries did with them
+        net, plain = _model(False)
+        _, extra = _model(True)
+        nb_bus = net.bus.shape[0]
+        Vp = plain.ac_pf(np.ones(nb_bus, dtype=np.complex128), MAX_IT, TOL)
+        Ve = extra.ac_pf(np.ones(nb_bus, dtype=np.complex128), MAX_IT, TOL)
+        self.assertGreater(np.abs(Ve - Vp).max(), 1e-3,
+                           "the added elements do not affect the solution")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/core/batch_algorithm/TimeSeries.cpp
+++ b/src/core/batch_algorithm/TimeSeries.cpp
@@ -183,11 +183,27 @@ CplxVect TimeSeries::_constant_sbus_pu(bool ac_solver_used) const
     const auto & s_generators = _grid_model.get_static_generators_as_data();
     const auto & loads = _grid_model.get_loads_as_data();
 
+    // The gridmodel's target vectors, presented to fill_SBus_* as the single-step
+    // matrices it expects, WITHOUT copying them: a 1 x n row-major matrix has exactly
+    // the memory layout of a contiguous n-vector, so an Eigen::Map over the vector's
+    // own storage is a view. Handing `.transpose()` over instead would not be -- the
+    // transpose of a column vector is not a RealMat, so binding it to the
+    // Eigen::Ref<const RealMat> parameter has to materialise it. The Refs are held in
+    // named locals rather than being called inline: that way the Map never depends on
+    // a temporary Ref's lifetime, whatever the accessors return.
+    const Eigen::Ref<const RealVect> gen_p_v = _grid_model.get_gen_target_p();
+    const Eigen::Ref<const RealVect> sgen_p_v = _grid_model.get_sgen_target_p();
+    const Eigen::Ref<const RealVect> load_p_v = _grid_model.get_load_target_p();
+    const Eigen::Ref<const RealVect> load_q_v = loads.get_target_q();
+    const Eigen::Map<const RealMat> gen_p(gen_p_v.data(), 1, gen_p_v.size());
+    const Eigen::Map<const RealMat> sgen_p(sgen_p_v.data(), 1, sgen_p_v.size());
+    const Eigen::Map<const RealMat> load_p(load_p_v.data(), 1, load_p_v.size());
+    const Eigen::Map<const RealMat> load_q(load_q_v.data(), 1, load_q_v.size());
+
+    // `accounted` does have to be its own buffer: it is written by fill_SBus_* and
+    // then scaled by sn_mva, which must NOT touch `res` (already per-unit). One
+    // vector-sized allocation per compute_Vs call, not per step.
     CplxMat accounted = CplxMat::Zero(1, nb_buses_solver_);
-    const RealMat gen_p = _grid_model.get_gen_target_p().transpose();
-    const RealMat sgen_p = _grid_model.get_sgen_target_p().transpose();
-    const RealMat load_p = _grid_model.get_load_target_p().transpose();
-    const RealMat load_q = loads.get_target_q().transpose();
     bool add_ = true;
     fill_SBus_real(accounted, generators, gen_p, id_me_to_solver_, add_);
     fill_SBus_real(accounted, s_generators, sgen_p, id_me_to_solver_, add_);

--- a/src/core/batch_algorithm/TimeSeries.cpp
+++ b/src/core/batch_algorithm/TimeSeries.cpp
@@ -80,17 +80,26 @@ int TimeSeries::compute_Vs(const Eigen::Ref<const RealMat> & gen_p,
     fill_SBus_real(_Sbuses, loads, load_p, id_me_to_solver_, add_);
     fill_SBus_imag(_Sbuses, loads, load_q, id_me_to_solver_, add_);
 
-    // add the (constant accross the steps) hvdc injections: fixed-setpoint
-    // lines, station reactive setpoints / LCC consumptions and, in dc, the
-    // saturated droop lines. The angle-droop flows of the linear-mode lines
-    // are theta dependent: they are handled by the solver itself (Hvdc
-    // extension of the NR system in ac, dc matrix term in dc).
-    CplxVect hvdc_sbus = CplxVect::Zero(nb_buses_solver_);
-    _grid_model.get_dclines_as_data().fillSbus(hvdc_sbus, id_me_to_solver_, ac_solver_used);
-    _Sbuses.rowwise() += hvdc_sbus.transpose();
-
     if(abs(sn_mva - 1.0) > _tol_equal_float) _Sbuses.array() /= static_cast<cplx_type>(sn_mva);
-    // TODO trafo hack for Sbus !
+
+    // ... and then everything else the gridmodel stamps into Sbus, which the four
+    // matrices above do NOT cover. They carry generator / static-generator ACTIVE
+    // power and load active+reactive power, and nothing more -- while
+    // LSGrid::fillSbus_me also stamps storage units, REACTIVE_POWER-mode SVCs, the
+    // reactive setpoint of a generator whose voltage regulation is off, a static
+    // generator's reactive setpoint, the hvdc injections, and (dc only) the phase
+    // shifter hack. None of those is a per-step input, so all of them are constant
+    // across the steps and must come from the grid.
+    //
+    // This is derived rather than enumerated on purpose: an enumeration falling
+    // behind is exactly the bug being fixed here (only the hvdc term was listed, so
+    // storages, SVCs and every reactive setpoint were silently dropped -- worth up
+    // to ~0.08 pu of voltage error on a 4-bus test). Instead take the COMPLETE
+    // injection the gridmodel just built and subtract the share the per-step
+    // matrices are responsible for, evaluated at the gridmodel's OWN injection
+    // values. What remains is by construction everything else, so an element type
+    // added to fillSbus_me later is picked up here for free.
+    _Sbuses.rowwise() += _constant_sbus_pu(ac_solver_used).transpose();
     //////////////////////////////////////////
 
     bool init_powerflow_has_conv = _finish_preprocessing(
@@ -145,6 +154,51 @@ int TimeSeries::compute_Vs(const Eigen::Ref<const RealMat> & gen_p,
     _status = 1;
     _timer_total = timer.duration();
     return _status;
+}
+
+CplxVect TimeSeries::_constant_sbus_pu(bool ac_solver_used) const
+{
+    // the complete per-unit injection, straight from the gridmodel
+    // (`prepare_solver_input_base` filled exactly one of these two)
+    CplxVect res;
+    if(ac_solver_used){
+        res = Sbus_;
+    } else {
+        // dc keeps everything real; the imaginary part is unused downstream
+        // (compute_one_powerflow takes Sbus.real()) but must be zero so that
+        // subtracting the reconstruction below cannot invent one
+        res = Pbus_.cast<cplx_type>();
+    }
+    if(static_cast<int>(res.size()) != nb_buses_solver_){
+        std::ostringstream exc_;
+        exc_ << "TimeSeries::_constant_sbus_pu: the gridmodel injection has "
+             << res.size() << " entries while the solver has " << nb_buses_solver_
+             << " buses. prepare_solver_input_base() must run first.";
+        throw std::runtime_error(exc_.str());
+    }
+
+    // ... minus the share compute_Vs rebuilds per step, evaluated at the gridmodel's
+    // own target values, so that the two cancel and only the rest is left
+    const auto & generators = _grid_model.get_generators_as_data();
+    const auto & s_generators = _grid_model.get_static_generators_as_data();
+    const auto & loads = _grid_model.get_loads_as_data();
+
+    CplxMat accounted = CplxMat::Zero(1, nb_buses_solver_);
+    const RealMat gen_p = _grid_model.get_gen_target_p().transpose();
+    const RealMat sgen_p = _grid_model.get_sgen_target_p().transpose();
+    const RealMat load_p = _grid_model.get_load_target_p().transpose();
+    const RealMat load_q = loads.get_target_q().transpose();
+    bool add_ = true;
+    fill_SBus_real(accounted, generators, gen_p, id_me_to_solver_, add_);
+    fill_SBus_real(accounted, s_generators, sgen_p, id_me_to_solver_, add_);
+    add_ = false;
+    fill_SBus_real(accounted, loads, load_p, id_me_to_solver_, add_);
+    fill_SBus_imag(accounted, loads, load_q, id_me_to_solver_, add_);
+
+    const real_type sn_mva = _grid_model.get_sn_mva();
+    if(abs(sn_mva - 1.0) > _tol_equal_float) accounted.array() /= static_cast<cplx_type>(sn_mva);
+    res -= accounted.row(0).transpose();
+    return res;
 }
 
 } // namespace ls2g

--- a/src/core/batch_algorithm/TimeSeries.hpp
+++ b/src/core/batch_algorithm/TimeSeries.hpp
@@ -78,6 +78,24 @@ class LS2G_API TimeSeries final: public BaseBatchSolverSynch
         }
 
     protected:
+        /**
+         * Per-unit injection that the four per-step matrices of `compute_Vs` do NOT
+         * account for, and which is therefore constant across the steps: storage
+         * units, REACTIVE_POWER-mode SVCs, the reactive setpoint of a generator whose
+         * voltage regulation is off, a static generator's reactive setpoint, the hvdc
+         * injections and (dc only) the phase-shifter term.
+         *
+         * Computed as `complete - accounted_for`: the complete injection the
+         * gridmodel built in `Sbus_` (ac) / `Pbus_` (dc), minus the same
+         * reconstruction `compute_Vs` performs, evaluated at the gridmodel's own
+         * target values. Deriving it this way -- instead of listing the elements --
+         * is what keeps it from falling out of date when a new element type starts
+         * contributing to LSGrid::fillSbus_me.
+         *
+         * Only valid after prepare_solver_input_base() has run.
+         */
+        CplxVect _constant_sbus_pu(bool ac_solver_used) const;
+
         template<class T>
         void fill_SBus_real(Eigen::Ref<CplxMat> Sbuses,
                             const T & structure_data,

--- a/src/core/element_container/OneSideContainer_PQ.hpp
+++ b/src/core/element_container/OneSideContainer_PQ.hpp
@@ -60,6 +60,7 @@ class OneSideContainer_PQ : public OneSideContainer
         // public generic API
 
         Eigen::Ref<const RealVect> get_target_p() const {return target_p_mw_;}
+        Eigen::Ref<const RealVect> get_target_q() const {return target_q_mvar_;}
 
         // base function that can be called
         void gen_p_per_bus(std::vector<real_type> & res) const override

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -74,6 +74,7 @@ add_executable(lightsim2grid_unit_tests
     test_powerflow_algorithm.cpp
     test_voltage_control_reclassify.cpp
     test_batch_voltage_control.cpp
+    test_timeseries_sbus.cpp
 )
 target_link_libraries(lightsim2grid_unit_tests PRIVATE lightsim2grid_core Catch2::Catch2WithMain)
 

--- a/src/tests/test_batch_voltage_control.cpp
+++ b/src/tests/test_batch_voltage_control.cpp
@@ -42,6 +42,7 @@ using Catch::Approx;
 using ls2g::AlgorithmType;
 using ls2g::ContingencyAnalysis;
 using ls2g::CplxVect;
+using ls2g::GlobalBusId;
 using ls2g::IntVect;
 using ls2g::LSGrid;
 using ls2g::RealVect;
@@ -416,5 +417,108 @@ TEST_CASE("a contingency stranding a regulated bus is reported, not silently wro
         REQUIRE(ca.converged().size() == 1);
         CHECK(ca.converged()[0] == 0);
         for (int b = 0; b < NB_BUS; ++b) CHECK(std::abs(ca.get_voltages()(0, b)) == 0.);
+    }
+}
+
+TEST_CASE("stale solver state on the source grid cannot leak into a batch", "[batch][stale]")
+{
+    // The nastiest shape of the mapping bug this file is about is not an EMPTY
+    // member but a stale NON-empty one, sized for a grid that no longer exists:
+    //
+    //   1. ac_pf runs                -> the AC maps are built for N buses
+    //   2. the grid changes so that a bus leaves the solver
+    //                                -> the AC maps are now wrong, and still N long
+    //   3. dc_pf runs                -> the DC maps are rebuilt at N-1; AC stays stale
+    //   4. a batch is built and runs  -> it inherits the grid's AC algorithm
+    //                                   (LSGrid::change_algorithm routes a DC type to
+    //                                   the separate _dc_algo slot, so asking the GRID
+    //                                   for DC never switches a batch over)
+    //
+    // A stale map is worse than an empty one: an empty one reads as "nothing to do",
+    // while a too-long one indexes past the end of the current solver vectors. What
+    // makes this safe is that a batch never reads the source grid's solver state --
+    // BaseBatchSolverSynch copies the grid (and LSGrid's copy constructor reset()s all
+    // of it), then prepare_solver_input_base calls tell_all_changed() before
+    // pre_process_solver, rebuilding every mapping from scratch on that copy.
+    //
+    // This case is deliberately cheap and allocation-light so it also runs under the
+    // valgrind pass of the C++ suite and the ASan/UBSan + Eigen-assertion builds,
+    // where an out-of-bounds read that stays inside the heap would still be caught.
+    const int nb_bus = 5;
+    auto build = [](LSGrid & grid) {
+        grid.set_sn_mva(100.);
+        grid.set_init_vm_pu(1.0);
+        grid.init_bus(static_cast<unsigned int>(nb_bus), 1, RealVect::Constant(nb_bus, 138.), 0, 0);
+        // lines 0:0-1, 1:1-2, 2:2-3, 3:1-4 -- bus 4 hangs off bus 1 by line 3 alone
+        Eigen::VectorXi f(4), t(4);
+        f << 0, 1, 2, 1;
+        t << 1, 2, 3, 4;
+        grid.init_powerlines(RealVect::Constant(4, 0.01), RealVect::Constant(4, 0.1),
+                             CplxVect::Zero(4), f, t);
+        RealVect lp(2), lq(2);
+        lp << LOAD_P, 5.;
+        lq << LOAD_Q, 1.;
+        Eigen::VectorXi lb(2);
+        lb << 3, 4;                      // load 1 is the only element on bus 4
+        grid.init_loads(lp, lq, lb);
+
+        RealVect gp(2), gv(2), gqn(2), gqx(2);
+        Eigen::VectorXi gb(2);
+        gp << 0., 0.;
+        gv << 1.02, V_SET;
+        gqn << -1000., -1000.;
+        gqx << 1000., 1000.;
+        gb << 0, 1;
+        grid.init_generators(gp, gv, gqn, gqx, gb);
+        grid.add_gen_slackbus(0, 1.);
+        grid.set_gen_regulated_bus(1, 3);   // remote control: needs id_ac_solver_to_me_
+        grid.tell_solver_need_reset();
+    };
+    // takes bus 4 out of the solver: open its only line and its only load
+    auto strand_bus_4 = [](LSGrid & grid) {
+        grid.deactivate_powerline(3);
+        grid.deactivate_load(1);
+        grid.deactivate_bus(GlobalBusId(4));
+    };
+    const CplxVect V0 = CplxVect::Constant(nb_bus, cplx_type(1., 0.));
+
+    LSGrid grid;
+    build(grid);
+    grid.change_algorithm(AlgorithmType::NR_SparseLU);
+    REQUIRE(grid.ac_pf(V0, 30, 1e-11).size() == nb_bus);
+    // the AC maps now describe the FULL grid
+    REQUIRE(static_cast<int>(grid.id_ac_solver_to_me().size()) == nb_bus);
+
+    strand_bus_4(grid);
+    grid.change_algorithm(AlgorithmType::DC_SparseLU);
+    REQUIRE(grid.dc_pf(V0, 30, 1e-11).size() == nb_bus);
+    // the DC maps followed the change; the AC ones are still the old, too-long ones.
+    // If they were not, this test would be vacuous.
+    REQUIRE(static_cast<int>(grid.id_dc_solver_to_me().size()) == nb_bus - 1);
+    REQUIRE(static_cast<int>(grid.id_ac_solver_to_me().size()) == nb_bus);
+
+    // the batch inherits the AC algorithm and must nonetheless reproduce a clean
+    // single-shot ac_pf of the stranded grid
+    TimeSeries ts(grid);
+    RealMat gen_p(1, 2), sgen_p(1, 0), load_p(1, 2), load_q(1, 2);
+    gen_p << 0., 0.;
+    load_p << LOAD_P, 5.;
+    load_q << LOAD_Q, 1.;
+    REQUIRE(ts.compute_Vs(gen_p, sgen_p, load_p, load_q, V0, 30, 1e-11) == 1);
+    const CplxVect Vts = ts.get_voltages().row(0);
+
+    LSGrid ref;
+    build(ref);
+    strand_bus_4(ref);
+    ref.change_algorithm(AlgorithmType::NR_SparseLU);
+    const CplxVect Vref = ref.ac_pf(V0, 30, 1e-11);
+    REQUIRE(Vref.size() == nb_bus);
+    CHECK(std::abs(Vref(3)) == Approx(V_SET).epsilon(1e-8));  // control still applied
+
+    for (int b = 0; b < nb_bus; ++b) {
+        if (b == 4) continue;  // stranded: the batch reports 0, ac_pf reports init_vm_pu
+        INFO("bus " << b);
+        CHECK(std::abs(Vts(b)) == Approx(std::abs(Vref(b))).epsilon(1e-9));
+        CHECK(std::arg(Vts(b)) == Approx(std::arg(Vref(b))).margin(1e-10));
     }
 }

--- a/src/tests/test_timeseries_sbus.cpp
+++ b/src/tests/test_timeseries_sbus.cpp
@@ -1,0 +1,324 @@
+// Copyright (c) 2026, RTE (https://www.rte-france.com)
+// See AUTHORS.txt
+// This Source Code Form is subject to the terms of the Mozilla Public License, version 2.0.
+// If a copy of the Mozilla Public License, version 2.0 was not distributed with this file,
+// you can obtain one at http://mozilla.org/MPL/2.0/.
+// SPDX-License-Identifier: MPL-2.0
+// This file is part of LightSim2grid, LightSim2grid implements a c++ backend targeting the Grid2Op platform.
+
+// TimeSeries::compute_Vs does NOT use the injection vector the gridmodel builds. It
+// rebuilds its own, per step, out of the four matrices the caller supplies:
+// generator and static-generator ACTIVE power, and load active + reactive power.
+//
+// LSGrid::fillSbus_me stamps rather more than that -- storage units,
+// REACTIVE_POWER-mode SVCs, the reactive setpoint of a generator whose voltage
+// regulation is off, a static generator's reactive setpoint, the hvdc injections and
+// (dc only) the phase-shifter term. None of those is a per-step input, so all of them
+// are constant across the steps and have to be taken from the grid. Only the hvdc
+// term ever was, so everything else used to be silently dropped: the powerflow
+// converged on an injection the caller never asked for, off by as much as 0.08 pu of
+// voltage on the four-bus feeder below.
+//
+// Every test here solves the same grid twice -- once single-shot, once as a one-step
+// TimeSeries carrying the grid's own injections -- and requires the voltages to
+// agree. That comparison is the real invariant: with the per-step matrices set to the
+// grid's own target values, a TimeSeries step must reproduce ac_pf / dc_pf exactly.
+
+#include <cmath>
+#include <string>
+#include <vector>
+
+#include <catch2/catch_approx.hpp>
+#include <catch2/catch_test_macros.hpp>
+
+#include "LSGrid.hpp"
+#include "batch_algorithm/TimeSeries.hpp"
+
+using Catch::Approx;
+using ls2g::AlgorithmType;
+using ls2g::CplxVect;
+using ls2g::LSGrid;
+using ls2g::RealVect;
+using ls2g::TimeSeries;
+using ls2g::cplx_type;
+using ls2g::real_type;
+
+namespace {
+
+using RealMat = Eigen::Matrix<real_type, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor>;
+
+const real_type LOAD_P = 50.;
+const real_type LOAD_Q = 10.;
+const int NB_BUS = 4;
+
+// 4-bus radial feeder 0-1-2-3 (r = 0.01, x = 0.1 pu), 50 MW / 10 MVAr at bus 3,
+// sn_mva = 100 -- deliberately != 1 so the per-unit conversion is exercised too.
+LSGrid make_skeleton()
+{
+    LSGrid g;
+    g.set_sn_mva(100.);
+    g.set_init_vm_pu(1.0);
+    const RealVect vn = RealVect::Constant(NB_BUS, 138.);
+    g.init_bus(static_cast<unsigned int>(NB_BUS), 1, vn, 0, 0);
+    const RealVect r = RealVect::Constant(NB_BUS - 1, 0.01);
+    const RealVect x = RealVect::Constant(NB_BUS - 1, 0.1);
+    const CplxVect h = CplxVect::Zero(NB_BUS - 1);
+    Eigen::VectorXi f(NB_BUS - 1), t(NB_BUS - 1);
+    for (int i = 0; i < NB_BUS - 1; ++i) { f(i) = i; t(i) = i + 1; }
+    g.init_powerlines(r, x, h, f, t);
+    RealVect lp(1), lq(1); lp << LOAD_P; lq << LOAD_Q;
+    Eigen::VectorXi lb(1); lb << NB_BUS - 1;
+    g.init_loads(lp, lq, lb);
+    return g;
+}
+
+// a slack generator at bus 0 and, optionally, a second generator at bus 1 with
+// voltage_regulator_on == false -- which is what makes its target_q part of Sbus
+void add_gens(LSGrid & g, bool with_q_mode_gen)
+{
+    const int nb = with_q_mode_gen ? 2 : 1;
+    RealVect p(nb), v(nb), q(nb), qmin(nb), qmax(nb);
+    Eigen::VectorXi b(nb);
+    p(0) = 0.; v(0) = 1.02; q(0) = 0.; qmin(0) = -1000.; qmax(0) = 1000.; b(0) = 0;
+    if (with_q_mode_gen) {
+        p(1) = 20.; v(1) = 1.0; q(1) = 30.;
+        qmin(1) = -1000.; qmax(1) = 1000.; b(1) = 1;
+    }
+    const std::vector<bool> vreg = with_q_mode_gen ? std::vector<bool>{true, false}
+                                                   : std::vector<bool>{true};
+    g.init_generators_full(p, v, q, vreg, qmin, qmax, b);
+    g.add_gen_slackbus(0, 1.);
+}
+
+void add_sgen(LSGrid & g, int bus, real_type p_mw, real_type q_mvar)
+{
+    RealVect sp(1), sq(1), pmin(1), pmax(1), qmin(1), qmax(1);
+    sp << p_mw; sq << q_mvar;
+    pmin << -1000.; pmax << 1000.; qmin << -1000.; qmax << 1000.;
+    Eigen::VectorXi sb(1); sb << bus;
+    g.init_sgens(sp, sq, pmin, pmax, qmin, qmax, sb);
+}
+
+void add_storage(LSGrid & g, int bus, real_type p_mw, real_type q_mvar)
+{
+    RealVect sp(1), sq(1);
+    sp << p_mw; sq << q_mvar;
+    Eigen::VectorXi sb(1); sb << bus;
+    g.init_storages(sp, sq, sb);
+}
+
+void add_q_mode_svc(LSGrid & g, int bus, real_type q_set_mvar)
+{
+    RealVect tv(1), qs(1), sl(1), bmin(1), bmax(1);
+    tv << 1.0; qs << q_set_mvar; sl << 0.; bmin << -1000.; bmax << 1000.;
+    Eigen::VectorXi reg(1), b(1); reg << bus; b << bus;
+    // SvcContainer::RegulationMode: REACTIVE_POWER = 2 (the mode that stamps Sbus;
+    // VOLTAGE mode is solved by the VoltageControl extension instead)
+    g.init_svcs({2}, tv, qs, sl, bmin, bmax, reg, b);
+}
+
+// a phase-shifting transformer in parallel with line 1-2. In DC its shift enters the
+// injection through TrafoContainer::hack_Sbus_for_dc_phase_shifter, applied by
+// fillSbus_me AFTER the per-unit division.
+void add_phase_shifter(LSGrid & g, int bus1, int bus2, real_type shift_deg)
+{
+    RealVect tr(1), tx(1), ratio(1), shift(1);
+    CplxVect tb(1);
+    tr << 0.01; tx << 0.1; tb << cplx_type(0., 0.); ratio << 1.; shift << shift_deg;
+    const std::vector<bool> tap_hv{true};
+    Eigen::VectorXi b1(1), b2(1); b1 << bus1; b2 << bus2;
+    g.init_trafo(tr, tx, tb, ratio, shift, tap_hv, b1, b2, false);
+}
+
+CplxVect flat(const LSGrid & g)
+{
+    return CplxVect::Constant(static_cast<Eigen::Index>(g.total_bus()), cplx_type(1., 0.));
+}
+
+// Solve `ref` single-shot and `ts_grid` (an identical grid) as a one-step TimeSeries
+// fed the grid's OWN injections, then require the two to agree. `ac` picks ac_pf/dc_pf
+// and, through the grid's algorithm, the batch path used.
+void check_timeseries_matches_single_shot(LSGrid & ref, LSGrid & ts_grid, bool ac = true)
+{
+    const AlgorithmType algo = ac ? AlgorithmType::NR_SparseLU : AlgorithmType::DC_SparseLU;
+    ref.change_algorithm(algo);
+    const CplxVect V = ac ? ref.ac_pf(flat(ref), 30, 1e-11) : ref.dc_pf(flat(ref), 30, 1e-11);
+    REQUIRE(V.size() == NB_BUS);
+
+    ts_grid.change_algorithm(algo);
+    TimeSeries ts(ts_grid);
+    // The batch classes inherit the grid's *AC* algorithm (BaseBatchSolverSynch's
+    // constructor reads get_algo(), and LSGrid::change_algorithm routes a DC type to
+    // the separate _dc_algo slot), so asking the GRID for DC is not enough -- the
+    // batch has to be switched over explicitly, or it silently runs AC.
+    if (!ac) ts.change_algorithm(algo);
+    const int nb_gen = static_cast<int>(ref.get_generators_as_data().nb());
+    const int nb_sgen = static_cast<int>(ref.get_static_generators_as_data().nb());
+    const int nb_load = static_cast<int>(ref.get_loads_as_data().nb());
+    RealMat gen_p(1, nb_gen), sgen_p(1, nb_sgen), load_p(1, nb_load), load_q(1, nb_load);
+    gen_p.row(0) = ref.get_gen_target_p().transpose();
+    if (nb_sgen > 0) sgen_p.row(0) = ref.get_sgen_target_p().transpose();
+    load_p.row(0) = ref.get_load_target_p().transpose();
+    load_q.row(0) = ref.get_loads_as_data().get_target_q().transpose();
+
+    REQUIRE(ts.compute_Vs(gen_p, sgen_p, load_p, load_q, flat(ts_grid), 30, 1e-11) == 1);
+    const CplxVect Vts = ts.get_voltages().row(0);
+    REQUIRE(Vts.size() == NB_BUS);
+    for (int b = 0; b < NB_BUS; ++b) {
+        INFO("bus " << b << (ac ? " (ac)" : " (dc)"));
+        CHECK(std::abs(Vts(b)) == Approx(std::abs(V(b))).epsilon(1e-9));
+        CHECK(std::arg(Vts(b)) == Approx(std::arg(V(b))).margin(1e-10));
+    }
+}
+
+}  // namespace
+
+
+TEST_CASE("a TimeSeries step reproduces the single shot with only loads and generators",
+          "[tssbus]")
+{
+    // the control: everything in this grid IS one of the four per-step matrices, so
+    // it passed even before the constant remainder was taken from the grid
+    LSGrid a = make_skeleton(); add_gens(a, false); a.tell_solver_need_reset();
+    LSGrid b = make_skeleton(); add_gens(b, false); b.tell_solver_need_reset();
+    check_timeseries_matches_single_shot(a, b);
+}
+
+TEST_CASE("a TimeSeries step keeps the reactive setpoint of a Q-mode generator", "[tssbus]")
+{
+    // voltage_regulator_on == false, so GeneratorContainer::fillSbus stamps
+    // `target_q` -- which no per-step matrix carries
+    LSGrid a = make_skeleton(); add_gens(a, true); a.tell_solver_need_reset();
+    LSGrid b = make_skeleton(); add_gens(b, true); b.tell_solver_need_reset();
+    check_timeseries_matches_single_shot(a, b);
+}
+
+TEST_CASE("a TimeSeries step keeps a static generator's reactive setpoint", "[tssbus]")
+{
+    // sgen_p carries the active power; the reactive setpoint has no matrix at all
+    auto build = [](LSGrid & g) {
+        add_gens(g, false);
+        add_sgen(g, 2, 10., 25.);
+        g.tell_solver_need_reset();
+    };
+    LSGrid a = make_skeleton(); build(a);
+    LSGrid b = make_skeleton(); build(b);
+    check_timeseries_matches_single_shot(a, b);
+}
+
+TEST_CASE("a TimeSeries step keeps storage units", "[tssbus]")
+{
+    // storages have no per-step matrix whatsoever: active AND reactive were dropped
+    auto build = [](LSGrid & g) {
+        add_gens(g, false);
+        add_storage(g, 2, 15., 20.);
+        g.tell_solver_need_reset();
+    };
+    LSGrid a = make_skeleton(); build(a);
+    LSGrid b = make_skeleton(); build(b);
+    check_timeseries_matches_single_shot(a, b);
+}
+
+TEST_CASE("a TimeSeries step keeps a REACTIVE_POWER-mode SVC", "[tssbus]")
+{
+    // the SVC mode that DOES stamp Sbus (VOLTAGE mode is a solver unknown instead,
+    // and is legitimately absent from it)
+    auto build = [](LSGrid & g) {
+        add_gens(g, false);
+        add_q_mode_svc(g, 2, 40.);
+        g.tell_solver_need_reset();
+    };
+    LSGrid a = make_skeleton(); build(a);
+    LSGrid b = make_skeleton(); build(b);
+    check_timeseries_matches_single_shot(a, b);
+}
+
+TEST_CASE("a TimeSeries step keeps all of them at once", "[tssbus]")
+{
+    // all four together, so a fix that happened to handle them only one at a time
+    // (or double-counted one) would show up here
+    auto build = [](LSGrid & g) {
+        add_gens(g, true);
+        add_sgen(g, 2, 10., 25.);
+        add_storage(g, 2, 15., 20.);
+        add_q_mode_svc(g, 1, 40.);
+        g.tell_solver_need_reset();
+    };
+    LSGrid a = make_skeleton(); build(a);
+    LSGrid b = make_skeleton(); build(b);
+    check_timeseries_matches_single_shot(a, b);
+}
+
+TEST_CASE("a DC TimeSeries step reproduces dc_pf", "[tssbus][dc]")
+{
+    // DC consumes the real part of the very same per-step matrix
+    // (BaseBatchSolverSynch::compute_one_powerflow falls back to Pbus_ only when no
+    // Sbus is supplied, which is not the TimeSeries case), so a storage unit's active
+    // power was dropped in DC too.
+    auto build = [](LSGrid & g) {
+        add_gens(g, false);
+        add_storage(g, 2, 15., 20.);
+        add_sgen(g, 1, 10., 25.);
+        g.tell_solver_need_reset();
+    };
+    LSGrid a = make_skeleton(); build(a);
+    LSGrid b = make_skeleton(); build(b);
+    check_timeseries_matches_single_shot(a, b, /*ac=*/false);
+}
+
+TEST_CASE("a DC TimeSeries step keeps the phase-shifter injection", "[tssbus][dc]")
+{
+    // TrafoContainer::hack_Sbus_for_dc_phase_shifter is applied by fillSbus_me AFTER
+    // the per-unit division, i.e. deliberately in physical units -- so it also
+    // exercises that the derived remainder does not re-scale what it must not.
+    auto build = [](LSGrid & g) {
+        add_gens(g, false);
+        add_phase_shifter(g, 1, 2, 5.);
+        g.tell_solver_need_reset();
+    };
+    LSGrid a = make_skeleton(); build(a);
+    LSGrid b = make_skeleton(); build(b);
+    check_timeseries_matches_single_shot(a, b, /*ac=*/false);
+}
+
+TEST_CASE("several TimeSeries steps still track the single shot", "[tssbus]")
+{
+    // the remainder is constant across steps, so it must be added to EVERY row, not
+    // just the first -- and the varying matrices must still vary
+    auto build = [](LSGrid & g) {
+        add_gens(g, true);
+        add_storage(g, 2, 15., 20.);
+        add_q_mode_svc(g, 1, 40.);
+        g.tell_solver_need_reset();
+    };
+    LSGrid ts_grid = make_skeleton(); build(ts_grid);
+    ts_grid.change_algorithm(AlgorithmType::NR_SparseLU);
+
+    const std::vector<real_type> scales{1.0, 1.15};
+    TimeSeries ts(ts_grid);
+    const int nb_steps = static_cast<int>(scales.size());
+    RealMat gen_p(nb_steps, 2), sgen_p(nb_steps, 0), load_p(nb_steps, 1), load_q(nb_steps, 1);
+    for (int s = 0; s < nb_steps; ++s) {
+        gen_p(s, 0) = 0.;
+        gen_p(s, 1) = 20. * scales[s];
+        load_p(s, 0) = LOAD_P * scales[s];
+        load_q(s, 0) = LOAD_Q * scales[s];
+    }
+    REQUIRE(ts.compute_Vs(gen_p, sgen_p, load_p, load_q, flat(ts_grid), 30, 1e-11) == 1);
+
+    for (int s = 0; s < nb_steps; ++s) {
+        INFO("step " << s);
+        LSGrid ref = make_skeleton(); build(ref);
+        ref.change_algorithm(AlgorithmType::NR_SparseLU);
+        ref.change_p_gen(1, gen_p(s, 1));
+        ref.change_p_load(0, load_p(s, 0));
+        ref.change_q_load(0, load_q(s, 0));
+        const CplxVect V = ref.ac_pf(flat(ref), 30, 1e-11);
+        REQUIRE(V.size() == NB_BUS);
+        const CplxVect Vts = ts.get_voltages().row(s);
+        for (int b = 0; b < NB_BUS; ++b) {
+            INFO("bus " << b);
+            CHECK(std::abs(Vts(b)) == Approx(std::abs(V(b))).epsilon(1e-9));
+        }
+    }
+}


### PR DESCRIPTION
## The bug

`TimeSeriesCPP` solves each step against an **incomplete injection vector**. It does not use the `Sbus` the gridmodel builds — it rebuilds its own, per step, out of the four matrices `compute_Vs` receives (generator and static-generator **active** power, load active + reactive power) plus the hvdc term read from the grid.

`LSGrid::fillSbus_me` stamps considerably more, and everything else was silently dropped. Measured on a 4-bus feeder, one-step `TimeSeries` against `ac_pf` with the same injections:

| dropped | in `LSGrid` Sbus | worst \|ΔV\| |
|---|---|---|
| loads P+Q, gens P, sgens P, hvdc | ✓ covered | control: **0** |
| gen Q when `voltage_regulator_on == false` | `tmp += i*target_q` | **0.032 pu** |
| static generator Q | `{p, q}` | **0.052 pu** |
| storage P **and** Q | `-= {p, q}` — absent altogether | **0.066 pu** |
| REACTIVE_POWER-mode SVC Q | ✓ — absent altogether | **0.081 pu** |
| DC phase shifter | `hack_Sbus_for_dc_phase_shifter` | dc only |

For the storage and SVC rows the `TimeSeries` voltages came back *bit-identical to a grid without the element*: it contributed nothing at all. The powerflow converged happily on an injection the caller never asked for.

**DC is affected too.** `compute_one_powerflow` falls back to the gridmodel's `Pbus_` only when *no* complex `Sbus` is supplied, which is not the `TimeSeries` case — it takes `_Sbuses.row(i).real()`, so a storage unit's active power went missing in DC as well, along with the phase-shifter term.

`ContingencyAnalysisCPP` (and `SecurityAnalysis`, which wraps it) was **never affected**: it hands the gridmodel's own complete `Sbus_` straight to the solver. Only `TimeSeries` substitutes a reconstruction.

## The fix

`TimeSeries::_constant_sbus_pu` derives the remainder instead of enumerating it: the complete per-unit injection the gridmodel just built (`Sbus_` in ac, `Pbus_` in dc) **minus** the very reconstruction `compute_Vs` performs, evaluated at the gridmodel's own target values. The two cancel, and what is left is by construction everything the per-step matrices do not carry.

That choice is the point of the PR. This bug *is* an enumeration that fell behind — only the hvdc term was ever listed — so replacing it with a longer list would just reset the clock. Deriving it means an element type added to `fillSbus_me` later is picked up for free. It also handles the DC phase-shifter term correctly without special-casing, that one being deliberately in physical units (`fillSbus_me` applies it *after* the `sn_mva` division).

Also adds `OneSideContainer_PQ::get_target_q()`, the counterpart of the existing `get_target_p()`, needed to evaluate the load reactive share of the subtraction.

## Tests

`src/tests/test_timeseries_sbus.cpp` (9 cases) and `lightsim2grid/tests/test_timeseries_sbus.py` (3 cases) assert the real invariant: **fed the grid's own injections, a one-step time series must reproduce `ac_pf` / `dc_pf` exactly.** Each dropped element kind separately and all of them together, in ac and in dc, plus a multi-step case (the remainder is constant, so it has to reach every row, not just the first) and a control grid whose whole injection the per-step matrices already covered.

**Eight of the nine C++ cases fail without the fix**; the control is the one that passes. The python side includes a guard-the-guard case asserting the added elements actually move the operating point, so the comparison cannot pass vacuously — that trap is exactly what made this bug survive the existing `TimeSeries` tests, which run on grids where every missing term happens to be zero.

## Verification

Full C++ suite green — 5111 assertions / 178 cases — in Release, under `__DEBUG_ASSERTS=1`, and pinned to C++14. Python: `test_hvdc_batch`, `test_Computers`, `test_TimeSerie`, `test_SecurityAnlysis_cpp`, `test_voltage_control_batch`, `test_voltage_control_reclassify`, `test_ACPF`, `test_DCPF`, `test_LSGrid_out_of_bounds` all green.

## One adjacent issue, not fixed here

`GeneratorContainer::fillSbus` skips a *pseudo-off* PV generator (`target_p == 0` under `turnedoff_no_pv`), while PV classification is computed once from the grid's `target_p` and never revisited per step. A `gen_p` series that crosses zero can therefore disagree with the PV set `TimeSeries` fixed up front. Same file, different bug — left alone deliberately.

---
_Generated by [Claude Code](https://claude.ai/code/session_015FU3fCG8p2dj3h6rRkTeyH)_