### PR TITLE
Solver-side data of a powerflow belongs to exactly one owner

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -149,6 +149,25 @@ TODO: a "combine mode" axis for ``ScenarioSweepCPP`` choosing between the curren
   a one-shot invalidation of what a family cached (as opposed to the ``allow_*`` mode above).
   ``prevent_cache_reuse()`` is the new name of ``tell_solver_need_reset()``, which still exists and
   behaves identically. Both are now documented rather than tagged "internal, do not use".
+- [FIXED] the solver-side data a powerflow is built from now belongs to exactly one owner.
+  ``LSGrid::pre_process_solver`` / ``pre_process_dc_solver`` (C++ only, not exposed to python)
+  serve two kinds of caller: the grid itself (``ac_pf`` / ``dc_pf`` / ``check_solution``, which
+  hand over their own members, so what comes out IS the family cache) and the batch algorithms
+  (``TimeSeries`` / ``ContingencyAnalysis`` / the sweeps, which own their containers and solve them
+  with an algorithm of their own). The slack weights and the PV / PQ split were exempt: they were
+  taken from the grid's members whatever the caller passed for everything else. So a batch build
+  wrote its own split into the grid's cache next to a ``Ybus`` / ``Sbus`` built for a different
+  labelling, and the cache-consistency guard compared one owner's container sizes against the
+  other's -- sizes agree far more often than labellings do, so a caller that reused its containers
+  with a "nothing changed" control would have skipped ``fillpv_pq`` and stamped the grid's PV / PQ
+  split onto its own system: converged, plausible, wrong. Nothing reached it (every batch asks for
+  a full rebuild), which is what made it worth closing before something did.
+  The three vectors are now parameters like the rest of the group, ``allow_cache_reuse`` fast paths
+  are reserved to the owner of a cache, mixing the two owners' containers in one call raises
+  instead of building a chimera, and a build into a caller's containers leaves the grid it was
+  called on rebuilding rather than reusing what is now half its own and half the caller's. This
+  changes the signature of the two ``pre_process_*`` methods (three added parameters) for C++
+  callers; nothing changes for python, and the numbers a batch returns are unchanged.
 - [BREAKING] the AC and the DC solver families no longer share ANY solver-side data.
   ``slack_weights``, the PV split and the PQ split were single members overwritten by whichever
   family solved last -- unlike ``Ybus`` / ``Sbus`` / the id maps, which were already per family.

--- a/src/core/LSGrid.cpp
+++ b/src/core/LSGrid.cpp
@@ -754,6 +754,9 @@ CplxVect LSGrid::ac_pf(const Eigen::Ref<const CplxVect> & Vinit,
                                     id_ac_solver_to_me_,
                                     slack_bus_id_ac_me_,
                                     slack_bus_id_ac_solver_,
+                                    slack_weights_ac_,
+                                    bus_pv_ac_,
+                                    bus_pq_ac_,
                                     is_ac,
                                     algo_controler_.ac_algo_controler());
 
@@ -1293,6 +1296,9 @@ CplxVect LSGrid::check_solution(const Eigen::Ref<const CplxVect> & V_proposed, b
                                     id_ac_solver_to_me_,
                                     slack_bus_id_ac_me_,
                                     slack_bus_id_ac_solver_,
+                                    slack_weights_ac_,
+                                    bus_pv_ac_,
+                                    bus_pq_ac_,
                                     is_ac, reset_solver,
                                     false);  // do NOT snap regulated buses to their target: we are testing V_proposed as-is
 
@@ -1396,16 +1402,56 @@ CplxVect LSGrid::_pre_process_solver_impl(
     GlobalBusIdVect & id_solver_to_me,
     GlobalBusIdVect & slack_bus_id_me,
     SolverBusIdVect & slack_bus_id_solver,
+    RealVect & slack_weights,
+    SolverBusIdVect & bus_pv,
+    SolverBusIdVect & bus_pq,
     const AlgoControl & solver_control,
     bool init_pv_vm_targets)
 {
     // cplx_type matrix => AC solver family, real_type matrix => DC solver family
     const bool is_ac = std::is_same<MatScalar, cplx_type>::value;
-    // this family's own solver-side data (the other family keeps its own copy of
-    // each of these, so the two never overwrite one another)
-    RealVect & slack_weights = is_ac ? slack_weights_ac_ : slack_weights_dc_;
-    SolverBusIdVect & bus_pv = is_ac ? bus_pv_ac_ : bus_pv_dc_;
-    SolverBusIdVect & bus_pq = is_ac ? bus_pq_ac_ : bus_pq_dc_;
+
+    // ---- whose solver-side data is this? ----------------------------------------
+    // Two kinds of caller reach this function, and they must not be treated alike.
+    //   - THE GRID ITSELF (ac_pf / dc_pf / check_solution) hands over its own
+    //     per-family members. What is built here IS the family cache, this grid's
+    //     algorithm is the one that will consume it, and reusing what the previous
+    //     powerflow left is the whole point.
+    //   - A FOREIGN BUILDER -- today the batch algorithms (TimeSeries /
+    //     ContingencyAnalysis / the sweeps, through BaseBatchSolverSynch), on a
+    //     private copy of the grid -- hands over vectors it owns and solves them with
+    //     an algorithm of its own. For it this function is a pure builder.
+    //
+    // `slack_weights`, `bus_pv` and `bus_pq` used to be exempt from that: they were
+    // taken from this grid's members whatever the caller passed for everything else.
+    // Two things followed, both silent.
+    //   1. A foreign build wrote its pv-pq split and its slack weights into the
+    //      grid's cache, on top of a Ybus / Sbus the grid had built for a different
+    //      labelling -- a cache that is a mixture of two owners and reads as valid.
+    //   2. The guard below sized one owner's containers against the other's. Sizes
+    //      agree far more often than labellings do, so a caller reusing its own
+    //      containers with a "nothing changed" control would have skipped fillpv_pq
+    //      and stamped THIS grid's pv-pq split onto ITS system: converged, plausible,
+    //      wrong. Nothing reaches that today (every foreign caller asks for a full
+    //      rebuild), which is exactly what makes it the kind of bug that surfaces
+    //      years later, in whichever batch path first tries to keep its Ybus.
+    // So the nine containers now travel as one group, from one owner, and only the
+    // owner of a cache may reuse it.
+    const int nb_own = _nb_own_cache_args(is_ac, &inj, &mat, &id_me_to_solver,
+                                          &id_solver_to_me, &slack_bus_id_me,
+                                          &slack_bus_id_solver, &slack_weights,
+                                          &bus_pv, &bus_pq);
+    if(nb_own != 0 && nb_own != 9){
+        std::ostringstream exc_;
+        exc_ << "LSGrid::pre_process_solver: " << nb_own << " of the 9 solver-side "
+             << "containers belong to this grid's own " << (is_ac ? "AC" : "DC")
+             << " cache and " << (9 - nb_own) << " to the caller. They must all come "
+             << "from the same owner: mixing them builds the matrices with one bus "
+             << "labelling and the pv/pq split (or the slack weights) with another, "
+             << "which converges to a wrong answer instead of failing.";
+        throw std::runtime_error(exc_.str());
+    }
+    const bool own_cache = (nb_own == 9);
 
     // ---- cache-consistency guard ------------------------------------------------
     // `solver_control` only records what changed SINCE the last solve of this
@@ -1432,6 +1478,13 @@ CplxVect LSGrid::_pre_process_solver_impl(
     // cache simply never has a usable one.
     const auto nb_bus_solver_cached = static_cast<Eigen::Index>(id_solver_to_me.size());
     const bool cache_unusable =
+        // a foreign builder never reuses: `solver_control`, the connectivity snapshot
+        // init_bus_status() compares against and the flags it raises all belong to
+        // THIS grid, and say nothing about what the caller's containers hold. Free in
+        // practice -- every foreign caller asks for a full rebuild anyway -- and it is
+        // what makes the mixed-owner fast path above structurally impossible rather
+        // than merely unreached.
+        !own_cache ||
         !(is_ac ? allow_ac_cache_reuse_ : allow_dc_cache_reuse_) ||
         (id_me_to_solver.size() != substations_.nb_bus()) ||  // never built, or built for another grid size
         (nb_bus_solver_cached == 0) ||
@@ -1441,7 +1494,13 @@ CplxVect LSGrid::_pre_process_solver_impl(
         (slack_weights.size() != nb_bus_solver_cached) ||
         (bus_pv.size() + bus_pq.size() > static_cast<std::size_t>(nb_bus_solver_cached));
 
-    if(solver_control.need_reset_solver() || cache_unusable){
+    // `_algo` / `_dc_algo` are THIS grid's algorithms: they consume this grid's cache
+    // and nothing else. A foreign builder solves with an algorithm of its own (see
+    // BaseBatchSolverSynch's `_algo`), so resetting ours -- throwing away a
+    // factorization our next own powerflow would have reused -- is at best wasted
+    // work, and pairing it with a "nothing changed" control it never sees is how a
+    // reset algorithm ends up asked to skip the rebuild it just lost.
+    if(own_cache && (solver_control.need_reset_solver() || cache_unusable)){
         if(is_ac) _algo.reset();
         else _dc_algo.reset();
     }
@@ -1541,48 +1600,71 @@ CplxVect LSGrid::_pre_process_solver_impl(
     // once the algorithm has actually run -- check_solution() comes through this
     // function too, without ever calling compute_pf, and clearing the flag there
     // would drop a rebuild the next real powerflow still needs.
-    const bool algo_needs_rebuild = is_ac ? ac_algo_needs_rebuild_ : dc_algo_needs_rebuild_;
-    if(cache_unusable || algo_needs_rebuild){
-        // Either the flags we were handed described a cache that did not exist (so
-        // we rebuilt everything just now), or the previous solve of this family
-        // diverged and its algorithm was reset. Both mean the algorithm must
-        // rebuild its own internals rather than skip on a "nothing changed" it
-        // cannot honour.
-        const AlgoControl all_changed;  // default ctor: everything changed
-        if(is_ac) _algo.tell_solver_control(all_changed);
-        else _dc_algo.tell_solver_control(all_changed);
-    } else {
-        if(is_ac) _algo.tell_solver_control(solver_control);
-        else _dc_algo.tell_solver_control(solver_control);
+    // Only when this grid's own algorithm is the one about to run on what we just
+    // built: a foreign builder configures its own (BaseBatchSolverSynch does it
+    // itself, from its own control), and telling ours about a solve it will not
+    // perform only desynchronizes it from the cache it still holds.
+    if(own_cache){
+        const bool algo_needs_rebuild = is_ac ? ac_algo_needs_rebuild_ : dc_algo_needs_rebuild_;
+        if(cache_unusable || algo_needs_rebuild){
+            // Either the flags we were handed described a cache that did not exist (so
+            // we rebuilt everything just now), or the previous solve of this family
+            // diverged and its algorithm was reset. Both mean the algorithm must
+            // rebuild its own internals rather than skip on a "nothing changed" it
+            // cannot honour.
+            const AlgoControl all_changed;  // default ctor: everything changed
+            if(is_ac) _algo.tell_solver_control(all_changed);
+            else _dc_algo.tell_solver_control(all_changed);
+        } else {
+            if(is_ac) _algo.tell_solver_control(solver_control);
+            else _dc_algo.tell_solver_control(solver_control);
+        }
     }
 
-    // Keep the member solver-side labelling in sync with the vectors we just built.
-    // The single-shot ac_pf / dc_pf pass the members themselves (self-assign, skipped
-    // below), but the batch algorithms (TimeSeries / ContingencyAnalysis, through
-    // BaseBatchSolverSynch) own their local vectors and pass those -- while the solver
-    // still reaches back into this LSGrid through `lsgrid_ptr` to build its NR
-    // extensions:
-    //   Base           -> get_free_vm_slack_solver_buses()    (slack_bus_id_*_solver_)
+    // A foreign build still has to PUBLISH what it built into this grid's members,
+    // because the solver reaches back into the LSGrid through `lsgrid_ptr` to build
+    // its NR extensions, and those read the members rather than anything they were
+    // handed:
+    //   Base           -> get_free_vm_slack_solver_buses()    (slack_bus_id_ac_solver_,
+    //                       id_me_to_ac_solver_)
     //   Hvdc           -> fill_hvdc_droop_solver_data()       (id_me_to_*_solver_)
-    //   VoltageControl -> fill_voltage_control_solver_data()  (id_*_solver_to_me_,
-    //                       id_me_to_*_solver_, and the two above)
+    //   VoltageControl -> fill_voltage_control_solver_data()  (id_me_to_ac_solver_,
+    //                       id_ac_solver_to_me_, bus_pq_ac_, and the two above)
     // A member left stale there does not read as an error, it reads as "nothing to
     // do": the controller list comes back empty and the solve SILENTLY drops remote
     // voltage control / the free Vm unknown of a distributed-slack participant. Note
-    // that the batch classes hold a *copy* of the grid, and LSGrid's copy constructor
-    // reset()s all of this, so stale here always means empty. Every member the
-    // extensions read must therefore reflect the active mapping in every path -- not
-    // just the forward map.
-    if(is_ac){
-        if(&id_me_to_solver != &id_me_to_ac_solver_) id_me_to_ac_solver_ = id_me_to_solver;
-        if(&id_solver_to_me != &id_ac_solver_to_me_) id_ac_solver_to_me_ = id_solver_to_me;
-        if(&slack_bus_id_me != &slack_bus_id_ac_me_) slack_bus_id_ac_me_ = slack_bus_id_me;
-        if(&slack_bus_id_solver != &slack_bus_id_ac_solver_) slack_bus_id_ac_solver_ = slack_bus_id_solver;
-    } else {
-        if(&id_me_to_solver != &id_me_to_dc_solver_) id_me_to_dc_solver_ = id_me_to_solver;
-        if(&id_solver_to_me != &id_dc_solver_to_me_) id_dc_solver_to_me_ = id_solver_to_me;
-        if(&slack_bus_id_me != &slack_bus_id_dc_me_) slack_bus_id_dc_me_ = slack_bus_id_me;
-        if(&slack_bus_id_solver != &slack_bus_id_dc_solver_) slack_bus_id_dc_solver_ = slack_bus_id_solver;
+    // `bus_pq_ac_`: the pv-pq split is part of what the extensions read, which is why
+    // it is published here and not merely built into the caller's own vector.
+    // (The single-shot ac_pf / dc_pf pass the members themselves, so there is nothing
+    // to publish -- own_cache covers exactly that case.)
+    if(!own_cache){
+        if(is_ac){
+            id_me_to_ac_solver_ = id_me_to_solver;
+            id_ac_solver_to_me_ = id_solver_to_me;
+            slack_bus_id_ac_me_ = slack_bus_id_me;
+            slack_bus_id_ac_solver_ = slack_bus_id_solver;
+            slack_weights_ac_ = slack_weights;
+            bus_pv_ac_ = bus_pv;
+            bus_pq_ac_ = bus_pq;
+        } else {
+            id_me_to_dc_solver_ = id_me_to_solver;
+            id_dc_solver_to_me_ = id_solver_to_me;
+            slack_bus_id_dc_me_ = slack_bus_id_me;
+            slack_bus_id_dc_solver_ = slack_bus_id_solver;
+            slack_weights_dc_ = slack_weights;
+            bus_pv_dc_ = bus_pv;
+            bus_pq_dc_ = bus_pq;
+        }
+        // ... and that publication is precisely what makes this grid's own cache for
+        // that family untrustworthy afterwards: the labelling and the split are now
+        // the caller's, while the matrix and the injections -- deliberately NOT
+        // published, they are the expensive half and the caller keeps them -- are
+        // still whatever this grid built last, if anything. The mixture is the right
+        // size and passes every structural check, so nothing downstream would notice
+        // it. This is the write-through that used to happen silently, for pv / pq /
+        // the slack weights only; now it is complete, and it is paid for:
+        if(is_ac) prevent_ac_cache_reuse();
+        else prevent_dc_cache_reuse();
     }
     return V;
 }
@@ -1595,13 +1677,17 @@ CplxVect LSGrid::pre_process_solver(
     GlobalBusIdVect & id_solver_to_me,
     GlobalBusIdVect & slack_bus_id_me,
     SolverBusIdVect & slack_bus_id_solver,
+    RealVect & slack_weights,
+    SolverBusIdVect & bus_pv,
+    SolverBusIdVect & bus_pq,
     bool /*is_ac*/,  // kept for API compatibility; DC now goes through pre_process_dc_solver
     const AlgoControl & solver_control,
     bool init_pv_vm_targets)
 {
     return _pre_process_solver_impl<cplx_type>(
         Vinit, Sbus, Ybus, id_me_to_solver, id_solver_to_me,
-        slack_bus_id_me, slack_bus_id_solver, solver_control, init_pv_vm_targets);
+        slack_bus_id_me, slack_bus_id_solver, slack_weights, bus_pv, bus_pq,
+        solver_control, init_pv_vm_targets);
 }
 
 CplxVect LSGrid::pre_process_dc_solver(
@@ -1612,11 +1698,15 @@ CplxVect LSGrid::pre_process_dc_solver(
     GlobalBusIdVect & id_solver_to_me,
     GlobalBusIdVect & slack_bus_id_me,
     SolverBusIdVect & slack_bus_id_solver,
+    RealVect & slack_weights,
+    SolverBusIdVect & bus_pv,
+    SolverBusIdVect & bus_pq,
     const AlgoControl & solver_control)
 {
     return _pre_process_solver_impl<real_type>(
         Vinit, Pbus, Bbus, id_me_to_solver, id_solver_to_me,
-        slack_bus_id_me, slack_bus_id_solver, solver_control, true);
+        slack_bus_id_me, slack_bus_id_solver, slack_weights, bus_pv, bus_pq,
+        solver_control, true);
 }
 
 CplxVect LSGrid::_get_results_back_to_orig_nodes(const Eigen::Ref<const CplxVect> & res_tmp,
@@ -2081,6 +2171,9 @@ CplxVect LSGrid::dc_pf(const Eigen::Ref<const CplxVect> & Vinit,
                                        id_dc_solver_to_me_,
                                        slack_bus_id_dc_me_,
                                        slack_bus_id_dc_solver_,
+                                       slack_weights_dc_,
+                                       bus_pv_dc_,
+                                       bus_pq_dc_,
                                        algo_controler_.dc_algo_controler());
     // start the solver (native real DC entry point)
     conv = _dc_algo.compute_pf_dc(

--- a/src/core/LSGrid.hpp
+++ b/src/core/LSGrid.hpp
@@ -1874,6 +1874,13 @@ class LS2G_API LSGrid final
         // Sbus stays a plain reference (not Eigen::Ref): forwarded into
         // _pre_process_solver_impl's inj, which forwards into prepare_injection,
         // which reassigns/resizes it.
+        // `slack_weights` / `bus_pv` / `bus_pq` complete the group: they used to be
+        // taken from this grid's own members whatever the caller passed for the rest,
+        // which meant a foreign builder silently wrote its pv-pq split and its slack
+        // weights into the grid's cache while leaving the grid's Ybus / Sbus behind.
+        // The whole group now travels together -- see the ownership check at the top
+        // of _pre_process_solver_impl, and BaseBatchSolverSynch::prepare_solver_input_base
+        // for the caller that owns its own.
         CplxVect pre_process_solver(const Eigen::Ref<const CplxVect> & Vinit,
                                     CplxVect & Sbus,
                                     Eigen::SparseMatrix<cplx_type> & Ybus,
@@ -1881,6 +1888,9 @@ class LS2G_API LSGrid final
                                     GlobalBusIdVect & id_solver_to_me,
                                     GlobalBusIdVect & slack_bus_id_me,
                                     SolverBusIdVect & slack_bus_id_solver,
+                                    RealVect & slack_weights,
+                                    SolverBusIdVect & bus_pv,
+                                    SolverBusIdVect & bus_pq,
                                     bool is_ac,
                                     const AlgoControl & solver_control,
                                     bool init_pv_vm_targets = true);
@@ -1897,6 +1907,9 @@ class LS2G_API LSGrid final
                                        GlobalBusIdVect & id_solver_to_me,
                                        GlobalBusIdVect & slack_bus_id_me,
                                        SolverBusIdVect & slack_bus_id_solver,
+                                       RealVect & slack_weights,
+                                       SolverBusIdVect & bus_pv,
+                                       SolverBusIdVect & bus_pq,
                                        const AlgoControl & solver_control);
 
         //for FDPF
@@ -2098,8 +2111,51 @@ class LS2G_API LSGrid final
                                           GlobalBusIdVect & id_solver_to_me,
                                           GlobalBusIdVect & slack_bus_id_me,
                                           SolverBusIdVect & slack_bus_id_solver,
+                                          RealVect & slack_weights,
+                                          SolverBusIdVect & bus_pv,
+                                          SolverBusIdVect & bus_pq,
                                           const AlgoControl & solver_control,
                                           bool init_pv_vm_targets);
+
+        // How many of the nine solver-side containers `_pre_process_solver_impl` was
+        // handed are this LSGrid's own cache for that family. Nine means the caller is
+        // the grid itself (ac_pf / dc_pf / check_solution, which pass their members);
+        // zero means a foreign builder (the batch algorithms, which own theirs). Any
+        // number in between is a programming error -- see the call site.
+        // Everything is compared as `const void *` so the two families' differently
+        // typed members can be handled by one runtime branch (C++14: no `if constexpr`).
+        // Nine pointer comparisons summed branchlessly, once per powerflow.
+        [[nodiscard]] int _nb_own_cache_args(bool is_ac,
+                                             const void * inj,
+                                             const void * mat,
+                                             const void * id_me_to_solver,
+                                             const void * id_solver_to_me,
+                                             const void * slack_bus_id_me,
+                                             const void * slack_bus_id_solver,
+                                             const void * slack_weights,
+                                             const void * bus_pv,
+                                             const void * bus_pq) const noexcept {
+            if(is_ac){
+                return (inj                 == (const void *) &acSbus_)
+                     + (mat                 == (const void *) &Ybus_ac_)
+                     + (id_me_to_solver     == (const void *) &id_me_to_ac_solver_)
+                     + (id_solver_to_me     == (const void *) &id_ac_solver_to_me_)
+                     + (slack_bus_id_me     == (const void *) &slack_bus_id_ac_me_)
+                     + (slack_bus_id_solver == (const void *) &slack_bus_id_ac_solver_)
+                     + (slack_weights       == (const void *) &slack_weights_ac_)
+                     + (bus_pv              == (const void *) &bus_pv_ac_)
+                     + (bus_pq              == (const void *) &bus_pq_ac_);
+            }
+            return (inj                 == (const void *) &dcPbus_)
+                 + (mat                 == (const void *) &Bbus_dc_)
+                 + (id_me_to_solver     == (const void *) &id_me_to_dc_solver_)
+                 + (id_solver_to_me     == (const void *) &id_dc_solver_to_me_)
+                 + (slack_bus_id_me     == (const void *) &slack_bus_id_dc_me_)
+                 + (slack_bus_id_solver == (const void *) &slack_bus_id_dc_solver_)
+                 + (slack_weights       == (const void *) &slack_weights_dc_)
+                 + (bus_pv              == (const void *) &bus_pv_dc_)
+                 + (bus_pq              == (const void *) &bus_pq_dc_);
+        }
         // matrix (re)initialization, overloaded per family (no `if constexpr`, C++14)
         void init_solver_matrix(Eigen::SparseMatrix<cplx_type> & mat, int nb_bus_solver){ init_Ybus(mat, nb_bus_solver); }
         void init_solver_matrix(Eigen::SparseMatrix<real_type> & mat, int nb_bus_solver){ init_Bbus(mat, nb_bus_solver); }

--- a/src/core/batch_algorithm/BaseBatchSolverSynch.hpp
+++ b/src/core/batch_algorithm/BaseBatchSolverSynch.hpp
@@ -497,6 +497,17 @@ class LS2G_API BaseBatchSolverSynch : protected BaseConstants
             id_me_to_solver_.clear();
             slack_ids_solver_ = SolverBusIdVect();
             slack_ids_me_ = GlobalBusIdVect();
+            // the pv-pq split and the slack weights belong to the same group as the
+            // matrix and the labelling above: cleared with them, rebuilt with them,
+            // and passed to the builder with them. They used to be fetched back out of
+            // _grid_model afterwards, which only worked because pre_process_solver
+            // wrote its pv-pq split into the grid's OWN cache whatever containers it
+            // had been handed -- a write-through that left the grid's cache holding
+            // this batch's split next to the grid's Ybus. See the ownership check in
+            // LSGrid::_pre_process_solver_impl.
+            bus_pv_ = SolverBusIdVect();
+            bus_pq_ = SolverBusIdVect();
+            slack_weights_ = RealVect();
             nb_buses_solver_ = -1;
 
             // fill the data correctly
@@ -511,6 +522,9 @@ class LS2G_API BaseBatchSolverSynch : protected BaseConstants
                     id_solver_to_me_,
                     slack_ids_me_,
                     slack_ids_solver_,
+                    slack_weights_,
+                    bus_pv_,
+                    bus_pq_,
                     ac_solver_used,
                     _algo_controler);
                 nb_buses_solver_ = static_cast<int>(Ybus_.cols());
@@ -524,23 +538,12 @@ class LS2G_API BaseBatchSolverSynch : protected BaseConstants
                     id_solver_to_me_,
                     slack_ids_me_,
                     slack_ids_solver_,
+                    slack_weights_,
+                    bus_pv_,
+                    bus_pq_,
                     _algo_controler);
                 nb_buses_solver_ = static_cast<int>(Bbus_.cols());
             }
-
-            // extract relevant information
-            // ask for the family this batch actually solved with: the grid keeps
-            // one pv-pq split and one set of slack weights PER family, and the
-            // family-less accessors answer for AC whenever an AC powerflow has run
-            // on this grid -- which is not necessarily the one we just built.
-            const SolverBusIdVect & gm_bus_pv = ac_solver_used ? _grid_model.get_ac_pv_solver() : _grid_model.get_dc_pv_solver();
-            const SolverBusIdVect & gm_bus_pq = ac_solver_used ? _grid_model.get_ac_pq_solver() : _grid_model.get_dc_pq_solver();
-            const RealVect gm_bus_sw = ac_solver_used ? _grid_model.get_ac_slack_weights_solver() : _grid_model.get_dc_slack_weights_solver();
-
-            // TODO copies are made here, which is not ideal
-            bus_pv_ = gm_bus_pv;  // was _to_intvect()
-            bus_pq_ = gm_bus_pq;  // was _to_intvect()
-            slack_weights_ = gm_bus_sw;
             return res;
         }
 

--- a/src/tests/test_batch_voltage_control.cpp
+++ b/src/tests/test_batch_voltage_control.cpp
@@ -316,6 +316,28 @@ TEST_CASE("a batch on an already-solved grid regulates too", "[batch][vctrl]")
     check_same_voltages(one_step_timeseries(grid, 2), ref);
 }
 
+TEST_CASE("the source grid still solves correctly after a batch ran on it", "[batch][vctrl]")
+{
+    // The batch copies the grid, but the copy is not where this could go wrong. Every
+    // batch prep calls pre_process_solver with the batch's OWN containers, and that
+    // call publishes the batch's labelling and pv-pq split into the grid it was called
+    // on -- next to a Ybus / Sbus it did not publish. On the copy that mixture is
+    // harmless (the copy never runs a powerflow of its own). The point here is the
+    // contract that makes it harmless anywhere: a build into someone else's containers
+    // always leaves that grid rebuilding, so no cache is ever half this grid's and
+    // half someone else's. Solve the source grid on both sides of a batch and it must
+    // not move.
+    LSGrid ref_grid = make_remote_gen_grid();
+    const CplxVect ref = single_shot(ref_grid);
+
+    LSGrid grid = make_remote_gen_grid();
+    check_same_voltages(single_shot(grid), ref);
+    check_same_voltages(one_step_timeseries(grid, 2), ref);
+    check_same_voltages(single_shot(grid), ref);   // ... and again, after the batch
+    check_same_voltages(empty_contingency(grid), ref);
+    check_same_voltages(single_shot(grid), ref);
+}
+
 TEST_CASE("two generators sharing one regulated bus share it in a batch too", "[batch][vctrl]")
 {
     // Sharing is the supported multi-controller case (test_powerflow_algorithm.cpp

--- a/src/tests/test_cache_reuse.cpp
+++ b/src/tests/test_cache_reuse.cpp
@@ -363,6 +363,116 @@ TEST_CASE("the structural half of the guard is what stands between unset_changes
 }
 
 // ---------------------------------------------------------------------------
+// 3b. the cache belongs to exactly one owner
+// ---------------------------------------------------------------------------
+
+TEST_CASE("a build into someone else's containers never leaves a half-replaced cache",
+          "[LSGrid][cache_reuse][batch]")
+{
+    // `pre_process_solver` / `pre_process_dc_solver` serve two kinds of caller.
+    // `ac_pf` / `dc_pf` / `check_solution` hand over the grid's OWN per-family
+    // members: what comes out is the family cache. The batch algorithms
+    // (BaseBatchSolverSynch and everything built on it) hand over containers they own
+    // and solve them with an algorithm of their own.
+    //
+    // For the second kind, the grid's members are still a real output: the NR
+    // extensions are not built from what the solver was handed, they are pulled back
+    // out of the LSGrid through `lsgrid_ptr` (bus labelling, slack ids, AND the pv-pq
+    // split -- see fill_voltage_control_solver_data's use of bus_pq_ac_). So the
+    // build has to publish there, and that publication is what leaves the grid's own
+    // cache a mixture: the caller's labelling and split next to the grid's own Ybus /
+    // Sbus, which are deliberately not published (they are the expensive half).
+    //
+    // Right size, passes every structural check, reads as valid. The only thing that
+    // makes it safe is that the grid is then told to rebuild -- so that is what these
+    // sections pin. (The other half of the contract, that the nine containers may not
+    // be MIXED between owners in one call, is enforced by a throw in
+    // _pre_process_solver_impl; it cannot be reached from outside the class, since
+    // building a mixed call needs non-const access to private members.)
+    SECTION("AC"){
+        LSGrid grid = make_grid();
+        const CplxVect v_before = solve_ac(grid);
+        REQUIRE(v_before.size() == 14);
+        REQUIRE_FALSE(grid.get_ac_algo_controler().need_reset_solver());  // cache is live
+
+        // exactly what a batch does: its own containers, its own control
+        CplxVect foreign_sbus;
+        Eigen::SparseMatrix<cplx_type> foreign_ybus;
+        ls2g::SolverBusIdVect foreign_id_me_to_solver, foreign_slack_solver, foreign_pv, foreign_pq;
+        ls2g::GlobalBusIdVect foreign_id_solver_to_me, foreign_slack_me;
+        RealVect foreign_sw;
+        const ls2g::AlgoControl foreign_control;  // default ctor: everything changed
+        grid.pre_process_solver(flat_start(grid), foreign_sbus, foreign_ybus,
+                                foreign_id_me_to_solver, foreign_id_solver_to_me,
+                                foreign_slack_me, foreign_slack_solver,
+                                foreign_sw, foreign_pv, foreign_pq,
+                                true, foreign_control);
+
+        // it built into the caller's containers ...
+        CHECK(foreign_ybus.rows() == 14);
+        CHECK(foreign_ybus.cols() == 14);
+        CHECK(foreign_sbus.size() == 14);
+        CHECK(foreign_sw.size() == 14);
+        CHECK(foreign_pq.size() > 0);
+        // ... published the pv-pq split the NR extensions read back out of the grid ...
+        CHECK(grid.get_ac_pq_solver().size() == foreign_pq.size());
+        CHECK(grid.get_ac_pv_solver().size() == foreign_pv.size());
+        // ... and left this grid unable to reuse what is now a mixture
+        CHECK(grid.get_ac_algo_controler().need_reset_solver());
+
+        // so the grid's own next powerflow is unaffected by the detour
+        CHECK((solve_ac(grid) - v_before).norm() < 1e-9);
+    }
+    SECTION("DC"){
+        LSGrid grid = make_grid();
+        const CplxVect v_before = solve_dc(grid);
+        REQUIRE(v_before.size() == 14);
+        REQUIRE_FALSE(grid.get_dc_algo_controler().need_reset_solver());
+
+        RealVect foreign_pbus;
+        Eigen::SparseMatrix<real_type> foreign_bbus;
+        ls2g::SolverBusIdVect foreign_id_me_to_solver, foreign_slack_solver, foreign_pv, foreign_pq;
+        ls2g::GlobalBusIdVect foreign_id_solver_to_me, foreign_slack_me;
+        RealVect foreign_sw;
+        const ls2g::AlgoControl foreign_control;
+        grid.pre_process_dc_solver(flat_start(grid), foreign_pbus, foreign_bbus,
+                                   foreign_id_me_to_solver, foreign_id_solver_to_me,
+                                   foreign_slack_me, foreign_slack_solver,
+                                   foreign_sw, foreign_pv, foreign_pq,
+                                   foreign_control);
+
+        CHECK(foreign_bbus.rows() == 14);
+        CHECK(foreign_pbus.size() == 14);
+        CHECK(grid.get_dc_pq_solver().size() == foreign_pq.size());
+        CHECK(grid.get_dc_algo_controler().need_reset_solver());
+
+        CHECK((solve_dc(grid) - v_before).norm() < 1e-9);
+    }
+    SECTION("one family's foreign build does not disturb the other family's cache"){
+        LSGrid grid = make_grid();
+        const CplxVect v_ac_before = solve_ac(grid);
+        const CplxVect v_dc_before = solve_dc(grid);
+
+        RealVect foreign_pbus;
+        Eigen::SparseMatrix<real_type> foreign_bbus;
+        ls2g::SolverBusIdVect foreign_id_me_to_solver, foreign_slack_solver, foreign_pv, foreign_pq;
+        ls2g::GlobalBusIdVect foreign_id_solver_to_me, foreign_slack_me;
+        RealVect foreign_sw;
+        const ls2g::AlgoControl foreign_control;
+        grid.pre_process_dc_solver(flat_start(grid), foreign_pbus, foreign_bbus,
+                                   foreign_id_me_to_solver, foreign_id_solver_to_me,
+                                   foreign_slack_me, foreign_slack_solver,
+                                   foreign_sw, foreign_pv, foreign_pq,
+                                   foreign_control);
+
+        CHECK(grid.get_dc_algo_controler().need_reset_solver());
+        CHECK_FALSE(grid.get_ac_algo_controler().need_reset_solver());  // AC untouched
+        CHECK((solve_ac(grid) - v_ac_before).norm() < 1e-9);
+        CHECK((solve_dc(grid) - v_dc_before).norm() < 1e-9);
+    }
+}
+
+// ---------------------------------------------------------------------------
 // 4. nothing cached ever crosses a serialization boundary
 // ---------------------------------------------------------------------------
 

--- a/src/tests/test_cache_reuse.cpp
+++ b/src/tests/test_cache_reuse.cpp
@@ -301,6 +301,67 @@ TEST_CASE("a 'nothing changed' claim never makes a powerflow read data that was 
     }
 }
 
+TEST_CASE("the structural half of the guard is what stands between unset_changes and an OOB read",
+          "[LSGrid][cache_reuse][unset_changes]")
+{
+    // The sections above all reach `unset_changes()` through
+    // `allow_cache_reuse(false)`, ie with BOTH families told never to reuse. The
+    // family that then runs is caught by the guard's FIRST term
+    // (`!allow_*_cache_reuse_`) before any of the structural comparisons matter,
+    // so those sections pass even with the structural half of the guard deleted.
+    //
+    // Turning off only the OTHER family is what exercises it. `unset_changes()`
+    // returns early only when both families cache automatically, so switching one
+    // off re-arms it -- and it marks BOTH families "in sync", including the one
+    // still allowed to reuse and whose solver-side data may never have been built.
+    // For that family nothing but the structural comparisons is left: with them
+    // removed, each of the three sequences below indexes a default-constructed
+    // id map / matrix / injection vector with bus ids in the hundreds. Under
+    // -O3 -DNDEBUG (what the wheels ship) that is a segfault, not an error.
+    //
+    // So: this is the test to look at before "the cache is reused by default now,
+    // the consistency check can go". It can go from `unset_changes()` only if
+    // `unset_changes()` stops making the claim on a family that cannot back it.
+    LSGrid ref_ac = make_grid();
+    LSGrid ref_dc = make_grid();
+    const CplxVect v_ac_ref = solve_ac(ref_ac);
+    const CplxVect v_dc_ref = solve_dc(ref_dc);
+
+    SECTION("DC still automatic, never solved, and unset_changes marks it in sync"){
+        LSGrid grid = make_grid();
+        grid.allow_ac_cache_reuse(false);   // only AC: unset_changes() is no longer a no-op
+        REQUIRE(grid.get_allow_dc_cache_reuse());
+        grid.unset_changes();               // claims DC is in sync -- it has built nothing
+        REQUIRE_FALSE(grid.get_dc_algo_controler().need_reset_solver());
+
+        const CplxVect v = solve_dc(grid);
+        REQUIRE(v.size() == 14);
+        CHECK((v - v_dc_ref).norm() < 1e-9);
+    }
+    SECTION("AC still automatic, never solved, and unset_changes marks it in sync"){
+        LSGrid grid = make_grid();
+        grid.allow_dc_cache_reuse(false);
+        REQUIRE(grid.get_allow_ac_cache_reuse());
+        grid.unset_changes();
+        REQUIRE_FALSE(grid.get_ac_algo_controler().need_reset_solver());
+
+        const CplxVect v = solve_ac(grid);
+        REQUIRE(v.size() == 14);
+        CHECK((v - v_ac_ref).norm() < 1e-9);
+    }
+    SECTION("the other family solved first, so the grid is warm but this family is not"){
+        LSGrid grid = make_grid();
+        REQUIRE(solve_ac(grid).size() == 14);  // AC cache is live, DC has nothing
+        grid.allow_ac_cache_reuse(false);
+        grid.unset_changes();
+        REQUIRE_FALSE(grid.get_dc_algo_controler().need_reset_solver());
+
+        const CplxVect v = solve_dc(grid);
+        REQUIRE(v.size() == 14);
+        CHECK((v - v_dc_ref).norm() < 1e-9);
+    }
+}
+
 // ---------------------------------------------------------------------------
 // 4. nothing cached ever crosses a serialization boundary
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Two commits. The first is tests only. The second is the actual fix.

This started from the question "now that the cache is reused by default, can the consistency check go from the internal path?". Answer: no, and measuring why turned up a separate, real ownership bug in the batch path.

---

## Commit 1 — `test: pin the structural half of the cache-consistency guard`

**No production code.** One test case added to `src/tests/test_cache_reuse.cpp`.

### Why the check can't go

Cost of the guard, callgrind instruction counts on the exotic-elements IEEE14 grid, taken as the slope between 200 and 1200 powerflows so grid construction cancels:

| | with guard | without | delta |
|---|---|---|---|
| AC, one load changed then solve | 839 340 instr/pf | 839 290 | −51 (0.006 %) |
| DC, warm cache, nothing changed | 28 095 instr/pf | 28 054 | −42 (0.15 %) |

The DC row is the floor — the cheapest powerflow this library can run (2.8 µs here). Invisible in wall clock: run-to-run spread on one unchanged binary was several times the difference.

And it is still load-bearing. `unset_changes()` returns early only when **both** families cache automatically. Switching one off re-arms it, and it marks *both* families "in sync" — including the one still allowed to reuse, whose solver-side data may never have been built. All three of these segfault under `-O3 -DNDEBUG` with the structural comparisons removed:

```python
grid.allow_ac_cache_reuse(False); grid.unset_changes(); grid.dc_pf(...)
grid.allow_dc_cache_reuse(False); grid.unset_changes(); grid.ac_pf(...)
grid.ac_pf(...); grid.allow_ac_cache_reuse(False); grid.unset_changes(); grid.dc_pf(...)
```

### The coverage gap this closes

Every existing `[unset_changes]` section reaches it through `allow_cache_reuse(false)` — **both** families — so the family that runs is stopped by the guard's first term (`!allow_*_cache_reuse_`) before any structural comparison matters. **The whole suite passes with the structural half deleted.** The new test case leaves one family automatic, which is what actually exercises it: it fails with SIGSEGV without the guard and passes with it.

---

## Commit 2 — `fix: the solver-side data of a powerflow belongs to exactly one owner`

### What the bug is

`pre_process_solver` / `pre_process_dc_solver` serve two kinds of caller:

- **The grid itself** (`ac_pf` / `dc_pf` / `check_solution`) hands over its own per-family members. What comes out *is* the family cache, and this grid's algorithm consumes it.
- **A foreign builder** — the batch algorithms, via `BaseBatchSolverSynch::prepare_solver_input_base` — hands over containers it owns (`Ybus_`, `Sbus_`, `id_me_to_solver_`, …) and solves them with an algorithm of its own.

Nine containers make up the group. Six were parameters. **Three — `slack_weights`, `bus_pv`, `bus_pq` — were not:** they were bound to `slack_weights_ac_` / `bus_pv_ac_` / `bus_pq_ac_` (or the `_dc_` set) whatever the caller passed for the other six. That was the old first three lines of `_pre_process_solver_impl`.

Three consequences, all silent:

1. **A batch build wrote its pv-pq split and slack weights into the grid's own cache**, next to a `Ybus` / `Sbus` built for a different bus labelling. The result is the right size and passes every structural check — and the grid went on claiming that cache was reusable. Checked directly against the pre-fix core: `need_reset_solver()` stays **false** across a foreign build that just replaced the labelling.

2. **The cache-consistency guard sized one owner's containers against the other's.** Sizes agree far more often than labellings do, so a caller reusing its containers with a "nothing changed" control would have skipped `fillpv_pq` and stamped *this grid's* pv-pq split onto *its* system — converged, plausible, wrong. Unreachable today only because every batch path calls `tell_all_changed()` first. I.e. until the first one that tries to keep its `Ybus` across scenarios, which is the obvious next optimization in there.

3. **`_algo.reset()` and `_algo.tell_solver_control()` fired on the grid's own algorithm** for a solve it would never perform, discarding a factorization the grid's next powerflow would have reused.

**To be clear about blast radius:** `BaseBatchSolverSynch` holds `LSGrid _grid_model` *by value*, so nothing user-facing is broken today. This is preventive.

### What changed

Read in this order:

- **`src/core/LSGrid.cpp:1414-1454`** — the new ownership block at the top of `_pre_process_solver_impl`. It replaces the three `is_ac ? member : member` bindings. `_nb_own_cache_args` (defined at `src/core/LSGrid.hpp:2128`) counts how many of the nine containers are this grid's own — nine pointer comparisons summed branchlessly. Nine means the grid called us; zero means a foreign builder; anything in between throws rather than building a chimera. That throw is an in-tree invariant only: the members are private, so a mixed call cannot be constructed from outside the class.

- **the guard, just below** — gains `!own_cache ||` as its first term. `solver_control`, the connectivity snapshot `init_bus_status()` compares against, and the flags it raises all describe *this* grid and say nothing about a caller's containers. So a foreign build always rebuilds. Free — they all asked for it anyway — and it makes the mixed-owner fast path *impossible* rather than merely unreached.

- **the two algorithm blocks** — now gated on `own_cache`. The grid's algorithm is only touched when it is the one that will run.

- **`src/core/LSGrid.cpp:1624-1668`** — the publication block, reworked. A foreign build still has to write its labelling into the members, because the NR extensions read the members rather than what the solver was handed. **Note `bus_pq_ac_` in that list**: `fill_voltage_control_solver_data` needs it, and the old write-through supplied it *by accident*. So the write-through wasn't purely a mistake — it was load-bearing and undocumented. It is now explicit, complete, and paid for: `prevent_ac_cache_reuse()` / `prevent_dc_cache_reuse()` at the end, so the grid rebuilds rather than reusing something half its own and half the caller's.

- **`src/core/batch_algorithm/BaseBatchSolverSynch.hpp:508`** — the batch clears and passes its own `bus_pv_` / `bus_pq_` / `slack_weights_`, and no longer fetches them back out of `_grid_model` afterwards. That also removes the three copies its own `TODO copies are made here, which is not ideal` flagged.

- signature change on the two `pre_process_*` methods (three added parameters). **C++ only — neither is exposed to python**, and the plugin API (`ls2g_api.hpp`) does not reference them.

### Cost

Same callgrind method as above:

| | before | after | delta |
|---|---|---|---|
| AC powerflow | 839 340 instr/pf | 839 431 | +90 (+0.011 %) |
| DC, warm cache | 28 095 instr/pf | 28 194 | +99 (+0.35 %) |

The DC figure is the ceiling. Nothing shows in wall clock. Most of it is argument marshalling for three more reference parameters, not the ownership check itself.

### Tests

- `src/tests/test_cache_reuse.cpp:369` — a build into a caller's containers leaves the grid rebuilding rather than half-replaced (AC, DC, and that one family's foreign build leaves the other family's cache alone).
- `src/tests/test_batch_voltage_control.cpp:319` — the source grid still solves identically on both sides of a `TimeSeries` and a `ContingencyAnalysis`.

**Worth knowing before you read them:** that batch-level test **passes against the pre-fix core too**. Today the batch rebuilds a labelling identical to the grid's, so the mixture is benign — it guards the contract rather than reproducing a live failure. What does separate pre- from post-fix is the invariant in the `test_cache_reuse.cpp` sections: pre-fix, a foreign build left `need_reset_solver()` false.

### Verified

210 test cases / 5814 assertions pass under Release, under C++14 (`LS2G_CXX_STANDARD=14`), under ASan+UBSan, and under valgrind (0 errors, no leaks).

The python layer could **not** be exercised — no pybind11 / numpy on the machine this ran on. No python-visible API changed, but `lightsim2grid/tests/` has not been run against this.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UtvkqXMvgCig75gruZCs7u

---
_Generated by [Claude Code](https://claude.ai/code/session_01UtvkqXMvgCig75gruZCs7u)_