### PR TITLE
A solver family's cached data is one object, not eighteen members

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -154,9 +154,17 @@ TODO: a "combine mode" axis for ``ScenarioSweepCPP`` choosing between the curren
   labelling, ``Ybus`` / ``Sbus``, the slack, the PV / PQ split and each family's connectivity
   snapshot are one picture of the grid taken at one instant, expressed in ONE bus labelling; they
   are now built, handed over and retired as one unit. ``LSGrid`` holds ``ac_cache_`` / ``dc_cache_``;
-  ``pre_process_solver`` / ``pre_process_dc_solver`` (C++ only, never exposed to python) take one
-  cache reference instead of seven loose containers. **This changes ``LSGrid``'s member layout**, so
-  anything that casts an ``LSGrid`` across a module boundary (``gpusim2grid``) must be rebuilt
+  ``pre_process_solver`` / ``pre_process_dc_solver`` (C++ only, never exposed to python) no longer
+  take a cache at all: they are defined by the fact that they build ``ac_cache_`` / ``dc_cache_`` for
+  this grid's own algorithm. Building a solver input into a cache the CALLER owns -- what the batch
+  algorithms do -- is now a separate pair, ``build_solver_input`` / ``build_dc_solver_input``, rather
+  than the same function distinguishing the two by comparing the cache's address. The two really are
+  different operations: the own-cache pair applies the reuse policy and resets / re-configures
+  ``_algo``; the foreign pair never re-stamps (the change flags describe THIS grid and say nothing
+  about someone else's cache), leaves this grid's algorithms alone, and publishes the labelling and
+  PV / PQ split into this grid's cache for the NR extensions before retiring it. The assembly itself
+  is shared, unchanged, in one private ``_build_into_cache``.
+  **This changes ``LSGrid``'s member layout**, so anything that casts an ``LSGrid`` across a module boundary (``gpusim2grid``) must be rebuilt
   against these headers -- which the plugin ABI policy in ``docs/solver_plugin.rst`` already
   requires. Nothing changes for python.
 - [FIXED] a batch algorithm no longer writes half of what it builds into the grid's cache.
@@ -262,7 +270,7 @@ TODO: a "combine mode" axis for ``ScenarioSweepCPP`` choosing between the curren
   ``LightSimBackend.runpf`` already carried a python-side workaround for the second one (the
   ``self._last_dc`` ``tell_solver_need_reset()``, comment: "otherwise might segfault"), and
   ``check_solution`` guarded against the first one locally with ``id_me_to_ac_solver_.size() > 0``.
-  The check now lives where the reuse decision is made instead: ``_pre_process_solver_impl``
+  The check now lives where the reuse decision is made instead: ``_pre_process_own_cache``
   verifies, in a handful of integer comparisons, that the data the flags describe is actually
   there, and falls back to a full rebuild otherwise. A wrong "nothing changed" can now cost time,
   never memory safety.

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -149,6 +149,33 @@ TODO: a "combine mode" axis for ``ScenarioSweepCPP`` choosing between the curren
   a one-shot invalidation of what a family cached (as opposed to the ``allow_*`` mode above).
   ``prevent_cache_reuse()`` is the new name of ``tell_solver_need_reset()``, which still exists and
   behaves identically. Both are now documented rather than tagged "internal, do not use".
+- [BREAKING] everything a solver family caches now lives in one object, ``SolverSideCache``
+  (``src/core/SolverSideCache.hpp``), instead of eighteen separate ``LSGrid`` members. The bus
+  labelling, ``Ybus`` / ``Sbus``, the slack, the PV / PQ split and each family's connectivity
+  snapshot are one picture of the grid taken at one instant, expressed in ONE bus labelling; they
+  are now built, handed over and retired as one unit. ``LSGrid`` holds ``ac_cache_`` / ``dc_cache_``;
+  ``pre_process_solver`` / ``pre_process_dc_solver`` (C++ only, never exposed to python) take one
+  cache reference instead of seven loose containers. **This changes ``LSGrid``'s member layout**, so
+  anything that casts an ``LSGrid`` across a module boundary (``gpusim2grid``) must be rebuilt
+  against these headers -- which the plugin ABI policy in ``docs/solver_plugin.rst`` already
+  requires. Nothing changes for python.
+- [FIXED] a batch algorithm no longer writes half of what it builds into the grid's cache.
+  ``slack_weights``, ``bus_pv`` and ``bus_pq`` were not parameters of ``pre_process_solver``: they
+  were taken from the grid's own members whatever the caller passed for the other six containers.
+  So a ``TimeSeries`` / ``ContingencyAnalysis`` build wrote its PV / PQ split and its slack weights
+  into the grid's cache, next to a ``Ybus`` built for a different labelling, and left that grid
+  still claiming the result was reusable; and the reuse guard compared one owner's container sizes
+  against the other's, so a caller that reused its own containers with a "nothing changed" control
+  would have skipped ``fillpv_pq`` and stamped the grid's PV / PQ split onto its own system --
+  converged, plausible, wrong. Nothing reached that (every batch asks for a full rebuild, and works
+  on a private copy of the grid), which is what made it worth closing before something did. A cache
+  being one object removes the whole class of mistake: there is no way to hand a function half of
+  it. What a foreign build still publishes into the grid -- the labelling and the split, which the
+  NR extensions read back through ``lsgrid_ptr`` rather than from what the solver was handed -- now
+  retires that grid's cache instead of leaving it a mixture.
+- [FIXED] a build into a caller's cache no longer resets or reconfigures the grid's own solver.
+  ``_algo.reset()`` / ``tell_solver_control()`` fired for a solve the grid would never perform,
+  discarding a factorization its next powerflow would have reused.
 - [BREAKING] the AC and the DC solver families no longer share ANY solver-side data.
   ``slack_weights``, the PV split and the PQ split were single members overwritten by whichever
   family solved last -- unlike ``Ybus`` / ``Sbus`` / the id maps, which were already per family.

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -124,31 +124,8 @@ TODO: a "combine mode" axis for ``ScenarioSweepCPP`` choosing between the curren
       contingency) and a cartesian one ("every registered contingency x every
       injection profile").
 
-[1.0.0] 2026-08-28
+[1.0.1] 2026-xx-yy
 --------------------
-- [BREAKING] **solver cache reuse is now automatic and on by default**, per solver family.
-  A powerflow reuses what the previous one of the same family built -- the compact bus labelling,
-  ``Ybus`` / ``Sbus``, the PV / PQ split, the slack weights -- and only re-stamps what the grid
-  reports as modified since. Every powerflow marks its own family "in sync" on the way out, so
-  ``LSGrid.unset_changes()`` is no longer needed: it is a no-op whenever reuse is enabled, and is
-  kept purely for backward compatibility. Worth ~24% of the time of a powerflow on a 14-bus grid,
-  and nothing has to be called to get it.
-  This is breaking for code that modifies the grid through a path that bypasses ``LSGrid``'s own
-  ``change_*`` / ``deactivate_*`` / ``reactivate_*`` methods (direct manipulation of the C++
-  containers, for instance). Such code used to get away with it as long as it never called
-  ``unset_changes()``; now it must say so with ``prevent_cache_reuse()`` (or the narrower
-  ``tell_recompute_ybus`` / ``tell_recompute_sbus``), or turn reuse off altogether with
-  ``allow_cache_reuse(False)``. Everything that goes through the public API is unaffected: a
-  completeness sweep over every mutating ``LSGrid`` method (``src/tests/test_cache_reuse.cpp``)
-  checks that the cached and the fully-rebuilt answer agree.
-- [ADDED] ``LSGrid.allow_cache_reuse(bool)`` / ``allow_ac_cache_reuse`` / ``allow_dc_cache_reuse``
-  and their ``get_*`` counterparts: turn cache reuse off (durably) for one family or both. The
-  answer is identical either way, so this is a debugging switch ("is this wrong number a caching
-  artefact?") and an escape hatch for code that mutates the containers directly.
-- [ADDED] ``LSGrid.prevent_cache_reuse()`` / ``prevent_ac_cache_reuse()`` / ``prevent_dc_cache_reuse()``:
-  a one-shot invalidation of what a family cached (as opposed to the ``allow_*`` mode above).
-  ``prevent_cache_reuse()`` is the new name of ``tell_solver_need_reset()``, which still exists and
-  behaves identically. Both are now documented rather than tagged "internal, do not use".
 - [BREAKING] everything a solver family caches now lives in one object, ``SolverSideCache``
   (``src/core/SolverSideCache.hpp``), instead of eighteen separate ``LSGrid`` members. The bus
   labelling, ``Ybus`` / ``Sbus``, the slack, the PV / PQ split and each family's connectivity
@@ -206,6 +183,32 @@ TODO: a "combine mode" axis for ``ScenarioSweepCPP`` choosing between the curren
   the check is free. What remains on the powerflow path is the ``allow_*_cache_reuse`` switch plus
   a debug-only assertion, so a future third claimant is caught by the C++ suite (run under ASan,
   UBSan and valgrind in CI) at no cost in release wheels.
+
+[1.0.0] 2026-08-28
+--------------------
+- [BREAKING] **solver cache reuse is now automatic and on by default**, per solver family.
+  A powerflow reuses what the previous one of the same family built -- the compact bus labelling,
+  ``Ybus`` / ``Sbus``, the PV / PQ split, the slack weights -- and only re-stamps what the grid
+  reports as modified since. Every powerflow marks its own family "in sync" on the way out, so
+  ``LSGrid.unset_changes()`` is no longer needed: it is a no-op whenever reuse is enabled, and is
+  kept purely for backward compatibility. Worth ~24% of the time of a powerflow on a 14-bus grid,
+  and nothing has to be called to get it.
+  This is breaking for code that modifies the grid through a path that bypasses ``LSGrid``'s own
+  ``change_*`` / ``deactivate_*`` / ``reactivate_*`` methods (direct manipulation of the C++
+  containers, for instance). Such code used to get away with it as long as it never called
+  ``unset_changes()``; now it must say so with ``prevent_cache_reuse()`` (or the narrower
+  ``tell_recompute_ybus`` / ``tell_recompute_sbus``), or turn reuse off altogether with
+  ``allow_cache_reuse(False)``. Everything that goes through the public API is unaffected: a
+  completeness sweep over every mutating ``LSGrid`` method (``src/tests/test_cache_reuse.cpp``)
+  checks that the cached and the fully-rebuilt answer agree.
+- [ADDED] ``LSGrid.allow_cache_reuse(bool)`` / ``allow_ac_cache_reuse`` / ``allow_dc_cache_reuse``
+  and their ``get_*`` counterparts: turn cache reuse off (durably) for one family or both. The
+  answer is identical either way, so this is a debugging switch ("is this wrong number a caching
+  artefact?") and an escape hatch for code that mutates the containers directly.
+- [ADDED] ``LSGrid.prevent_cache_reuse()`` / ``prevent_ac_cache_reuse()`` / ``prevent_dc_cache_reuse()``:
+  a one-shot invalidation of what a family cached (as opposed to the ``allow_*`` mode above).
+  ``prevent_cache_reuse()`` is the new name of ``tell_solver_need_reset()``, which still exists and
+  behaves identically. Both are now documented rather than tagged "internal, do not use".
 - [BREAKING] the AC and the DC solver families no longer share ANY solver-side data.
   ``slack_weights``, the PV split and the PQ split were single members overwritten by whichever
   family solved last -- unlike ``Ybus`` / ``Sbus`` / the id maps, which were already per family.
@@ -270,7 +273,7 @@ TODO: a "combine mode" axis for ``ScenarioSweepCPP`` choosing between the curren
   ``LightSimBackend.runpf`` already carried a python-side workaround for the second one (the
   ``self._last_dc`` ``tell_solver_need_reset()``, comment: "otherwise might segfault"), and
   ``check_solution`` guarded against the first one locally with ``id_me_to_ac_solver_.size() > 0``.
-  The check now lives where the reuse decision is made instead: ``_pre_process_own_cache``
+  The check now lives where the reuse decision is made instead: ``_pre_process_solver_impl``
   verifies, in a handful of integer comparisons, that the data the flags describe is actually
   there, and falls back to a full rebuild otherwise. A wrong "nothing changed" can now cost time,
   never memory safety.

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -176,6 +176,28 @@ TODO: a "combine mode" axis for ``ScenarioSweepCPP`` choosing between the curren
 - [FIXED] a build into a caller's cache no longer resets or reconfigures the grid's own solver.
   ``_algo.reset()`` / ``tell_solver_control()`` fired for a solve the grid would never perform,
   discarding a factorization its next powerflow would have reused.
+- [FIXED] ``LSGrid.unset_changes()`` no longer papers over a change that has not been solved.
+  Its contract is "a powerflow has run, past changes can be forgotten" -- but nothing checked that
+  a powerflow *had* run, so calling it with a modification outstanding cleared the flags that
+  described it and the next powerflow re-solved the OLD system: converged, plausible, and wrong by
+  0.038 pu on a 14-bus grid with one line deactivated. It now refuses instead: each family is
+  marked only if its change control reports nothing outstanding AND its cache is structurally
+  intact and still matches the grid's connectivity; a family that cannot back the claim is retired
+  and rebuilds on its next powerflow. It still applies to BOTH families, as it always has.
+  Note a cache cannot detect this by self-inspection -- changing a line's impedance, a transformer
+  tap or a load target leaves every vector size and every bus status exactly as they were -- which
+  is why the new ``AlgoControl.nothing_changed()`` is the load-bearing test. The element containers
+  remain the sole authority on what changed: they declare it through ``AlgoControl`` in their own
+  modifiers, and ``unset_changes()`` only reads that back. The structural check beside it answers a
+  different question (is the data there at all, and the right shape) and says nothing about change.
+- [ADDED] ``AlgoControl.nothing_changed()``: has every change this control tracks already been
+  consumed by a solve? The exact negation of ``tell_all_changed()``.
+- the powerflow path no longer re-verifies that the data behind a "nothing changed" claim exists.
+  The two entry points that can make such a claim without having built anything --
+  ``unset_changes()`` and ``check_solution()`` -- now verify it themselves, at an altitude where
+  the check is free. What remains on the powerflow path is the ``allow_*_cache_reuse`` switch plus
+  a debug-only assertion, so a future third claimant is caught by the C++ suite (run under ASan,
+  UBSan and valgrind in CI) at no cost in release wheels.
 - [BREAKING] the AC and the DC solver families no longer share ANY solver-side data.
   ``slack_weights``, the PV split and the PQ split were single members overwritten by whichever
   family solved last -- unlike ``Ybus`` / ``Sbus`` / the id maps, which were already per family.

--- a/src/core/LSGrid.cpp
+++ b/src/core/LSGrid.cpp
@@ -739,7 +739,6 @@ CplxVect LSGrid::ac_pf(const Eigen::Ref<const CplxVect> & Vinit,
     // pre process the data to define a proper jacobian matrix, the proper voltage vector etc.
     bool is_ac = true;
     CplxVect V = pre_process_solver(Vinit,
-                                    ac_cache_,
                                     algo_controler_.ac_algo_controler());
 
     // start the solver
@@ -1267,14 +1266,13 @@ CplxVect LSGrid::check_solution(const Eigen::Ref<const CplxVect> & V_proposed, b
     // default-constructed (empty) size, and `fill_hvdc_droop_solver_data`'s
     // `id_me_to_solver[bus_id]` lookup (bus ids in the hundreds/thousands) then read
     // out of bounds -- a silent, hard-to-reproduce segfault instead of a clean rebuild.
-    // (the cache-consistency guard in _pre_process_solver_impl now catches this case too,
+    // (the cache-consistency guard in _pre_process_own_cache now catches this case too,
     // and the two families' variants of it; this stays as the local, cheaper statement of
     // what check_solution itself may assume)
     if(ac_cache_.may_be_reused() && ac_cache_.is_consistent(substations_.nb_bus())){
         reset_solver.tell_none_changed();
     }
     CplxVect V = pre_process_solver(V_proposed,
-                                    ac_cache_,
                                     reset_solver,
                                     false);  // do NOT snap regulated buses to their target: we are testing V_proposed as-is
 
@@ -1369,88 +1367,26 @@ void LSGrid::prepare_injection(RealVect & Pbus, bool redo_all, bool converter_ch
         }
 }
 
+// ---------------------------------------------------------------------------
+// THE BUILD, and the two things a caller can want done around it.
+//
+// `_build_into_cache` assembles a solver family's whole input out of this grid.
+// It is the same work whoever asked, and it is the bulk of what used to be one
+// function serving two callers through an `own_cache` flag. What the two callers
+// actually disagree about is everything AROUND it -- the reuse policy and the
+// algorithm on one side, publication and retirement on the other -- so that is
+// what the two entry points below are, and the flag is gone.
+// ---------------------------------------------------------------------------
 template<class MatScalar>
-CplxVect LSGrid::_pre_process_solver_impl(
+CplxVect LSGrid::_build_into_cache(
     const Eigen::Ref<const CplxVect> & Vinit,
     SolverSideCache<MatScalar> & cache,
     const AlgoControl & solver_control,
+    bool force_full_rebuild,
     bool init_pv_vm_targets)
 {
-    // cplx_type matrix => AC solver family, real_type matrix => DC solver family
-    const bool is_ac = SolverSideCache<MatScalar>::is_ac;
-
-    // ---- whose cache is this? ---------------------------------------------------
-    // `ac_pf` / `dc_pf` / `check_solution` pass this grid's own cache: what gets
-    // built here IS the family cache, and this grid's algorithm is what will solve
-    // it. The batch algorithms (BaseBatchSolverSynch, on a private copy of the
-    // grid) pass a cache they own and solve it with an algorithm of their own; for
-    // them this is a pure builder.
-    // One address comparison, because the whole cache is one object -- there is no
-    // way to hand this function half of someone's cache and half of ours.
-    const bool own_cache = _is_own_cache(cache);
-
-    // ---- cache-consistency guard ------------------------------------------------
-    // `solver_control` only records what changed SINCE the last solve of this
-    // family. It cannot say whether that family was ever solved at all, so nothing
-    // stops a caller from asserting "nothing changed" -- which is what
-    // `unset_changes()` used to do for BOTH families at once -- while the
-    // solver-side data of the family about to run is still default-constructed.
-    // The "nothing to rebuild" path was then taken with an empty
-    // `cache.id_me_to_solver` / `cache.mat` / `cache.inj`, and everything downstream indexes those
-    // with bus ids in the hundreds: an out-of-bounds read (a segfault), not a
-    // clean rebuild. Three sequences reached it, all of them documented usage:
-    //     unset_changes(); ac_pf();           // never solved at all
-    //     dc_pf(); unset_changes(); ac_pf();  // built for the other family
-    //     ac_pf(); unset_changes(); dc_pf();  // idem
-    // (the second one is why `LightSimBackend.runpf` carried a `self._last_dc`
-    // `tell_solver_need_reset()` with an "otherwise might segfault" comment, and
-    // the same failure mode `check_solution` guards against locally with
-    // `ac_cache_.id_me_to_solver.size() > 0`).
-    // So: never trust the flags alone. Check that the data they describe is really
-    // there, and fall back to a full rebuild when it is not -- a wrong "nothing
-    // changed" can then cost time, never memory safety. This is a handful of
-    // integer comparisons, off any inner loop. It is also where
-    // `allow_*_cache_reuse(false)` takes effect: a family told not to reuse its
-    // cache simply never has a usable one.
-    // A foreign builder never reuses: `solver_control`, the connectivity snapshot
-    // init_bus_status() raises its flags against, and those flags themselves all
-    // describe THIS grid, and say nothing about what is in someone else's cache.
-    // Free in practice -- every foreign caller asks for a full rebuild anyway.
-    //
-    // Beyond that this path asks only the switch. It does NOT re-verify that the
-    // data behind a "nothing changed" claim exists, because by the time we are here
-    // that claim has already been vouched for:
-    //   - the grid raises the flags itself as it is modified (change_*, deactivate_*,
-    //     init_bus_status, set_state, the copy ctor, a divergence): all of those can
-    //     only make the cache MORE stale, never falsely fresh;
-    //   - `AlgoControl`'s constructor asks for a full rebuild, so a grid that never
-    //     solved rebuilds;
-    //   - python cannot clear the flags: `get_*_algo_controler()` is bound read-only
-    //     (binding_misc.cpp exposes the has_* / need_* getters, no tell_*);
-    //   - the two places that CAN claim "nothing changed" without having built
-    //     anything -- `unset_changes()` and `check_solution()` -- verify it
-    //     themselves, at their own altitude, where an O(nb_bus) check is free.
-    // The assertion below is what keeps that reasoning honest: no cost in release
-    // (-DNDEBUG, what the wheels ship), and it fires in the C++ suite -- which CI
-    // runs under ASan, UBSan and valgrind -- the day a fourth claimant appears.
-    const bool cache_unusable = !own_cache || !cache.may_be_reused();
-    assert((cache_unusable || solver_control.need_reset_solver() ||
-            solver_control.has_dimension_changed() ||
-            cache.is_consistent(substations_.nb_bus())) &&
-           "a 'nothing changed' control was handed to a cache that cannot back it: "
-           "some caller marked this family valid without building it");
-
-    // `_algo` / `_dc_algo` are THIS grid's algorithms and consume this grid's cache
-    // and nothing else. A foreign builder solves with its own (BaseBatchSolverSynch
-    // holds one), so resetting ours would only throw away a factorization our next
-    // own powerflow would have reused.
-    if(own_cache && (solver_control.need_reset_solver() || cache_unusable)){
-        if(is_ac) _algo.reset();
-        else _dc_algo.reset();
-    }
-
     bool redo_all =
-            cache_unusable ||
+            force_full_rebuild ||
             solver_control.need_reset_solver() ||
             solver_control.has_dimension_changed();
 
@@ -1481,7 +1417,7 @@ CplxVect LSGrid::_pre_process_solver_impl(
 
     // init_bus_status can set the flag "has_dimension_change", so redo this here
     redo_all =
-            cache_unusable ||
+            force_full_rebuild ||
             solver_control.need_reset_solver() ||
             solver_control.has_dimension_changed();
     bool converter_changed = false;
@@ -1536,38 +1472,163 @@ CplxVect LSGrid::_pre_process_solver_impl(
         cache.slack_weights = generators_.get_slack_weights_solver(cache.mat.rows(), cache.id_me_to_solver);
     }
 
-    // Set when this family's previous powerflow diverged and its algorithm was
-    // reset (see process_results). Every built-in algorithm also raises its own
-    // `need_factorize_` in reset() and would rebuild without being told, but an
-    // external (plugin) solver is under no such obligation: all it is promised is
-    // the AlgoControl it is handed. Only READ here, and cleared by process_results
-    // once the algorithm has actually run -- check_solution() comes through this
-    // function too, without ever calling compute_pf, and clearing the flag there
-    // would drop a rebuild the next real powerflow still needs.
-    // Only when this grid's own algorithm is the one about to run on what we just
-    // built: a foreign builder configures its own, and telling ours about a solve
-    // it will never perform only desynchronizes it from the cache it still holds.
-    if(own_cache){
-        if(cache_unusable || cache.algo_needs_rebuild){
-            // Either the flags we were handed described a cache that did not exist
-            // (so we rebuilt everything just now), or the previous solve of this
-            // family diverged and its algorithm was reset. Both mean the algorithm
-            // must rebuild its own internals rather than skip on a "nothing
-            // changed" it cannot honour.
-            const AlgoControl all_changed;  // default ctor: everything changed
-            if(is_ac) _algo.tell_solver_control(all_changed);
-            else _dc_algo.tell_solver_control(all_changed);
-        } else {
-            if(is_ac) _algo.tell_solver_control(solver_control);
-            else _dc_algo.tell_solver_control(solver_control);
-        }
+    return V;
+}
+
+CplxVect LSGrid::pre_process_solver(
+    const Eigen::Ref<const CplxVect> & Vinit,
+    const AlgoControl & solver_control,
+    bool init_pv_vm_targets)
+{
+    return _pre_process_own_cache<cplx_type>(Vinit, ac_cache_, solver_control, init_pv_vm_targets);
+}
+
+CplxVect LSGrid::pre_process_dc_solver(
+    const Eigen::Ref<const CplxVect> & Vinit,
+    const AlgoControl & solver_control)
+{
+    return _pre_process_own_cache<real_type>(Vinit, dc_cache_, solver_control, true);
+}
+
+template<class MatScalar>
+CplxVect LSGrid::_pre_process_own_cache(
+    const Eigen::Ref<const CplxVect> & Vinit,
+    SolverSideCache<MatScalar> & cache,
+    const AlgoControl & solver_control,
+    bool init_pv_vm_targets)
+{
+    // cplx_type matrix => AC solver family, real_type matrix => DC solver family
+    const bool is_ac = SolverSideCache<MatScalar>::is_ac;
+
+    // ---- may the previous build be re-stamped rather than rebuilt? --------------
+    // `solver_control` only records what changed SINCE the last solve of this
+    // family. It cannot say whether that family was ever solved at all, so nothing
+    // stops a caller from asserting "nothing changed" -- which is what
+    // `unset_changes()` used to do for BOTH families at once -- while the
+    // solver-side data of the family about to run is still default-constructed.
+    // The "nothing to rebuild" path was then taken with an empty
+    // `cache.id_me_to_solver` / `cache.mat` / `cache.inj`, and everything downstream
+    // indexes those with bus ids in the hundreds: an out-of-bounds read (a
+    // segfault), not a clean rebuild. Three sequences reached it, all of them
+    // documented usage:
+    //     unset_changes(); ac_pf();           // never solved at all
+    //     dc_pf(); unset_changes(); ac_pf();  // built for the other family
+    //     ac_pf(); unset_changes(); dc_pf();  // idem
+    // (the second one is why `LightSimBackend.runpf` carried a `self._last_dc`
+    // `tell_solver_need_reset()` with an "otherwise might segfault" comment, and
+    // the same failure mode `check_solution` guards against locally.)
+    //
+    // This path asks only the switch -- it is also where `allow_*_cache_reuse(false)`
+    // takes effect. It does NOT re-verify that the data behind a "nothing changed"
+    // claim exists, because by the time we are here that claim has already been
+    // vouched for:
+    //   - the grid raises the flags itself as it is modified (change_*, deactivate_*,
+    //     init_bus_status, set_state, the copy ctor, a divergence): all of those can
+    //     only make the cache MORE stale, never falsely fresh;
+    //   - `AlgoControl`'s constructor asks for a full rebuild, so a grid that never
+    //     solved rebuilds;
+    //   - python cannot clear the flags: `get_*_algo_controler()` is bound read-only
+    //     (binding_misc.cpp exposes the has_* / need_* getters, no tell_*);
+    //   - the two places that CAN claim "nothing changed" without having built
+    //     anything -- `unset_changes()` and `check_solution()` -- verify it
+    //     themselves, at their own altitude, where an O(nb_bus) check is free.
+    // The assertion below is what keeps that reasoning honest: no cost in release
+    // (-DNDEBUG, what the wheels ship), and it fires in the C++ suite -- which CI
+    // runs under ASan, UBSan and valgrind -- the day a fourth claimant appears.
+    const bool cache_unusable = !cache.may_be_reused();
+    assert((cache_unusable || solver_control.need_reset_solver() ||
+            solver_control.has_dimension_changed() ||
+            cache.is_consistent(substations_.nb_bus())) &&
+           "a 'nothing changed' control was handed to a cache that cannot back it: "
+           "some caller marked this family valid without building it");
+
+    // Our own algorithm is about to run on what we are about to build, so a full
+    // rebuild means its internals (a factorization of the previous system) are
+    // stale too.
+    if(solver_control.need_reset_solver() || cache_unusable){
+        if(is_ac) _algo.reset();
+        else _dc_algo.reset();
     }
 
-    // A foreign build has to PUBLISH what it built into this grid's own cache,
-    // because the solver does not get its NR extensions from what it was handed --
-    // it reaches back into the LSGrid through `lsgrid_ptr` and reads the members:
-    //   Base           -> get_free_vm_slack_solver_buses()   (slack_bus_id_solver,
-    //                       id_me_to_solver)
+    CplxVect V = _build_into_cache(Vinit, cache, solver_control, cache_unusable, init_pv_vm_targets);
+
+    // `cache.algo_needs_rebuild` is set when this family's previous powerflow
+    // diverged and its algorithm was reset (see process_results). Every built-in
+    // algorithm also raises its own `need_factorize_` in reset() and would rebuild
+    // without being told, but an external (plugin) solver is under no such
+    // obligation: all it is promised is the AlgoControl it is handed. Only READ
+    // here, and cleared by process_results once the algorithm has actually run --
+    // check_solution() comes through this function too, without ever calling
+    // compute_pf, and clearing the flag there would drop a rebuild the next real
+    // powerflow still needs.
+    if(cache_unusable || cache.algo_needs_rebuild){
+        // Either the flags we were handed described a cache that did not exist
+        // (so we rebuilt everything just now), or the previous solve of this
+        // family diverged and its algorithm was reset. Both mean the algorithm
+        // must rebuild its own internals rather than skip on a "nothing
+        // changed" it cannot honour.
+        const AlgoControl all_changed;  // default ctor: everything changed
+        if(is_ac) _algo.tell_solver_control(all_changed);
+        else _dc_algo.tell_solver_control(all_changed);
+    } else {
+        if(is_ac) _algo.tell_solver_control(solver_control);
+        else _dc_algo.tell_solver_control(solver_control);
+    }
+    return V;
+}
+
+CplxVect LSGrid::build_solver_input(
+    const Eigen::Ref<const CplxVect> & Vinit,
+    AcSolverCache & out,
+    const AlgoControl & solver_control)
+{
+    return _build_foreign_cache<cplx_type>(Vinit, out, solver_control);
+}
+
+CplxVect LSGrid::build_dc_solver_input(
+    const Eigen::Ref<const CplxVect> & Vinit,
+    DcSolverCache & out,
+    const AlgoControl & solver_control)
+{
+    return _build_foreign_cache<real_type>(Vinit, out, solver_control);
+}
+
+template<class MatScalar>
+CplxVect LSGrid::_build_foreign_cache(
+    const Eigen::Ref<const CplxVect> & Vinit,
+    SolverSideCache<MatScalar> & out,
+    const AlgoControl & solver_control)
+{
+    // Our own cache is not a foreign one: taking this path with it would rebuild
+    // it while telling our algorithm nothing, then retire what was just built.
+    // The caller wanted pre_process_solver. One address comparison, once per
+    // build, and it cannot be got wrong: the family is already in the type.
+    if(_is_own_cache(out)){
+        throw std::runtime_error(
+            "LSGrid::build_solver_input: handed this grid's own solver cache. That "
+            "entry point builds into a cache the CALLER owns and solves with the "
+            "caller's own algorithm; to build this grid's own cache for its own "
+            "powerflow, call pre_process_solver / pre_process_dc_solver instead.");
+    }
+
+    // A foreign build never re-stamps: `solver_control`, the connectivity snapshot
+    // init_bus_status() raises its flags against, and those flags themselves all
+    // describe THIS grid, and say nothing about what is in `out`.
+    CplxVect V = _build_into_cache(Vinit, out, solver_control,
+                                   /*force_full_rebuild=*/true,
+                                   /*init_pv_vm_targets=*/true);
+
+    // `_algo` / `_dc_algo` are deliberately untouched: they are THIS grid's, they
+    // hold a factorization of THIS grid's cache, and the caller solves `out` with
+    // an algorithm of its own (BaseBatchSolverSynch holds one). Resetting or
+    // re-configuring ours for a solve we will never perform would only throw that
+    // factorization away and desynchronize the algorithm from the cache it holds.
+
+    // ---- publish the layout, then retire it -------------------------------------
+    // The NR extensions do not read the cache the solver was handed. They call back
+    // into the grid through `lsgrid_ptr`:
+    //   Base           -> get_free_vm_slack_solver_buses()  (id_me_to_solver,
+    //                       slack_bus_id_solver)
     //   Hvdc           -> fill_hvdc_droop_solver_data()      (id_me_to_solver)
     //   VoltageControl -> fill_voltage_control_solver_data() (id_me_to_solver,
     //                       id_solver_to_me, bus_pq, and the two above)
@@ -1583,40 +1644,22 @@ CplxVect LSGrid::_pre_process_solver_impl(
     // caller's while its matrix and injections are still ours. Right size, passes
     // every structural check, and wrong. It is only ever read by the extensions,
     // during the caller's own solve; this grid must never SOLVE from it.
-    if(!own_cache){
-        SolverSideCache<MatScalar> & mine = _own_cache_for(cache);
-        mine.id_me_to_solver = cache.id_me_to_solver;
-        mine.id_solver_to_me = cache.id_solver_to_me;
-        mine.slack_bus_id_me = cache.slack_bus_id_me;
-        mine.slack_bus_id_solver = cache.slack_bus_id_solver;
-        mine.slack_weights = cache.slack_weights;
-        mine.bus_pv = cache.bus_pv;
-        mine.bus_pq = cache.bus_pq;
-        // ... and it is not a cache any more, it is a view for the extensions:
-        // clear the snapshot so the next own powerflow of this family rebuilds
-        // instead of solving the mixture (is_usable() rejects a snapshot that does
-        // not cover the grid), and raise the flags that say so.
-        _retire_cache(mine, is_ac ? algo_controler_.ac_algo_controler()
-                                  : algo_controler_.dc_algo_controler());
-    }
+    SolverSideCache<MatScalar> & mine = _own_cache_for(out);
+    mine.id_me_to_solver = out.id_me_to_solver;
+    mine.id_solver_to_me = out.id_solver_to_me;
+    mine.slack_bus_id_me = out.slack_bus_id_me;
+    mine.slack_bus_id_solver = out.slack_bus_id_solver;
+    mine.slack_weights = out.slack_weights;
+    mine.bus_pv = out.bus_pv;
+    mine.bus_pq = out.bus_pq;
+    // ... and it is not a cache any more, it is a view for the extensions:
+    // clear the snapshot so the next own powerflow of this family rebuilds
+    // instead of solving the mixture (is_consistent() rejects a snapshot that does
+    // not cover the grid), and raise the flags that say so.
+    _retire_cache(mine, SolverSideCache<MatScalar>::is_ac
+                            ? algo_controler_.ac_algo_controler()
+                            : algo_controler_.dc_algo_controler());
     return V;
-}
-
-CplxVect LSGrid::pre_process_solver(
-    const Eigen::Ref<const CplxVect> & Vinit,
-    AcSolverCache & cache,
-    const AlgoControl & solver_control,
-    bool init_pv_vm_targets)
-{
-    return _pre_process_solver_impl<cplx_type>(Vinit, cache, solver_control, init_pv_vm_targets);
-}
-
-CplxVect LSGrid::pre_process_dc_solver(
-    const Eigen::Ref<const CplxVect> & Vinit,
-    DcSolverCache & cache,
-    const AlgoControl & solver_control)
-{
-    return _pre_process_solver_impl<real_type>(Vinit, cache, solver_control, true);
 }
 
 CplxVect LSGrid::_get_results_back_to_orig_nodes(const Eigen::Ref<const CplxVect> & res_tmp,
@@ -2075,7 +2118,6 @@ CplxVect LSGrid::dc_pf(const Eigen::Ref<const CplxVect> & Vinit,
     // pre process the data: builds the real DC admittance matrix dc_cache_.mat and real power vector dc_cache_.inj
     bool is_ac = false;
     CplxVect V = pre_process_dc_solver(Vinit,
-                                       dc_cache_,
                                        algo_controler_.dc_algo_controler());
     // start the solver (native real DC entry point)
     conv = _dc_algo.compute_pf_dc(

--- a/src/core/LSGrid.cpp
+++ b/src/core/LSGrid.cpp
@@ -23,15 +23,15 @@ LSGrid::LSGrid(const LSGrid & other)
     init_vm_pu_ = other.init_vm_pu_;
     sn_mva_ = other.sn_mva_;
     compute_results_ = other.compute_results_;
-    allow_ac_cache_reuse_ = other.allow_ac_cache_reuse_;
-    allow_dc_cache_reuse_ = other.allow_dc_cache_reuse_;
+    ac_cache_.allow_reuse = other.ac_cache_.allow_reuse;
+    dc_cache_.allow_reuse = other.dc_cache_.allow_reuse;
     init_kwargs_ = other.init_kwargs_;
     _bus_fusion_rep = other._bus_fusion_rep;
 
     // copy the powersystem representation
     // 1. bus
-    last_bus_status_saved_ = other.last_bus_status_saved_;
-    last_bus_status_dc_ = other.last_bus_status_dc_;
+    ac_cache_.last_bus_status = other.ac_cache_.last_bus_status;
+    dc_cache_.last_bus_status = other.dc_cache_.last_bus_status;
     substations_ = other.substations_;
     max_nb_bus_per_sub_ = substations_.nmax_busbar_per_sub();
     n_sub_ = substations_.nb_sub();
@@ -118,7 +118,7 @@ LSGrid::StateRes LSGrid::get_state() const
                             ls_to_orig,
                             init_vm_pu_,
                             sn_mva_,
-                            last_bus_status_saved_,
+                            ac_cache_.last_bus_status,
                             res_substation,
                             res_line,
                             res_shunt,
@@ -671,41 +671,41 @@ void LSGrid::init_bus(unsigned int n_sub,
 void LSGrid::reset(bool reset_solver, bool reset_ac, bool reset_dc)
 {
     if(reset_ac){
-        id_me_to_ac_solver_ = SolverBusIdVect();
-        id_ac_solver_to_me_ = GlobalBusIdVect();
-        slack_bus_id_ac_solver_ = SolverBusIdVect();
-        Ybus_ac_ = Eigen::SparseMatrix<cplx_type>();
+        ac_cache_.id_me_to_solver = SolverBusIdVect();
+        ac_cache_.id_solver_to_me = GlobalBusIdVect();
+        ac_cache_.slack_bus_id_solver = SolverBusIdVect();
+        ac_cache_.mat = Eigen::SparseMatrix<cplx_type>();
     }
 
     if(reset_dc){
-        id_me_to_dc_solver_ = SolverBusIdVect();
-        id_dc_solver_to_me_ = GlobalBusIdVect();
-        slack_bus_id_dc_solver_ = SolverBusIdVect();
-        Bbus_dc_ = Eigen::SparseMatrix<real_type>();
+        dc_cache_.id_me_to_solver = SolverBusIdVect();
+        dc_cache_.id_solver_to_me = GlobalBusIdVect();
+        dc_cache_.slack_bus_id_solver = SolverBusIdVect();
+        dc_cache_.mat = Eigen::SparseMatrix<real_type>();
     }
 
     timer_last_ac_pf_= 0.;
     timer_last_dc_pf_ = 0.;
 
-    acSbus_ = CplxVect();
-    dcPbus_ = RealVect();
-    bus_pv_ac_ = SolverBusIdVect();
-    bus_pq_ac_ = SolverBusIdVect();
-    bus_pv_dc_ = SolverBusIdVect();
-    bus_pq_dc_ = SolverBusIdVect();
-    slack_weights_dc_ = RealVect();
-    ac_algo_needs_rebuild_ = false;  // the algorithms themselves are reset below
-    dc_algo_needs_rebuild_ = false;
+    ac_cache_.inj = CplxVect();
+    dc_cache_.inj = RealVect();
+    ac_cache_.bus_pv = SolverBusIdVect();
+    ac_cache_.bus_pq = SolverBusIdVect();
+    dc_cache_.bus_pv = SolverBusIdVect();
+    dc_cache_.bus_pq = SolverBusIdVect();
+    dc_cache_.slack_weights = RealVect();
+    ac_cache_.algo_needs_rebuild = false;  // the algorithms themselves are reset below
+    dc_cache_.algo_needs_rebuild = false;
 
     algo_controler_.ac_algo_controler().tell_all_changed();
     algo_controler_.dc_algo_controler().tell_all_changed();
-    tell_solver_need_reset(); // also handles last_bus_status_saved_
+    tell_solver_need_reset(); // also handles ac_cache_.last_bus_status
     
-    slack_bus_id_ac_me_ = GlobalBusIdVect();  // slack bus id, gridmodel number
-    slack_bus_id_ac_solver_ = SolverBusIdVect();  // slack bus id, solver number
-    slack_bus_id_dc_me_ = GlobalBusIdVect();
-    slack_bus_id_dc_solver_ = SolverBusIdVect();
-    slack_weights_ac_ = RealVect();
+    ac_cache_.slack_bus_id_me = GlobalBusIdVect();  // slack bus id, gridmodel number
+    ac_cache_.slack_bus_id_solver = SolverBusIdVect();  // slack bus id, solver number
+    dc_cache_.slack_bus_id_me = GlobalBusIdVect();
+    dc_cache_.slack_bus_id_solver = SolverBusIdVect();
+    ac_cache_.slack_weights = RealVect();
 
     // reset the solvers
     if (reset_solver){
@@ -747,30 +747,24 @@ CplxVect LSGrid::ac_pf(const Eigen::Ref<const CplxVect> & Vinit,
 
     // pre process the data to define a proper jacobian matrix, the proper voltage vector etc.
     bool is_ac = true;
-    CplxVect V = pre_process_solver(Vinit, 
-                                    acSbus_,
-                                    Ybus_ac_,
-                                    id_me_to_ac_solver_,
-                                    id_ac_solver_to_me_,
-                                    slack_bus_id_ac_me_,
-                                    slack_bus_id_ac_solver_,
-                                    is_ac,
+    CplxVect V = pre_process_solver(Vinit,
+                                    ac_cache_,
                                     algo_controler_.ac_algo_controler());
 
     // start the solver
     conv = _algo.compute_pf(
-        Ybus_ac_,
+        ac_cache_.mat,
         V,
-        acSbus_,
-        slack_bus_id_ac_solver_.as_eigen(),  // was _to_intvect()
-        slack_weights_ac_,
-        bus_pv_ac_.as_eigen(),  // was _to_intvect()
-        bus_pq_ac_.as_eigen(),  // was _to_intvect()
+        ac_cache_.inj,
+        ac_cache_.slack_bus_id_solver.as_eigen(),  // was _to_intvect()
+        ac_cache_.slack_weights,
+        ac_cache_.bus_pv.as_eigen(),  // was _to_intvect()
+        ac_cache_.bus_pq.as_eigen(),  // was _to_intvect()
         max_iter,
         tol / sn_mva_);
 
     // store results (in ac mode) 
-    process_results(conv, res, Vinit, true, id_me_to_ac_solver_);
+    process_results(conv, res, Vinit, true, ac_cache_.id_me_to_solver);
 
     timer_last_ac_pf_ = timer.duration();
     // return the vector of complex voltage at each bus
@@ -782,7 +776,7 @@ void LSGrid::fill_hvdc_droop_solver_data(HvdcDroopSolverData & data, bool ac) co
     data.clear();
     const int nb_hvdc = static_cast<int>(hvdc_lines_.nb());
     if(nb_hvdc == 0) return;
-    const SolverBusIdVect & id_me_to_solver = ac ? id_me_to_ac_solver_ : id_me_to_dc_solver_;
+    const SolverBusIdVect & id_me_to_solver = ac ? ac_cache_.id_me_to_solver : dc_cache_.id_me_to_solver;
     const std::vector<bool> & droop_enabled = hvdc_lines_.get_droop_enabled();
     const std::vector<bool> & status_global = hvdc_lines_.get_status_global();
     std::vector<int> indices;
@@ -866,15 +860,15 @@ void LSGrid::fill_voltage_control_solver_data(VoltageControlSolverData & data, b
 {
     data.clear();
     if(!ac) return;  // DC: no voltage control (no-op, SVC contributes nothing)
-    const SolverBusIdVect & id_me_to_solver = id_me_to_ac_solver_;
-    const int nb_bus_solver = static_cast<int>(id_ac_solver_to_me_.size());
+    const SolverBusIdVect & id_me_to_solver = ac_cache_.id_me_to_solver;
+    const int nb_bus_solver = static_cast<int>(ac_cache_.id_solver_to_me.size());
     if(nb_bus_solver == 0) return;
 
     // PQ membership: a bus owns a Q equation AND a Vm unknown iff it is a PQ bus
-    // (PV buses have only theta/P, the slack none). bus_pq_ac_ is set by fillpv_pq.
+    // (PV buses have only theta/P, the slack none). ac_cache_.bus_pq is set by fillpv_pq.
     std::vector<bool> is_pq(nb_bus_solver, false);
-    for(int k = 0; k < static_cast<int>(bus_pq_ac_.size()); ++k){
-        const int b = bus_pq_ac_(k).cast_int();
+    for(int k = 0; k < static_cast<int>(ac_cache_.bus_pq.size()); ++k){
+        const int b = ac_cache_.bus_pq(k).cast_int();
         if(b >= 0 && b < nb_bus_solver) is_pq[b] = true;
     }
     // Slack buses are not PQ in the base block, but a slack bus that is not pinned
@@ -1144,15 +1138,15 @@ std::set<int> LSGrid::get_free_vm_slack_solver_buses() const
     std::set<int> res;
     // solver-bus ids of the slack buses
     std::set<int> slack;
-    for(int k = 0; k < static_cast<int>(slack_bus_id_ac_solver_.size()); ++k){
-        slack.insert(slack_bus_id_ac_solver_(k).cast_int());
+    for(int k = 0; k < static_cast<int>(ac_cache_.slack_bus_id_solver.size()); ++k){
+        slack.insert(ac_cache_.slack_bus_id_solver(k).cast_int());
     }
     if(slack.empty()) return res;
 
     // A slack bus is Vm-fixed (PV-like, no Q equation) only when a LOCAL
     // voltage-regulating generator pins its magnitude. Collect those buses.
     std::set<int> locally_vfixed;
-    const SolverBusIdVect & id_me_to_solver = id_me_to_ac_solver_;
+    const SolverBusIdVect & id_me_to_solver = ac_cache_.id_me_to_solver;
     // ... except that a local regulator on a bus a control GROUP regulates does not
     // pin it: it is enrolled as a member of that group instead (see
     // get_group_controlled_buses and the reclassification in fillpv_pq), and the
@@ -1278,28 +1272,23 @@ CplxVect LSGrid::check_solution(const Eigen::Ref<const CplxVect> & V_proposed, b
     // AC solver bus mapping has actually been built at least once (by a prior
     // `ac_pf`/`dc_pf`/`check_solution` call). Calling `check_solution` as the very
     // first operation on a freshly-built model with `tell_none_changed()`
-    // unconditionally used to leave `id_me_to_ac_solver_`/`Ybus_ac_` at their
+    // unconditionally used to leave `ac_cache_.id_me_to_solver`/`ac_cache_.mat` at their
     // default-constructed (empty) size, and `fill_hvdc_droop_solver_data`'s
     // `id_me_to_solver[bus_id]` lookup (bus ids in the hundreds/thousands) then read
     // out of bounds -- a silent, hard-to-reproduce segfault instead of a clean rebuild.
     // (the cache-consistency guard in _pre_process_solver_impl now catches this case too,
     // and the two families' variants of it; this stays as the local, cheaper statement of
     // what check_solution itself may assume)
-    if(id_me_to_ac_solver_.size() > 0) reset_solver.tell_none_changed();
+    if(ac_cache_.id_me_to_solver.size() > 0) reset_solver.tell_none_changed();
     CplxVect V = pre_process_solver(V_proposed,
-                                    acSbus_,
-                                    Ybus_ac_,
-                                    id_me_to_ac_solver_,
-                                    id_ac_solver_to_me_,
-                                    slack_bus_id_ac_me_,
-                                    slack_bus_id_ac_solver_,
-                                    is_ac, reset_solver,
+                                    ac_cache_,
+                                    reset_solver,
                                     false);  // do NOT snap regulated buses to their target: we are testing V_proposed as-is
 
     // compute the mismatch
-    CplxVect tmp = Ybus_ac_ * V;  // this is a vector
+    CplxVect tmp = ac_cache_.mat * V;  // this is a vector
     tmp = tmp.array().conjugate();  // i take the conjugate
-    CplxVect mis = V.array() * tmp.array() - acSbus_.array();  // TODO ac or dc here
+    CplxVect mis = V.array() * tmp.array() - ac_cache_.inj.array();  // TODO ac or dc here
 
     // the angle-droop (AC emulation) hvdc flows are not part of Sbus: they
     // leave the buses, so they add to the computed power, ie to the mismatch
@@ -1317,7 +1306,7 @@ CplxVect LSGrid::check_solution(const Eigen::Ref<const CplxVect> & V_proposed, b
 
     // store results
     CplxVect res = _get_results_back_to_orig_nodes(mis,
-                                                   id_me_to_ac_solver_,
+                                                   ac_cache_.id_me_to_solver,
                                                    static_cast<int>(V_proposed.size())
                                                    );
     if(abs(sn_mva_- 1.) > BaseConstants::_tol_equal_float) res *= sn_mva_;
@@ -1387,25 +1376,25 @@ void LSGrid::prepare_injection(RealVect & Pbus, bool redo_all, bool converter_ch
         }
 }
 
-template<class MatScalar, class InjVect>
+template<class MatScalar>
 CplxVect LSGrid::_pre_process_solver_impl(
     const Eigen::Ref<const CplxVect> & Vinit,
-    InjVect & inj,
-    Eigen::SparseMatrix<MatScalar> & mat,
-    SolverBusIdVect & id_me_to_solver,
-    GlobalBusIdVect & id_solver_to_me,
-    GlobalBusIdVect & slack_bus_id_me,
-    SolverBusIdVect & slack_bus_id_solver,
+    SolverSideCache<MatScalar> & cache,
     const AlgoControl & solver_control,
     bool init_pv_vm_targets)
 {
     // cplx_type matrix => AC solver family, real_type matrix => DC solver family
-    const bool is_ac = std::is_same<MatScalar, cplx_type>::value;
-    // this family's own solver-side data (the other family keeps its own copy of
-    // each of these, so the two never overwrite one another)
-    RealVect & slack_weights = is_ac ? slack_weights_ac_ : slack_weights_dc_;
-    SolverBusIdVect & bus_pv = is_ac ? bus_pv_ac_ : bus_pv_dc_;
-    SolverBusIdVect & bus_pq = is_ac ? bus_pq_ac_ : bus_pq_dc_;
+    const bool is_ac = SolverSideCache<MatScalar>::is_ac;
+
+    // ---- whose cache is this? ---------------------------------------------------
+    // `ac_pf` / `dc_pf` / `check_solution` pass this grid's own cache: what gets
+    // built here IS the family cache, and this grid's algorithm is what will solve
+    // it. The batch algorithms (BaseBatchSolverSynch, on a private copy of the
+    // grid) pass a cache they own and solve it with an algorithm of their own; for
+    // them this is a pure builder.
+    // One address comparison, because the whole cache is one object -- there is no
+    // way to hand this function half of someone's cache and half of ours.
+    const bool own_cache = _is_own_cache(cache);
 
     // ---- cache-consistency guard ------------------------------------------------
     // `solver_control` only records what changed SINCE the last solve of this
@@ -1414,7 +1403,7 @@ CplxVect LSGrid::_pre_process_solver_impl(
     // `unset_changes()` used to do for BOTH families at once -- while the
     // solver-side data of the family about to run is still default-constructed.
     // The "nothing to rebuild" path was then taken with an empty
-    // `id_me_to_solver` / `mat` / `inj`, and everything downstream indexes those
+    // `cache.id_me_to_solver` / `cache.mat` / `cache.inj`, and everything downstream indexes those
     // with bus ids in the hundreds: an out-of-bounds read (a segfault), not a
     // clean rebuild. Three sequences reached it, all of them documented usage:
     //     unset_changes(); ac_pf();           // never solved at all
@@ -1423,25 +1412,24 @@ CplxVect LSGrid::_pre_process_solver_impl(
     // (the second one is why `LightSimBackend.runpf` carried a `self._last_dc`
     // `tell_solver_need_reset()` with an "otherwise might segfault" comment, and
     // the same failure mode `check_solution` guards against locally with
-    // `id_me_to_ac_solver_.size() > 0`).
+    // `ac_cache_.id_me_to_solver.size() > 0`).
     // So: never trust the flags alone. Check that the data they describe is really
     // there, and fall back to a full rebuild when it is not -- a wrong "nothing
     // changed" can then cost time, never memory safety. This is a handful of
     // integer comparisons, off any inner loop. It is also where
     // `allow_*_cache_reuse(false)` takes effect: a family told not to reuse its
     // cache simply never has a usable one.
-    const auto nb_bus_solver_cached = static_cast<Eigen::Index>(id_solver_to_me.size());
-    const bool cache_unusable =
-        !(is_ac ? allow_ac_cache_reuse_ : allow_dc_cache_reuse_) ||
-        (id_me_to_solver.size() != substations_.nb_bus()) ||  // never built, or built for another grid size
-        (nb_bus_solver_cached == 0) ||
-        (mat.rows() != nb_bus_solver_cached) ||
-        (mat.cols() != mat.rows()) ||
-        (inj.size() != nb_bus_solver_cached) ||
-        (slack_weights.size() != nb_bus_solver_cached) ||
-        (bus_pv.size() + bus_pq.size() > static_cast<std::size_t>(nb_bus_solver_cached));
+    // A foreign builder never reuses: `solver_control`, the connectivity snapshot
+    // init_bus_status() raises its flags against, and those flags themselves all
+    // describe THIS grid, and say nothing about what is in someone else's cache.
+    // Free in practice -- every foreign caller asks for a full rebuild anyway.
+    const bool cache_unusable = !own_cache || !cache.is_usable(substations_.nb_bus());
 
-    if(solver_control.need_reset_solver() || cache_unusable){
+    // `_algo` / `_dc_algo` are THIS grid's algorithms and consume this grid's cache
+    // and nothing else. A foreign builder solves with its own (BaseBatchSolverSynch
+    // holds one), so resetting ours would only throw away a factorization our next
+    // own powerflow would have reused.
+    if(own_cache && (solver_control.need_reset_solver() || cache_unusable)){
         if(is_ac) _algo.reset();
         else _dc_algo.reset();
     }
@@ -1452,7 +1440,7 @@ CplxVect LSGrid::_pre_process_solver_impl(
             solver_control.has_dimension_changed();
 
     if (redo_all || solver_control.has_slack_participate_changed()){
-        slack_bus_id_me = generators_.get_slack_bus_id();
+        cache.slack_bus_id_me = generators_.get_slack_bus_id();
         // this is the slack bus ids with the gridmodel ordering, not the solver ordering.
         // conversion to solver ordering is done in init_slack_bus
 
@@ -1460,13 +1448,13 @@ CplxVect LSGrid::_pre_process_solver_impl(
         // the front so the NR uses it as slack_ids[0] (the reference) without
         // changing the slack set or weights. See LSGrid::set_reference_slack_bus.
         if (_forced_ref_slack_bus_id >= 0){
-            std::vector<int> sids = slack_bus_id_me.to_int_vector();
+            std::vector<int> sids = cache.slack_bus_id_me.to_int_vector();
             for (std::size_t i = 1; i < sids.size(); ++i){
                 if (sids[i] == _forced_ref_slack_bus_id){
                     const int ref = sids[i];
                     sids.erase(sids.begin() + static_cast<std::ptrdiff_t>(i));
                     sids.insert(sids.begin(), ref);
-                    slack_bus_id_me = GlobalBusIdVect(sids);
+                    cache.slack_bus_id_me = GlobalBusIdVect(sids);
                     break;
                 }
             }
@@ -1483,35 +1471,35 @@ CplxVect LSGrid::_pre_process_solver_impl(
             solver_control.has_dimension_changed();
     bool converter_changed = false;
     if (redo_all || solver_control.ybus_change_sparsity_pattern()){
-        init_converter_bus_id(id_me_to_solver, id_solver_to_me);
-        const int nb_bus_solver = static_cast<int>(id_solver_to_me.size());
-        init_solver_matrix(mat, nb_bus_solver);
+        init_converter_bus_id(cache.id_me_to_solver, cache.id_solver_to_me);
+        const int nb_bus_solver = static_cast<int>(cache.id_solver_to_me.size());
+        init_solver_matrix(cache.mat, nb_bus_solver);
         converter_changed = true;
     }
     if (redo_all || converter_changed || solver_control.need_recompute_ybus()){
-        fill_solver_matrix(mat, id_me_to_solver);
+        fill_solver_matrix(cache.mat, cache.id_me_to_solver);
     }
     if (redo_all || converter_changed ||
         solver_control.has_slack_participate_changed() ||
         solver_control.has_pv_changed() ||
         solver_control.has_pq_changed()) {
-            init_slack_bus(id_me_to_solver, id_solver_to_me, slack_bus_id_me, slack_bus_id_solver);
-            fillpv_pq(id_me_to_solver, id_solver_to_me, slack_bus_id_solver, bus_pv, bus_pq);
+            init_slack_bus(cache.id_me_to_solver, cache.id_solver_to_me, cache.slack_bus_id_me, cache.slack_bus_id_solver);
+            fillpv_pq(cache.id_me_to_solver, cache.id_solver_to_me, cache.slack_bus_id_solver, cache.bus_pv, cache.bus_pq);
         }
 
     // type-specific injection assembly (complex Sbus for AC, real Pbus for DC)
-    prepare_injection(inj, redo_all, converter_changed, id_me_to_solver, id_solver_to_me, solver_control);
+    prepare_injection(cache.inj, redo_all, converter_changed, cache.id_me_to_solver, cache.id_solver_to_me, solver_control);
 
-    const int nb_bus_solver = static_cast<int>(id_solver_to_me.size());
+    const int nb_bus_solver = static_cast<int>(cache.id_solver_to_me.size());
     CplxVect V = CplxVect::Constant(nb_bus_solver, init_vm_pu_);
     for(int bus_solver_id = 0; bus_solver_id < nb_bus_solver; ++bus_solver_id){
-        GlobalBusId bus_me_id = id_solver_to_me[bus_solver_id];
+        GlobalBusId bus_me_id = cache.id_solver_to_me[bus_solver_id];
         if(bus_me_id.cast_int() == BaseConstants::_deactivated_bus_id){
             //TODO DEBUG MODE : only in debug mode
             std::ostringstream exc_;
             exc_ << "LSGrid::pre_process_solver: the bus with solver id ";
             exc_ << bus_solver_id;
-            exc_ << " is connected, but mapped (in id_solver_to_me) to a disconnected bus (global / gridmodel id)";
+            exc_ << " is connected, but mapped (in cache.id_solver_to_me) to a disconnected bus (global / gridmodel id)";
             throw std::runtime_error(exc_.str());
         }
         V(bus_solver_id) = Vinit(bus_me_id.cast_int());
@@ -1521,16 +1509,16 @@ CplxVect LSGrid::_pre_process_solver_impl(
         // to their own target voltage magnitude. Skipped by check_solution, which must
         // evaluate the caller-supplied voltage as given (see the `init_pv_vm_targets`
         // doc on `pre_process_solver`).
-        generators_.set_vm(V, id_me_to_solver);
-        hvdc_lines_.set_vm(V, id_me_to_solver);
-        svcs_.set_vm(V, id_me_to_solver);  // VOLTAGE-mode SVCs (init quality at the regulated bus)
+        generators_.set_vm(V, cache.id_me_to_solver);
+        hvdc_lines_.set_vm(V, cache.id_me_to_solver);
+        svcs_.set_vm(V, cache.id_me_to_solver);  // VOLTAGE-mode SVCs (init quality at the regulated bus)
     }
 
     if(redo_all ||
        solver_control.has_slack_participate_changed() ||
        solver_control.has_pv_changed() ||
        solver_control.has_slack_weight_changed()){
-        slack_weights = generators_.get_slack_weights_solver(mat.rows(), id_me_to_solver);
+        cache.slack_weights = generators_.get_slack_weights_solver(cache.mat.rows(), cache.id_me_to_solver);
     }
 
     // Set when this family's previous powerflow diverged and its algorithm was
@@ -1541,82 +1529,79 @@ CplxVect LSGrid::_pre_process_solver_impl(
     // once the algorithm has actually run -- check_solution() comes through this
     // function too, without ever calling compute_pf, and clearing the flag there
     // would drop a rebuild the next real powerflow still needs.
-    const bool algo_needs_rebuild = is_ac ? ac_algo_needs_rebuild_ : dc_algo_needs_rebuild_;
-    if(cache_unusable || algo_needs_rebuild){
-        // Either the flags we were handed described a cache that did not exist (so
-        // we rebuilt everything just now), or the previous solve of this family
-        // diverged and its algorithm was reset. Both mean the algorithm must
-        // rebuild its own internals rather than skip on a "nothing changed" it
-        // cannot honour.
-        const AlgoControl all_changed;  // default ctor: everything changed
-        if(is_ac) _algo.tell_solver_control(all_changed);
-        else _dc_algo.tell_solver_control(all_changed);
-    } else {
-        if(is_ac) _algo.tell_solver_control(solver_control);
-        else _dc_algo.tell_solver_control(solver_control);
+    // Only when this grid's own algorithm is the one about to run on what we just
+    // built: a foreign builder configures its own, and telling ours about a solve
+    // it will never perform only desynchronizes it from the cache it still holds.
+    if(own_cache){
+        if(cache_unusable || cache.algo_needs_rebuild){
+            // Either the flags we were handed described a cache that did not exist
+            // (so we rebuilt everything just now), or the previous solve of this
+            // family diverged and its algorithm was reset. Both mean the algorithm
+            // must rebuild its own internals rather than skip on a "nothing
+            // changed" it cannot honour.
+            const AlgoControl all_changed;  // default ctor: everything changed
+            if(is_ac) _algo.tell_solver_control(all_changed);
+            else _dc_algo.tell_solver_control(all_changed);
+        } else {
+            if(is_ac) _algo.tell_solver_control(solver_control);
+            else _dc_algo.tell_solver_control(solver_control);
+        }
     }
 
-    // Keep the member solver-side labelling in sync with the vectors we just built.
-    // The single-shot ac_pf / dc_pf pass the members themselves (self-assign, skipped
-    // below), but the batch algorithms (TimeSeries / ContingencyAnalysis, through
-    // BaseBatchSolverSynch) own their local vectors and pass those -- while the solver
-    // still reaches back into this LSGrid through `lsgrid_ptr` to build its NR
-    // extensions:
-    //   Base           -> get_free_vm_slack_solver_buses()    (slack_bus_id_*_solver_)
-    //   Hvdc           -> fill_hvdc_droop_solver_data()       (id_me_to_*_solver_)
-    //   VoltageControl -> fill_voltage_control_solver_data()  (id_*_solver_to_me_,
-    //                       id_me_to_*_solver_, and the two above)
-    // A member left stale there does not read as an error, it reads as "nothing to
-    // do": the controller list comes back empty and the solve SILENTLY drops remote
-    // voltage control / the free Vm unknown of a distributed-slack participant. Note
-    // that the batch classes hold a *copy* of the grid, and LSGrid's copy constructor
-    // reset()s all of this, so stale here always means empty. Every member the
-    // extensions read must therefore reflect the active mapping in every path -- not
-    // just the forward map.
-    if(is_ac){
-        if(&id_me_to_solver != &id_me_to_ac_solver_) id_me_to_ac_solver_ = id_me_to_solver;
-        if(&id_solver_to_me != &id_ac_solver_to_me_) id_ac_solver_to_me_ = id_solver_to_me;
-        if(&slack_bus_id_me != &slack_bus_id_ac_me_) slack_bus_id_ac_me_ = slack_bus_id_me;
-        if(&slack_bus_id_solver != &slack_bus_id_ac_solver_) slack_bus_id_ac_solver_ = slack_bus_id_solver;
-    } else {
-        if(&id_me_to_solver != &id_me_to_dc_solver_) id_me_to_dc_solver_ = id_me_to_solver;
-        if(&id_solver_to_me != &id_dc_solver_to_me_) id_dc_solver_to_me_ = id_solver_to_me;
-        if(&slack_bus_id_me != &slack_bus_id_dc_me_) slack_bus_id_dc_me_ = slack_bus_id_me;
-        if(&slack_bus_id_solver != &slack_bus_id_dc_solver_) slack_bus_id_dc_solver_ = slack_bus_id_solver;
+    // A foreign build has to PUBLISH what it built into this grid's own cache,
+    // because the solver does not get its NR extensions from what it was handed --
+    // it reaches back into the LSGrid through `lsgrid_ptr` and reads the members:
+    //   Base           -> get_free_vm_slack_solver_buses()   (slack_bus_id_solver,
+    //                       id_me_to_solver)
+    //   Hvdc           -> fill_hvdc_droop_solver_data()      (id_me_to_solver)
+    //   VoltageControl -> fill_voltage_control_solver_data() (id_me_to_solver,
+    //                       id_solver_to_me, bus_pq, and the two above)
+    // Left stale, that does not read as an error, it reads as "nothing to do": the
+    // controller list comes back empty and the solve SILENTLY drops remote voltage
+    // control / the free Vm unknown of a distributed-slack participant. Note
+    // `bus_pq`: the pv-pq split is part of what the extensions read, which is why
+    // publishing only the labelling is not enough.
+    //
+    // Copying the whole cache would also copy the matrix -- the expensive half, and
+    // the one thing the caller keeps for itself -- so publish the rest and then say
+    // out loud what that leaves behind: a cache whose labelling and split are the
+    // caller's while its matrix and injections are still ours. Right size, passes
+    // every structural check, and wrong. It is only ever read by the extensions,
+    // during the caller's own solve; this grid must never SOLVE from it.
+    if(!own_cache){
+        SolverSideCache<MatScalar> & mine = _own_cache_for(cache);
+        mine.id_me_to_solver = cache.id_me_to_solver;
+        mine.id_solver_to_me = cache.id_solver_to_me;
+        mine.slack_bus_id_me = cache.slack_bus_id_me;
+        mine.slack_bus_id_solver = cache.slack_bus_id_solver;
+        mine.slack_weights = cache.slack_weights;
+        mine.bus_pv = cache.bus_pv;
+        mine.bus_pq = cache.bus_pq;
+        // ... and it is not a cache any more, it is a view for the extensions:
+        // clear the snapshot so the next own powerflow of this family rebuilds
+        // instead of solving the mixture (is_usable() rejects a snapshot that does
+        // not cover the grid), and raise the flags that say so.
+        _retire_cache(mine, is_ac ? algo_controler_.ac_algo_controler()
+                                  : algo_controler_.dc_algo_controler());
     }
     return V;
 }
 
 CplxVect LSGrid::pre_process_solver(
     const Eigen::Ref<const CplxVect> & Vinit,
-    CplxVect & Sbus,
-    Eigen::SparseMatrix<cplx_type> & Ybus,
-    SolverBusIdVect & id_me_to_solver,
-    GlobalBusIdVect & id_solver_to_me,
-    GlobalBusIdVect & slack_bus_id_me,
-    SolverBusIdVect & slack_bus_id_solver,
-    bool /*is_ac*/,  // kept for API compatibility; DC now goes through pre_process_dc_solver
+    AcSolverCache & cache,
     const AlgoControl & solver_control,
     bool init_pv_vm_targets)
 {
-    return _pre_process_solver_impl<cplx_type>(
-        Vinit, Sbus, Ybus, id_me_to_solver, id_solver_to_me,
-        slack_bus_id_me, slack_bus_id_solver, solver_control, init_pv_vm_targets);
+    return _pre_process_solver_impl<cplx_type>(Vinit, cache, solver_control, init_pv_vm_targets);
 }
 
 CplxVect LSGrid::pre_process_dc_solver(
     const Eigen::Ref<const CplxVect> & Vinit,
-    RealVect & Pbus,
-    Eigen::SparseMatrix<real_type> & Bbus,
-    SolverBusIdVect & id_me_to_solver,
-    GlobalBusIdVect & id_solver_to_me,
-    GlobalBusIdVect & slack_bus_id_me,
-    SolverBusIdVect & slack_bus_id_solver,
+    DcSolverCache & cache,
     const AlgoControl & solver_control)
 {
-    return _pre_process_solver_impl<real_type>(
-        Vinit, Pbus, Bbus, id_me_to_solver, id_solver_to_me,
-        slack_bus_id_me, slack_bus_id_solver, solver_control, true);
+    return _pre_process_solver_impl<real_type>(Vinit, cache, solver_control, true);
 }
 
 CplxVect LSGrid::_get_results_back_to_orig_nodes(const Eigen::Ref<const CplxVect> & res_tmp,
@@ -1667,7 +1652,7 @@ void LSGrid::process_results(bool conv,
             !(ac ? _algo.is_builtin_algo() : _dc_algo.is_builtin_algo());
         if (is_external_algo) conv = _check_solver_output(ac);
     }
-    bool & algo_needs_rebuild = ac ? ac_algo_needs_rebuild_ : dc_algo_needs_rebuild_;
+    bool & algo_needs_rebuild = ac ? ac_cache_.algo_needs_rebuild : dc_cache_.algo_needs_rebuild;
     if (conv){
         algo_needs_rebuild = false;  // the algorithm just ran and rebuilt what it needed
         if(compute_results_){
@@ -1705,7 +1690,7 @@ void LSGrid::process_results(bool conv,
     // data was built by pre_process either way -- but a family whose reuse was
     // turned off must not be marked: `allow_*_cache_reuse(false)` means "always
     // rebuild", and a stale mark would be the one thing able to defeat it.
-    if(ac ? allow_ac_cache_reuse_ : allow_dc_cache_reuse_) _mark_cache_valid(ac);
+    if(ac ? ac_cache_.allow_reuse : dc_cache_.allow_reuse) _mark_cache_valid(ac);
 }
 
 bool LSGrid::_check_solver_output(bool ac)
@@ -1713,8 +1698,8 @@ bool LSGrid::_check_solver_output(bool ac)
     const Eigen::Ref<const CplxVect> V  = ac ? _algo.get_V()  : _dc_algo.get_V();
     const Eigen::Ref<const RealVect> Va = ac ? _algo.get_Va() : _dc_algo.get_Va();
     const Eigen::Ref<const RealVect> Vm = ac ? _algo.get_Vm() : _dc_algo.get_Vm();
-    const int nb_bus_solver = ac ? static_cast<int>(id_ac_solver_to_me_.size())
-                                 : static_cast<int>(id_dc_solver_to_me_.size());
+    const int nb_bus_solver = ac ? static_cast<int>(ac_cache_.id_solver_to_me.size())
+                                 : static_cast<int>(dc_cache_.id_solver_to_me.size());
     const char * algo_name = ac ? "AC" : "DC";
 
     if((V.size() != nb_bus_solver) || (Va.size() != nb_bus_solver) || (Vm.size() != nb_bus_solver))
@@ -1942,7 +1927,7 @@ void LSGrid::compute_results(bool ac){
     const auto & Vm = ac ? _algo.get_Vm() : _dc_algo.get_Vm();
     const auto & V = ac ? _algo.get_V() : _dc_algo.get_V();
 
-    const SolverBusIdVect & id_me_to_solver = ac ? id_me_to_ac_solver_ : id_me_to_dc_solver_;
+    const SolverBusIdVect & id_me_to_solver = ac ? ac_cache_.id_me_to_solver : dc_cache_.id_me_to_solver;
     // for powerlines
     powerlines_.compute_results(Va, Vm, V, id_me_to_solver, substations_.get_bus_vn_kv(), sn_mva_, ac);  // TODO have a function to dispatch that to all type of elements
     // for trafo
@@ -1968,23 +1953,23 @@ void LSGrid::compute_results(bool ac){
     RealVect active_mismatch;
     if(ac){
         // In AC mode i am not forced to run through all the grid
-        // auto tmp = (Ybus_ac_ * V).conjugate();
-        mismatch = V.array() * (Ybus_ac_ * V).conjugate().array() - acSbus_.array();
+        // auto tmp = (ac_cache_.mat * V).conjugate();
+        mismatch = V.array() * (ac_cache_.mat * V).conjugate().array() - ac_cache_.inj.array();
         active_mismatch = mismatch.real() * sn_mva_;
     } else{
         // distributed slack (DC): the global active power imbalance -sum(Pbus) is shared among the
         // participating slack buses proportionally to their (normalized) slack weights. With a single
         // slack this assigns the whole imbalance to the reference bus (historical behaviour).
         active_mismatch = RealVect::Zero(V.size());
-        const real_type imbalance = -dcPbus_.sum() * sn_mva_;
-        if(slack_weights_dc_.size() == active_mismatch.size()){
-            for(int k=0; k < slack_weights_dc_.size(); ++k){
-                if(slack_weights_dc_(k) <= BaseConstants::my_zero_) continue;
-                active_mismatch(k) = slack_weights_dc_(k) * imbalance;
+        const real_type imbalance = -dc_cache_.inj.sum() * sn_mva_;
+        if(dc_cache_.slack_weights.size() == active_mismatch.size()){
+            for(int k=0; k < dc_cache_.slack_weights.size(); ++k){
+                if(dc_cache_.slack_weights(k) <= BaseConstants::my_zero_) continue;
+                active_mismatch(k) = dc_cache_.slack_weights(k) * imbalance;
             }
         } else {
             // fallback (should not happen): assign the whole imbalance to the reference slack bus
-            const SolverBusId id_slack = slack_bus_id_dc_solver_(0);
+            const SolverBusId id_slack = dc_cache_.slack_bus_id_solver(0);
             active_mismatch(id_slack.cast_int()) = imbalance;
         }
     }
@@ -2072,33 +2057,28 @@ CplxVect LSGrid::dc_pf(const Eigen::Ref<const CplxVect> & Vinit,
 
     // reset_results();  // clear the results  No need to do it, results are neceassirly set or reset in post process
 
-    // pre process the data: builds the real DC admittance matrix Bbus_dc_ and real power vector dcPbus_
+    // pre process the data: builds the real DC admittance matrix dc_cache_.mat and real power vector dc_cache_.inj
     bool is_ac = false;
     CplxVect V = pre_process_dc_solver(Vinit,
-                                       dcPbus_,
-                                       Bbus_dc_,
-                                       id_me_to_dc_solver_,
-                                       id_dc_solver_to_me_,
-                                       slack_bus_id_dc_me_,
-                                       slack_bus_id_dc_solver_,
+                                       dc_cache_,
                                        algo_controler_.dc_algo_controler());
     // start the solver (native real DC entry point)
     conv = _dc_algo.compute_pf_dc(
-        Bbus_dc_,
+        dc_cache_.mat,
         V,
-        dcPbus_,
-        slack_bus_id_dc_solver_.as_eigen(),  // was _to_intvect()
-        slack_weights_dc_,
-        bus_pv_dc_.as_eigen(),  // was _to_intvect()
-        bus_pq_dc_.as_eigen());  // was _to_intvect()
+        dc_cache_.inj,
+        dc_cache_.slack_bus_id_solver.as_eigen(),  // was _to_intvect()
+        dc_cache_.slack_weights,
+        dc_cache_.bus_pv.as_eigen(),  // was _to_intvect()
+        dc_cache_.bus_pq.as_eigen());  // was _to_intvect()
     // store results (fase -> because I am in dc mode)
-    process_results(conv, res, Vinit, is_ac, id_me_to_dc_solver_);
+    process_results(conv, res, Vinit, is_ac, dc_cache_.id_me_to_solver);
     timer_last_dc_pf_ = timer.duration();
     return res;
 }
 
 RealMat LSGrid::get_ptdf_solver(){
-    if(Bbus_dc_.size() == 0){
+    if(dc_cache_.mat.size() == 0){
         throw std::runtime_error("LSGrid::get_ptdf: Cannot get the ptdf without having first computed a DC powerflow.");
     }
     // return the freshly-computed matrix directly (RVO/move) instead of binding it
@@ -2109,7 +2089,7 @@ RealMat LSGrid::get_ptdf_solver(){
 
 
 RealMat LSGrid::get_ptdf(){
-    if(Bbus_dc_.size() == 0){
+    if(dc_cache_.mat.size() == 0){
         throw std::runtime_error("LSGrid::get_ptdf: Cannot get the ptdf without having first computed a DC powerflow.");
     }
     const RealMat & PTDF_solver = get_ptdf_solver();
@@ -2123,7 +2103,7 @@ RealMat LSGrid::get_ptdf(){
 }
 
 RealMat LSGrid::get_lodf(){
-    if(Bbus_dc_.size() == 0){
+    if(dc_cache_.mat.size() == 0){
         throw std::runtime_error("LSGrid::get_lodf: Cannot get the ptdf without having first computed a DC powerflow.");
     }
     const size_t n_line = powerlines_.nb();
@@ -2148,7 +2128,7 @@ RealMat LSGrid::get_lodf(){
             // branch carries no DC flow at all (TwoSidesContainer_rxh_A::fillBdc
             // drops it from Bbus entirely -- "disco on one side == disco on both
             // sides"), and its open/stale bus id must not index
-            // id_me_to_dc_solver_ -- propagate the deactivated sentinel instead,
+            // dc_cache_.id_me_to_solver -- propagate the deactivated sentinel instead,
             // so BaseDCAlgo::get_lodf gives it the identity treatment (its
             // "outage" changes nothing, anywhere).
             from_bus_solver[el_id] = BaseConstants::_deactivated_bus_id;
@@ -2157,18 +2137,18 @@ RealMat LSGrid::get_lodf(){
         }
         // from side
         GlobalBusId f_grid_bus = from_bus[el_id];
-        SolverBusId f_solver_bus = id_me_to_dc_solver_[f_grid_bus.cast_int()];
+        SolverBusId f_solver_bus = dc_cache_.id_me_to_solver[f_grid_bus.cast_int()];
         from_bus_solver[el_id] = f_solver_bus.cast_int();
         // to side
         GlobalBusId t_grid_bus = to_bus[el_id];
-        SolverBusId t_solver_bus = id_me_to_dc_solver_[t_grid_bus.cast_int()];
+        SolverBusId t_solver_bus = dc_cache_.id_me_to_solver[t_grid_bus.cast_int()];
         to_bus_solver[el_id] = t_solver_bus.cast_int();
     }
     return _dc_algo.get_lodf(from_bus_solver, to_bus_solver);
 }
 
 Eigen::SparseMatrix<real_type> LSGrid::get_Bf_solver(){
-    if(Bbus_dc_.size() == 0){
+    if(dc_cache_.mat.size() == 0){
         throw std::runtime_error("LSGrid::get_Bf_solver: Cannot get the Bf matrix without having first computed a DC powerflow.");
     }
     Eigen::SparseMatrix<real_type> Bf;
@@ -2177,11 +2157,11 @@ Eigen::SparseMatrix<real_type> LSGrid::get_Bf_solver(){
 }
 
 Eigen::SparseMatrix<real_type> LSGrid::get_Bf(){
-    if(Bbus_dc_.size() == 0){
+    if(dc_cache_.mat.size() == 0){
         throw std::runtime_error("LSGrid::get_Bf: Cannot get the Bf matrix without having first computed a DC powerflow.");
     }
     Eigen::SparseMatrix<real_type> Bf_solver = get_Bf_solver();
-    return _relabel_matrix(Bf_solver, id_dc_solver_to_me_, false);
+    return _relabel_matrix(Bf_solver, dc_cache_.id_solver_to_me, false);
 }
 
 void LSGrid::add_gen_slackbus(int gen_id, real_type weight){
@@ -2307,7 +2287,7 @@ void LSGrid::fillBp_Bpp(Eigen::SparseMatrix<real_type> & Bp,
                            FDPFMethod xb_or_bx) const
 {
     // clear the matrices
-    const int nb_bus_solver = static_cast<int>(id_ac_solver_to_me_.size());
+    const int nb_bus_solver = static_cast<int>(ac_cache_.id_solver_to_me.size());
     Bp = Eigen::SparseMatrix<real_type>(nb_bus_solver, nb_bus_solver);
     Bpp = Eigen::SparseMatrix<real_type>(nb_bus_solver, nb_bus_solver);
 
@@ -2317,14 +2297,14 @@ void LSGrid::fillBp_Bpp(Eigen::SparseMatrix<real_type> & Bp,
     tripletList_Bp.reserve(substations_.nb_bus() + 4 * powerlines_.nb() + 4 * trafos_.nb() + shunts_.nb());
     tripletList_Bpp.reserve(substations_.nb_bus() + 4 * powerlines_.nb() + 4 * trafos_.nb() + shunts_.nb());
     // run through the grid and get the parameters to fill them
-    powerlines_.fillBp_Bpp(tripletList_Bp, tripletList_Bpp, id_me_to_ac_solver_, sn_mva_, xb_or_bx);  // TODO have a function to dispatch that to all type of elements
-    shunts_.fillBp_Bpp(tripletList_Bp, tripletList_Bpp, id_me_to_ac_solver_, sn_mva_, xb_or_bx);
-    trafos_.fillBp_Bpp(tripletList_Bp, tripletList_Bpp, id_me_to_ac_solver_, sn_mva_, xb_or_bx);
-    loads_.fillBp_Bpp(tripletList_Bp, tripletList_Bpp, id_me_to_ac_solver_, sn_mva_, xb_or_bx);
-    sgens_.fillBp_Bpp(tripletList_Bp, tripletList_Bpp, id_me_to_ac_solver_, sn_mva_, xb_or_bx);
-    storages_.fillBp_Bpp(tripletList_Bp, tripletList_Bpp, id_me_to_ac_solver_, sn_mva_, xb_or_bx);
-    generators_.fillBp_Bpp(tripletList_Bp, tripletList_Bpp, id_me_to_ac_solver_, sn_mva_, xb_or_bx);
-    hvdc_lines_.fillBp_Bpp(tripletList_Bp, tripletList_Bpp, id_me_to_ac_solver_, sn_mva_, xb_or_bx);
+    powerlines_.fillBp_Bpp(tripletList_Bp, tripletList_Bpp, ac_cache_.id_me_to_solver, sn_mva_, xb_or_bx);  // TODO have a function to dispatch that to all type of elements
+    shunts_.fillBp_Bpp(tripletList_Bp, tripletList_Bpp, ac_cache_.id_me_to_solver, sn_mva_, xb_or_bx);
+    trafos_.fillBp_Bpp(tripletList_Bp, tripletList_Bpp, ac_cache_.id_me_to_solver, sn_mva_, xb_or_bx);
+    loads_.fillBp_Bpp(tripletList_Bp, tripletList_Bpp, ac_cache_.id_me_to_solver, sn_mva_, xb_or_bx);
+    sgens_.fillBp_Bpp(tripletList_Bp, tripletList_Bpp, ac_cache_.id_me_to_solver, sn_mva_, xb_or_bx);
+    storages_.fillBp_Bpp(tripletList_Bp, tripletList_Bpp, ac_cache_.id_me_to_solver, sn_mva_, xb_or_bx);
+    generators_.fillBp_Bpp(tripletList_Bp, tripletList_Bpp, ac_cache_.id_me_to_solver, sn_mva_, xb_or_bx);
+    hvdc_lines_.fillBp_Bpp(tripletList_Bp, tripletList_Bpp, ac_cache_.id_me_to_solver, sn_mva_, xb_or_bx);
     // now make the matrices effectively
     Bp.setFromTriplets(tripletList_Bp.begin(), tripletList_Bp.end());
     Bp.makeCompressed();
@@ -2335,7 +2315,7 @@ void LSGrid::fillBp_Bpp(Eigen::SparseMatrix<real_type> & Bp,
 
 void LSGrid::fillBf_for_PTDF(Eigen::SparseMatrix<real_type> & Bf, bool transpose) const
 {
-    const int nb_bus_solver = static_cast<int>(id_dc_solver_to_me_.size());
+    const int nb_bus_solver = static_cast<int>(dc_cache_.id_solver_to_me.size());
     // TODO DEBUG MODE
     if(nb_bus_solver == 0) throw std::runtime_error("LSGrid::fillBf_for_PTDF: it appears no DC powerflow has run on your grid.");
     
@@ -2347,14 +2327,14 @@ void LSGrid::fillBf_for_PTDF(Eigen::SparseMatrix<real_type> & Bf, bool transpose
     std::vector<Eigen::Triplet<real_type> > tripletList;
     tripletList.reserve(substations_.nb_bus() + 2 * powerlines_.nb() + 2 * trafos_.nb());
     
-    powerlines_.fillBf_for_PTDF(tripletList, id_me_to_dc_solver_, sn_mva_, powerlines_.nb(), transpose);  // TODO have a function to dispatch that to all type of elements
-    shunts_.fillBf_for_PTDF(tripletList, id_me_to_dc_solver_, sn_mva_, powerlines_.nb(), transpose);
-    trafos_.fillBf_for_PTDF(tripletList, id_me_to_dc_solver_, sn_mva_, powerlines_.nb(), transpose);
-    loads_.fillBf_for_PTDF(tripletList, id_me_to_dc_solver_, sn_mva_, powerlines_.nb(), transpose);
-    sgens_.fillBf_for_PTDF(tripletList, id_me_to_dc_solver_, sn_mva_, powerlines_.nb(), transpose);
-    storages_.fillBf_for_PTDF(tripletList, id_me_to_dc_solver_, sn_mva_, powerlines_.nb(), transpose);
-    generators_.fillBf_for_PTDF(tripletList, id_me_to_dc_solver_, sn_mva_, powerlines_.nb(), transpose);
-    hvdc_lines_.fillBf_for_PTDF(tripletList, id_me_to_dc_solver_, sn_mva_, powerlines_.nb(), transpose);
+    powerlines_.fillBf_for_PTDF(tripletList, dc_cache_.id_me_to_solver, sn_mva_, powerlines_.nb(), transpose);  // TODO have a function to dispatch that to all type of elements
+    shunts_.fillBf_for_PTDF(tripletList, dc_cache_.id_me_to_solver, sn_mva_, powerlines_.nb(), transpose);
+    trafos_.fillBf_for_PTDF(tripletList, dc_cache_.id_me_to_solver, sn_mva_, powerlines_.nb(), transpose);
+    loads_.fillBf_for_PTDF(tripletList, dc_cache_.id_me_to_solver, sn_mva_, powerlines_.nb(), transpose);
+    sgens_.fillBf_for_PTDF(tripletList, dc_cache_.id_me_to_solver, sn_mva_, powerlines_.nb(), transpose);
+    storages_.fillBf_for_PTDF(tripletList, dc_cache_.id_me_to_solver, sn_mva_, powerlines_.nb(), transpose);
+    generators_.fillBf_for_PTDF(tripletList, dc_cache_.id_me_to_solver, sn_mva_, powerlines_.nb(), transpose);
+    hvdc_lines_.fillBf_for_PTDF(tripletList, dc_cache_.id_me_to_solver, sn_mva_, powerlines_.nb(), transpose);
 
     Bf.setFromTriplets(tripletList.begin(), tripletList.end());
     Bf.makeCompressed();
@@ -2408,10 +2388,10 @@ std::tuple<int, int> LSGrid::assign_slack_to_most_connected(){
     generators_.remove_all_slackbus();
     res_gen_id = generators_.assign_slack_bus(res_bus_id, gen_p_per_bus, algo_controler_);
     std::get<1>(res) = res_gen_id;
-    slack_bus_id_ac_solver_ = SolverBusIdVect();
-    slack_bus_id_dc_solver_ = SolverBusIdVect();
-    slack_weights_ac_ = RealVect();
-    slack_weights_dc_ = RealVect();
+    ac_cache_.slack_bus_id_solver = SolverBusIdVect();
+    dc_cache_.slack_bus_id_solver = SolverBusIdVect();
+    ac_cache_.slack_weights = RealVect();
+    dc_cache_.slack_weights = RealVect();
     return res;
 }
 

--- a/src/core/LSGrid.cpp
+++ b/src/core/LSGrid.cpp
@@ -6,6 +6,7 @@
 // SPDX-License-Identifier: MPL-2.0
 // This file is part of LightSim2grid, LightSim2grid implements a c++ backend targeting the Grid2Op platform.
 
+#include <cassert>
 #include "LSGrid.hpp"
 #include "AlgorithmSelector.hpp"  // to avoid circular references
 #include "BinaryArchive.hpp"
@@ -1279,7 +1280,9 @@ CplxVect LSGrid::check_solution(const Eigen::Ref<const CplxVect> & V_proposed, b
     // (the cache-consistency guard in _pre_process_solver_impl now catches this case too,
     // and the two families' variants of it; this stays as the local, cheaper statement of
     // what check_solution itself may assume)
-    if(ac_cache_.id_me_to_solver.size() > 0) reset_solver.tell_none_changed();
+    if(ac_cache_.may_be_reused() && ac_cache_.is_consistent(substations_.nb_bus())){
+        reset_solver.tell_none_changed();
+    }
     CplxVect V = pre_process_solver(V_proposed,
                                     ac_cache_,
                                     reset_solver,
@@ -1423,7 +1426,29 @@ CplxVect LSGrid::_pre_process_solver_impl(
     // init_bus_status() raises its flags against, and those flags themselves all
     // describe THIS grid, and say nothing about what is in someone else's cache.
     // Free in practice -- every foreign caller asks for a full rebuild anyway.
-    const bool cache_unusable = !own_cache || !cache.is_usable(substations_.nb_bus());
+    //
+    // Beyond that this path asks only the switch. It does NOT re-verify that the
+    // data behind a "nothing changed" claim exists, because by the time we are here
+    // that claim has already been vouched for:
+    //   - the grid raises the flags itself as it is modified (change_*, deactivate_*,
+    //     init_bus_status, set_state, the copy ctor, a divergence): all of those can
+    //     only make the cache MORE stale, never falsely fresh;
+    //   - `AlgoControl`'s constructor asks for a full rebuild, so a grid that never
+    //     solved rebuilds;
+    //   - python cannot clear the flags: `get_*_algo_controler()` is bound read-only
+    //     (binding_misc.cpp exposes the has_* / need_* getters, no tell_*);
+    //   - the two places that CAN claim "nothing changed" without having built
+    //     anything -- `unset_changes()` and `check_solution()` -- verify it
+    //     themselves, at their own altitude, where an O(nb_bus) check is free.
+    // The assertion below is what keeps that reasoning honest: no cost in release
+    // (-DNDEBUG, what the wheels ship), and it fires in the C++ suite -- which CI
+    // runs under ASan, UBSan and valgrind -- the day a fourth claimant appears.
+    const bool cache_unusable = !own_cache || !cache.may_be_reused();
+    assert((cache_unusable || solver_control.need_reset_solver() ||
+            solver_control.has_dimension_changed() ||
+            cache.is_consistent(substations_.nb_bus())) &&
+           "a 'nothing changed' control was handed to a cache that cannot back it: "
+           "some caller marked this family valid without building it");
 
     // `_algo` / `_dc_algo` are THIS grid's algorithms and consume this grid's cache
     // and nothing else. A foreign builder solves with its own (BaseBatchSolverSynch

--- a/src/core/LSGrid.cpp
+++ b/src/core/LSGrid.cpp
@@ -671,45 +671,35 @@ void LSGrid::init_bus(unsigned int n_sub,
 
 void LSGrid::reset(bool reset_solver, bool reset_ac, bool reset_dc)
 {
-    if(reset_ac){
-        ac_cache_.id_me_to_solver = SolverBusIdVect();
-        ac_cache_.id_solver_to_me = GlobalBusIdVect();
-        ac_cache_.slack_bus_id_solver = SolverBusIdVect();
-        ac_cache_.mat = Eigen::SparseMatrix<cplx_type>();
-    }
-
-    if(reset_dc){
-        dc_cache_.id_me_to_solver = SolverBusIdVect();
-        dc_cache_.id_solver_to_me = GlobalBusIdVect();
-        dc_cache_.slack_bus_id_solver = SolverBusIdVect();
-        dc_cache_.mat = Eigen::SparseMatrix<real_type>();
-    }
+    // A family's solver-side data is ONE object, so "reset the AC side" is one
+    // call. What clear() deliberately leaves alone is the two policy flags:
+    // `allow_reuse` is the caller's standing choice and a reset is not a request
+    // to change it, and `algo_needs_rebuild` belongs to the algorithm, handled
+    // below with the algorithms themselves.
+    if(reset_ac) ac_cache_.clear();
+    if(reset_dc) dc_cache_.clear();
 
     timer_last_ac_pf_= 0.;
     timer_last_dc_pf_ = 0.;
 
-    ac_cache_.inj = CplxVect();
-    dc_cache_.inj = RealVect();
-    ac_cache_.bus_pv = SolverBusIdVect();
-    ac_cache_.bus_pq = SolverBusIdVect();
-    dc_cache_.bus_pv = SolverBusIdVect();
-    dc_cache_.bus_pq = SolverBusIdVect();
-    dc_cache_.slack_weights = RealVect();
-    ac_cache_.algo_needs_rebuild = false;  // the algorithms themselves are reset below
-    dc_cache_.algo_needs_rebuild = false;
-
     algo_controler_.ac_algo_controler().tell_all_changed();
     algo_controler_.dc_algo_controler().tell_all_changed();
-    tell_solver_need_reset(); // also handles ac_cache_.last_bus_status
-    
-    ac_cache_.slack_bus_id_me = GlobalBusIdVect();  // slack bus id, gridmodel number
-    ac_cache_.slack_bus_id_solver = SolverBusIdVect();  // slack bus id, solver number
-    dc_cache_.slack_bus_id_me = GlobalBusIdVect();
-    dc_cache_.slack_bus_id_solver = SolverBusIdVect();
-    ac_cache_.slack_weights = RealVect();
+    // Retires BOTH caches -- it clears the connectivity snapshot, which is what
+    // `is_consistent` / `unset_changes()` read as "nothing built". Needed even
+    // for a family whose data was left in place just above: the controls say
+    // everything changed, and the snapshot must not contradict them.
+    prevent_cache_reuse();
 
     // reset the solvers
     if (reset_solver){
+        // The algorithms rebuild from scratch just below, so whatever a previous
+        // divergence asked them to redo is moot. Cleared HERE and not
+        // unconditionally: with `reset_solver` false they keep their internals,
+        // and this flag is then the only thing that will still tell them to
+        // rebuild from the cache.
+        ac_cache_.algo_needs_rebuild = false;
+        dc_cache_.algo_needs_rebuild = false;
+
         _algo.reset();
         _algo.set_lsgrid(this);
         _algo.tell_solver_control(algo_controler_.ac_algo_controler());

--- a/src/core/LSGrid.hpp
+++ b/src/core/LSGrid.hpp
@@ -21,6 +21,7 @@
 #include <cmath>  // for PI
 
 #include "Utils.hpp"
+#include "SolverSideCache.hpp"
 
 // eigen is necessary to easily pass data from numpy to c++ without any copy.
 // and to optimize the matrix operations
@@ -172,22 +173,22 @@ class LS2G_API LSGrid final
          */
         size_t total_bus() const {return substations_.nb_bus();}
 
-        const SolverBusIdVect & id_me_to_ac_solver() const {return id_me_to_ac_solver_;}
-        const GlobalBusIdVect & id_ac_solver_to_me() const {return id_ac_solver_to_me_;}
-        const SolverBusIdVect & id_me_to_dc_solver() const {return id_me_to_dc_solver_;}
-        const GlobalBusIdVect & id_dc_solver_to_me() const {return id_dc_solver_to_me_;}
+        const SolverBusIdVect & id_me_to_ac_solver() const {return ac_cache_.id_me_to_solver;}
+        const GlobalBusIdVect & id_ac_solver_to_me() const {return ac_cache_.id_solver_to_me;}
+        const SolverBusIdVect & id_me_to_dc_solver() const {return dc_cache_.id_me_to_solver;}
+        const GlobalBusIdVect & id_dc_solver_to_me() const {return dc_cache_.id_solver_to_me;}
 
         std::vector<int> id_me_to_ac_solver_numpy() const {
-            return id_me_to_ac_solver_.to_int_vector();
+            return ac_cache_.id_me_to_solver.to_int_vector();
         }
         std::vector<int> id_ac_solver_to_me_numpy() const {
-            return id_ac_solver_to_me_.to_int_vector();
+            return ac_cache_.id_solver_to_me.to_int_vector();
         }
         std::vector<int> id_me_to_dc_solver_numpy() const {
-            return id_me_to_dc_solver_.to_int_vector();
+            return dc_cache_.id_me_to_solver.to_int_vector();
         }
         std::vector<int> id_dc_solver_to_me_numpy() const {
-            return id_dc_solver_to_me_.to_int_vector();
+            return dc_cache_.id_solver_to_me.to_int_vector();
         }
 
         // retrieve the underlying data (raw class)
@@ -515,8 +516,8 @@ class LS2G_API LSGrid final
             // must not conclude anything about DC, which may be several grid
             // modifications behind. A snapshot is refreshed only by
             // _mark_cache_valid(), ie when that family has actually rebuilt.
-            _flag_dimension_change(new_status, last_bus_status_saved_, algo_controler_.ac_algo_controler());
-            _flag_dimension_change(new_status, last_bus_status_dc_, algo_controler_.dc_algo_controler());
+            _flag_dimension_change(new_status, ac_cache_.last_bus_status, algo_controler_.ac_algo_controler());
+            _flag_dimension_change(new_status, dc_cache_.last_bus_status, algo_controler_.dc_algo_controler());
         }
         void set_substation_names(const std::vector<std::string> & sub_names){
             substations_.init_sub_names(sub_names);
@@ -608,13 +609,13 @@ class LS2G_API LSGrid final
         // answer is identical either way, so this is a debugging switch (is a
         // wrong result a caching bug?) or a safety net for code that mutates the
         // containers behind LSGrid's back -- not something a normal user needs.
-        void allow_ac_cache_reuse(bool allowed){allow_ac_cache_reuse_ = allowed;}
-        void allow_dc_cache_reuse(bool allowed){allow_dc_cache_reuse_ = allowed;}
-        void allow_cache_reuse(bool allowed){allow_ac_cache_reuse_ = allowed; allow_dc_cache_reuse_ = allowed;}
-        [[nodiscard]] bool get_allow_ac_cache_reuse() const {return allow_ac_cache_reuse_;}
-        [[nodiscard]] bool get_allow_dc_cache_reuse() const {return allow_dc_cache_reuse_;}
+        void allow_ac_cache_reuse(bool allowed){ac_cache_.allow_reuse = allowed;}
+        void allow_dc_cache_reuse(bool allowed){dc_cache_.allow_reuse = allowed;}
+        void allow_cache_reuse(bool allowed){ac_cache_.allow_reuse = allowed; dc_cache_.allow_reuse = allowed;}
+        [[nodiscard]] bool get_allow_ac_cache_reuse() const {return ac_cache_.allow_reuse;}
+        [[nodiscard]] bool get_allow_dc_cache_reuse() const {return dc_cache_.allow_reuse;}
         // true only when BOTH families are allowed to reuse their cache
-        [[nodiscard]] bool get_allow_cache_reuse() const {return allow_ac_cache_reuse_ && allow_dc_cache_reuse_;}
+        [[nodiscard]] bool get_allow_cache_reuse() const {return ac_cache_.allow_reuse && dc_cache_.allow_reuse;}
 
         /**
          * Throw away everything a family cached and start its next powerflow from
@@ -629,14 +630,8 @@ class LS2G_API LSGrid final
          *
          * Formerly `tell_solver_need_reset()`, still available under that name.
          */
-        void prevent_ac_cache_reuse(){
-            last_bus_status_saved_ = std::vector<bool>(substations_.nb_bus(), false);
-            algo_controler_.ac_algo_controler().tell_solver_need_reset();
-        }
-        void prevent_dc_cache_reuse(){
-            last_bus_status_dc_ = std::vector<bool>(substations_.nb_bus(), false);
-            algo_controler_.dc_algo_controler().tell_solver_need_reset();
-        }
+        void prevent_ac_cache_reuse(){_retire_cache(ac_cache_, algo_controler_.ac_algo_controler());}
+        void prevent_dc_cache_reuse(){_retire_cache(dc_cache_, algo_controler_.dc_algo_controler());}
         void prevent_cache_reuse(){prevent_ac_cache_reuse(); prevent_dc_cache_reuse();}
         // backward-compatible name of `prevent_cache_reuse()`
         void tell_solver_need_reset(){prevent_cache_reuse();}
@@ -656,7 +651,7 @@ class LS2G_API LSGrid final
          * Kept for backward compatibility: new code should simply not call it.
          */
         void unset_changes(){
-            if(allow_ac_cache_reuse_ && allow_dc_cache_reuse_) return;  // already done, after every powerflow
+            if(ac_cache_.allow_reuse && dc_cache_.allow_reuse) return;  // already done, after every powerflow
             _mark_cache_valid(true);
             _mark_cache_valid(false);
         }  //should be used after the powerflow as run, so some vectors will not be recomputed if not needed.
@@ -1129,7 +1124,7 @@ class LS2G_API LSGrid final
          * controller, and SVC-regulated slack buses. A slack bus that DOES host a
          * local PV generator stays Vm-fixed (PV-like) with no Q equation. AC
          * labelling. Only valid once `pre_process_solver` ran (it needs
-         * `id_me_to_ac_solver_` / `slack_bus_id_ac_solver_`).
+         * `ac_cache_.id_me_to_solver` / `ac_cache_.slack_bus_id_solver`).
          */
         std::set<int> get_free_vm_slack_solver_buses() const;
         /**
@@ -1271,7 +1266,7 @@ class LS2G_API LSGrid final
          * @return Eigen::SparseMatrix<cplx_type> 
          */
         Eigen::SparseMatrix<cplx_type> get_Ybus_solver() const {
-            return Ybus_ac_;  // This is copied to python
+            return ac_cache_.mat;  // This is copied to python
         }
 
         /**
@@ -1289,7 +1284,7 @@ class LS2G_API LSGrid final
          * @return Eigen::SparseMatrix<cplx_type> 
          */
         Eigen::SparseMatrix<real_type> get_dcYbus_solver() const {
-            return Bbus_dc_;  // This is copied to python (DC admittance matrix is real)
+            return dc_cache_.mat;  // This is copied to python (DC admittance matrix is real)
         }
 
         /**
@@ -1307,7 +1302,7 @@ class LS2G_API LSGrid final
          * @return Eigen::Ref<const CplxVect>
          */
         [[nodiscard]] Eigen::Ref<const CplxVect> get_Sbus_solver() const{
-            return acSbus_;
+            return ac_cache_.inj;
         }
 
         /**
@@ -1325,7 +1320,7 @@ class LS2G_API LSGrid final
          * @return Eigen::Ref<const CplxVect>
          */
         [[nodiscard]] Eigen::Ref<const RealVect> get_dcSbus_solver() const{
-            return dcPbus_;  // DC power injection is real (active power P)
+            return dc_cache_.inj;  // DC power injection is real (active power P)
         }
 
         /**
@@ -1345,7 +1340,7 @@ class LS2G_API LSGrid final
          * @return Eigen::Ref<const CplxVect>
          */
         [[nodiscard]] Eigen::SparseMatrix<cplx_type> get_Ybus() const {
-            return _relabel_matrix(Ybus_ac_, id_ac_solver_to_me_);
+            return _relabel_matrix(ac_cache_.mat, ac_cache_.id_solver_to_me);
         }
 
         /**
@@ -1365,7 +1360,7 @@ class LS2G_API LSGrid final
          * @return Eigen::Ref<const CplxVect>
          */
         [[nodiscard]] Eigen::SparseMatrix<real_type> get_dcYbus() const {
-            return _relabel_matrix(Bbus_dc_, id_dc_solver_to_me_);
+            return _relabel_matrix(dc_cache_.mat, dc_cache_.id_solver_to_me);
         }
 
         /**
@@ -1383,7 +1378,7 @@ class LS2G_API LSGrid final
          * @return Eigen::Ref<const CplxVect>
          */
         [[nodiscard]] CplxVect get_Sbus() const {
-            return _relabel_vector(acSbus_, id_ac_solver_to_me_);
+            return _relabel_vector(ac_cache_.inj, ac_cache_.id_solver_to_me);
         }
 
         /**
@@ -1401,7 +1396,7 @@ class LS2G_API LSGrid final
          * @return Eigen::Ref<const CplxVect>
          */
         [[nodiscard]] RealVect get_dcSbus() const {
-            return _relabel_vector(dcPbus_, id_dc_solver_to_me_);
+            return _relabel_vector(dc_cache_.inj, dc_cache_.id_solver_to_me);
         }
 
         /**
@@ -1412,7 +1407,7 @@ class LS2G_API LSGrid final
          * @return Eigen::Ref<const Eigen::VectorXi> 
          */
         [[nodiscard]] const SolverBusIdVect & get_pv_solver() const{
-            return _has_ac_cache() ? bus_pv_ac_ : bus_pv_dc_;
+            return _has_ac_cache() ? ac_cache_.bus_pv : dc_cache_.bus_pv;
         }
         /**
          * @brief Get the vector (list) of pv buses, solver labelling
@@ -1430,10 +1425,10 @@ class LS2G_API LSGrid final
         // behind the other), so ask for the one you mean: the family-less
         // accessors above answer for AC when an AC powerflow has run, and only
         // fall back to DC otherwise.
-        [[nodiscard]] const SolverBusIdVect & get_ac_pv_solver() const {return bus_pv_ac_;}
-        [[nodiscard]] const SolverBusIdVect & get_dc_pv_solver() const {return bus_pv_dc_;}
-        [[nodiscard]] Eigen::Ref<const IntVect> get_ac_pv_solver_numpy() const {return bus_pv_ac_.as_eigen();}
-        [[nodiscard]] Eigen::Ref<const IntVect> get_dc_pv_solver_numpy() const {return bus_pv_dc_.as_eigen();}
+        [[nodiscard]] const SolverBusIdVect & get_ac_pv_solver() const {return ac_cache_.bus_pv;}
+        [[nodiscard]] const SolverBusIdVect & get_dc_pv_solver() const {return dc_cache_.bus_pv;}
+        [[nodiscard]] Eigen::Ref<const IntVect> get_ac_pv_solver_numpy() const {return ac_cache_.bus_pv.as_eigen();}
+        [[nodiscard]] Eigen::Ref<const IntVect> get_dc_pv_solver_numpy() const {return dc_cache_.bus_pv.as_eigen();}
 
         /**
          * @brief Get the vector (list) of pv buses, gridmodel labelling
@@ -1443,8 +1438,8 @@ class LS2G_API LSGrid final
          * @return const Eigen::VectorXi
          */
         [[nodiscard]] GlobalBusIdVect get_pv() const{
-            if(_has_ac_cache()) return _relabel_vector2<SolverBusIdVect, GlobalBusIdVect>(bus_pv_ac_, id_ac_solver_to_me_);
-            if(id_dc_solver_to_me_.size() > 0) return _relabel_vector2<SolverBusIdVect, GlobalBusIdVect>(bus_pv_dc_, id_dc_solver_to_me_);
+            if(_has_ac_cache()) return _relabel_vector2<SolverBusIdVect, GlobalBusIdVect>(ac_cache_.bus_pv, ac_cache_.id_solver_to_me);
+            if(dc_cache_.id_solver_to_me.size() > 0) return _relabel_vector2<SolverBusIdVect, GlobalBusIdVect>(dc_cache_.bus_pv, dc_cache_.id_solver_to_me);
             throw std::runtime_error("LSGrid::get_pv: impossible to retrieve the `gridmodel` bus label as it appears no powerflow has run.");
         }
         [[nodiscard]] IntVect get_pv_numpy() const{
@@ -1459,7 +1454,7 @@ class LS2G_API LSGrid final
          * @return Eigen::Ref<const Eigen::VectorXi> 
          */
         [[nodiscard]] const SolverBusIdVect & get_pq_solver() const{
-            return _has_ac_cache() ? bus_pq_ac_ : bus_pq_dc_;
+            return _has_ac_cache() ? ac_cache_.bus_pq : dc_cache_.bus_pq;
         }
         /**
          * @brief Get the vector (list) of pq buses, solver labelling
@@ -1472,10 +1467,10 @@ class LS2G_API LSGrid final
             return get_pq_solver().as_eigen();  // was _to_intvect()
         }
         // per-family variants, see get_ac_pv_solver / get_dc_pv_solver above
-        [[nodiscard]] const SolverBusIdVect & get_ac_pq_solver() const {return bus_pq_ac_;}
-        [[nodiscard]] const SolverBusIdVect & get_dc_pq_solver() const {return bus_pq_dc_;}
-        [[nodiscard]] Eigen::Ref<const IntVect> get_ac_pq_solver_numpy() const {return bus_pq_ac_.as_eigen();}
-        [[nodiscard]] Eigen::Ref<const IntVect> get_dc_pq_solver_numpy() const {return bus_pq_dc_.as_eigen();}
+        [[nodiscard]] const SolverBusIdVect & get_ac_pq_solver() const {return ac_cache_.bus_pq;}
+        [[nodiscard]] const SolverBusIdVect & get_dc_pq_solver() const {return dc_cache_.bus_pq;}
+        [[nodiscard]] Eigen::Ref<const IntVect> get_ac_pq_solver_numpy() const {return ac_cache_.bus_pq.as_eigen();}
+        [[nodiscard]] Eigen::Ref<const IntVect> get_dc_pq_solver_numpy() const {return dc_cache_.bus_pq.as_eigen();}
 
         /**
          * @brief Get the vector (list) of pq buses, grimodel labelling
@@ -1485,8 +1480,8 @@ class LS2G_API LSGrid final
          * @return const Eigen::VectorXi
          */
         [[nodiscard]] GlobalBusIdVect get_pq() const{
-            if(_has_ac_cache()) return _relabel_vector2<SolverBusIdVect, GlobalBusIdVect>(bus_pq_ac_, id_ac_solver_to_me_);
-            if(id_dc_solver_to_me_.size() > 0) return _relabel_vector2<SolverBusIdVect, GlobalBusIdVect>(bus_pq_dc_, id_dc_solver_to_me_);
+            if(_has_ac_cache()) return _relabel_vector2<SolverBusIdVect, GlobalBusIdVect>(ac_cache_.bus_pq, ac_cache_.id_solver_to_me);
+            if(dc_cache_.id_solver_to_me.size() > 0) return _relabel_vector2<SolverBusIdVect, GlobalBusIdVect>(dc_cache_.bus_pq, dc_cache_.id_solver_to_me);
             throw std::runtime_error("LSGrid::get_pq: impossible to retrieve the `gridmodel` bus label as it appears no powerflow has run.");
         }
         [[nodiscard]] IntVect get_pq_numpy() const{
@@ -1499,7 +1494,7 @@ class LS2G_API LSGrid final
          * @return Eigen::Ref<const Eigen::VectorXi> 
          */
         [[nodiscard]] const SolverBusIdVect & get_slack_ids_solver() const{
-            return slack_bus_id_ac_solver_;
+            return ac_cache_.slack_bus_id_solver;
         }
         /**
          * @brief Get the vector (list) of pq buses, grimodel labelling
@@ -1509,7 +1504,7 @@ class LS2G_API LSGrid final
          * @return const Eigen::VectorXi
          */
         [[nodiscard]] Eigen::Ref<const IntVect> get_slack_ids_solver_numpy() const{
-            return slack_bus_id_ac_solver_.as_eigen();  // was _to_intvect()
+            return ac_cache_.slack_bus_id_solver.as_eigen();  // was _to_intvect()
         }
 
         /**
@@ -1518,7 +1513,7 @@ class LS2G_API LSGrid final
          * @return const Eigen::VectorXi 
          */
         [[nodiscard]] GlobalBusIdVect get_slack_ids() const {
-            return _relabel_vector2<SolverBusIdVect, GlobalBusIdVect>(slack_bus_id_ac_solver_, id_ac_solver_to_me_);
+            return _relabel_vector2<SolverBusIdVect, GlobalBusIdVect>(ac_cache_.slack_bus_id_solver, ac_cache_.id_solver_to_me);
         }
         [[nodiscard]] IntVect get_slack_ids_numpy() const {
             return get_slack_ids().as_eigen();  // was _to_intvect()
@@ -1530,7 +1525,7 @@ class LS2G_API LSGrid final
          * @return const SolverBusIdVect &
          */
         [[nodiscard]] const SolverBusIdVect & get_slack_ids_dc_solver() const{
-            return slack_bus_id_dc_solver_;
+            return dc_cache_.slack_bus_id_solver;
         }
         /**
          * @brief Get the ids of the buses that participate to the slack (DC), solver labelling
@@ -1538,13 +1533,13 @@ class LS2G_API LSGrid final
          * @return Eigen::Ref<const IntVect> 
          */
         [[nodiscard]] Eigen::Ref<const IntVect> get_slack_ids_dc_solver_numpy() const{
-            return slack_bus_id_dc_solver_.as_eigen();  // was _to_intvect()
+            return dc_cache_.slack_bus_id_solver.as_eigen();  // was _to_intvect()
         }
 
         [[nodiscard]] GlobalBusIdVect get_slack_ids_dc() const{
             return _relabel_vector2<SolverBusIdVect, GlobalBusIdVect>(
-                slack_bus_id_dc_solver_,
-                id_dc_solver_to_me_);
+                dc_cache_.slack_bus_id_solver,
+                dc_cache_.id_solver_to_me);
         }
         /**
          * @brief Get the ids of the buses that participate to the slack (DC), gridmodel labelling
@@ -1563,11 +1558,11 @@ class LS2G_API LSGrid final
          * @return Eigen::Ref<const RealVect> 
          */
         [[nodiscard]] Eigen::Ref<const RealVect> get_slack_weights_solver() const{
-            return _has_ac_cache() ? slack_weights_ac_ : slack_weights_dc_;
+            return _has_ac_cache() ? ac_cache_.slack_weights : dc_cache_.slack_weights;
         }
         // per-family variants, see get_ac_pv_solver / get_dc_pv_solver above
-        [[nodiscard]] Eigen::Ref<const RealVect> get_ac_slack_weights_solver() const {return slack_weights_ac_;}
-        [[nodiscard]] Eigen::Ref<const RealVect> get_dc_slack_weights_solver() const {return slack_weights_dc_;}
+        [[nodiscard]] Eigen::Ref<const RealVect> get_ac_slack_weights_solver() const {return ac_cache_.slack_weights;}
+        [[nodiscard]] Eigen::Ref<const RealVect> get_dc_slack_weights_solver() const {return dc_cache_.slack_weights;}
 
         /**
          * @brief Get the slack weights for each buses (gridmodel labelling)
@@ -1577,8 +1572,8 @@ class LS2G_API LSGrid final
          * @return Eigen::Ref<const RealVect> 
          */
         [[nodiscard]] RealVect get_slack_weights() const{
-            if(_has_ac_cache()) return _relabel_vector(slack_weights_ac_, id_ac_solver_to_me_);
-            if(id_dc_solver_to_me_.size() > 0) return _relabel_vector(slack_weights_dc_, id_dc_solver_to_me_);
+            if(_has_ac_cache()) return _relabel_vector(ac_cache_.slack_weights, ac_cache_.id_solver_to_me);
+            if(dc_cache_.id_solver_to_me.size() > 0) return _relabel_vector(dc_cache_.slack_weights, dc_cache_.id_solver_to_me);
             throw std::runtime_error("LSGrid::get_slack_weights: impossible to retrieve the `gridmodel` bus label as it appears no powerflow has run.");
         }
 
@@ -1597,8 +1592,8 @@ class LS2G_API LSGrid final
          * @return CplxVect
          */
         [[nodiscard]] CplxVect get_V() const{
-            if(id_ac_solver_to_me_.size() > 0) return _relabel_vector(get_V_solver(), id_ac_solver_to_me_);
-            if(id_dc_solver_to_me_.size() > 0) return _relabel_vector(get_V_solver(), id_dc_solver_to_me_);
+            if(ac_cache_.id_solver_to_me.size() > 0) return _relabel_vector(get_V_solver(), ac_cache_.id_solver_to_me);
+            if(dc_cache_.id_solver_to_me.size() > 0) return _relabel_vector(get_V_solver(), dc_cache_.id_solver_to_me);
             throw std::runtime_error("LSGrid::get_V: impossible to retrieve the `gridmodel` bus label as it appears no powerflow has run.");
         }
 
@@ -1617,8 +1612,8 @@ class LS2G_API LSGrid final
          * @return const RealVect
          */
         [[nodiscard]] RealVect get_Va() const{
-            if(id_ac_solver_to_me_.size() > 0) return _relabel_vector(get_Va_solver(), id_ac_solver_to_me_);
-            if(id_dc_solver_to_me_.size() > 0) return _relabel_vector(get_Va_solver(), id_dc_solver_to_me_);
+            if(ac_cache_.id_solver_to_me.size() > 0) return _relabel_vector(get_Va_solver(), ac_cache_.id_solver_to_me);
+            if(dc_cache_.id_solver_to_me.size() > 0) return _relabel_vector(get_Va_solver(), dc_cache_.id_solver_to_me);
             throw std::runtime_error("LSGrid::get_Va: impossible to retrieve the `gridmodel` bus label as it appears no powerflow has run.");
         }
 
@@ -1637,8 +1632,8 @@ class LS2G_API LSGrid final
          * @return const RealVect
          */
         [[nodiscard]] RealVect get_Vm() const{
-            if(id_ac_solver_to_me_.size() > 0) return _relabel_vector(get_Vm_solver(), id_ac_solver_to_me_);
-            if(id_dc_solver_to_me_.size() > 0) return _relabel_vector(get_Vm_solver(), id_dc_solver_to_me_);
+            if(ac_cache_.id_solver_to_me.size() > 0) return _relabel_vector(get_Vm_solver(), ac_cache_.id_solver_to_me);
+            if(dc_cache_.id_solver_to_me.size() > 0) return _relabel_vector(get_Vm_solver(), dc_cache_.id_solver_to_me);
             throw std::runtime_error("LSGrid::get_Vm: impossible to retrieve the `gridmodel` bus label as it appears no powerflow has run.");
         }
 
@@ -1859,44 +1854,37 @@ class LS2G_API LSGrid final
         is_ac indicates if you want to perform and AC powerflow or a DC powerflow and reset_solver indicates
         if you will perform a powerflow after it or not. (usually put ``true`` here).
 
-        This is use internally by ac_pf or dc_pf but also when doing batched solvers (*eg* TimeSeries or Contingency analysis)
-        **/
-        // `init_pv_vm_targets`: when true (the default, used by the real ac_pf / dc_pf
-        // solves), voltage-controlled elements with no droop/slope (generators, HVDC
-        // converters, zero-slope SVCs -- see SvcContainer::set_vm) have the proposed
-        // voltage MAGNITUDE at their regulated bus snapped to their own target, a
-        // reasonable NR-initialization heuristic. `check_solution` passes `false`: it
-        // is testing a caller-supplied (eg OLF's) voltage as-is, and silently
-        // overwriting it there defeats the whole point of the check -- even a tiny,
-        // physically-correct gap between that voltage and the local target (the
-        // regulator doing its job) can look like a large spurious power mismatch at a
-        // strongly-meshed bus.
-        // Sbus stays a plain reference (not Eigen::Ref): forwarded into
-        // _pre_process_solver_impl's inj, which forwards into prepare_injection,
-        // which reassigns/resizes it.
+        /**
+         * Build (or re-stamp) everything a solver family needs, into `cache`.
+         *
+         * `cache` is the whole output: bus labelling, matrix, injections, slack,
+         * pv-pq split. Passing it as ONE object is the point -- see
+         * SolverSideCache.hpp. Two kinds of caller:
+         *   - this grid itself (ac_pf / dc_pf / check_solution) passes ac_cache_ /
+         *     dc_cache_, so what comes out IS the family cache and may be reused by
+         *     the next powerflow of that family;
+         *   - anything else (the batch algorithms) passes a cache it owns. That
+         *     never reuses, and it leaves this grid's own cache of that family
+         *     marked for a full rebuild -- see the end of _pre_process_solver_impl.
+         *
+         * `init_pv_vm_targets`: when true (every real powerflow), voltage-controlled
+         * elements with no droop/slope (generators, HVDC converters, zero-slope SVCs
+         * -- see SvcContainer::set_vm) have the proposed voltage MAGNITUDE at their
+         * regulated bus snapped to their own target, a reasonable NR-initialization
+         * heuristic. `check_solution` passes false: it is testing a caller-supplied
+         * (eg OLF's) voltage as-is, and silently overwriting it there defeats the
+         * whole point of the check -- even a tiny, physically-correct gap between
+         * that voltage and the local target (the regulator doing its job) can look
+         * like a large spurious power mismatch at a strongly-meshed bus.
+         */
         CplxVect pre_process_solver(const Eigen::Ref<const CplxVect> & Vinit,
-                                    CplxVect & Sbus,
-                                    Eigen::SparseMatrix<cplx_type> & Ybus,
-                                    SolverBusIdVect & id_me_to_solver,
-                                    GlobalBusIdVect & id_solver_to_me,
-                                    GlobalBusIdVect & slack_bus_id_me,
-                                    SolverBusIdVect & slack_bus_id_solver,
-                                    bool is_ac,
+                                    AcSolverCache & cache,
                                     const AlgoControl & solver_control,
                                     bool init_pv_vm_targets = true);
 
-        // DC-specific pre processing: builds the real Bbus (admittance) matrix and the
-        // real Pbus (active power) vector, reusing the shared bus-mapping helpers. Mirrors
-        // pre_process_solver but keeps the whole DC path real (no complex Ybus / Sbus).
-        // Pbus stays a plain reference (not Eigen::Ref): same resize-forwarding
-        // reason as pre_process_solver's Sbus above.
+        /// DC counterpart: real Bbus / Pbus, no `init_pv_vm_targets` (always on).
         CplxVect pre_process_dc_solver(const Eigen::Ref<const CplxVect> & Vinit,
-                                       RealVect & Pbus,
-                                       Eigen::SparseMatrix<real_type> & Bbus,
-                                       SolverBusIdVect & id_me_to_solver,
-                                       GlobalBusIdVect & id_solver_to_me,
-                                       GlobalBusIdVect & slack_bus_id_me,
-                                       SolverBusIdVect & slack_bus_id_solver,
+                                       DcSolverCache & cache,
                                        const AlgoControl & solver_control);
 
         //for FDPF
@@ -2008,7 +1996,7 @@ class LS2G_API LSGrid final
          * from the same vector (input) that uses the solver convention.
          *
          * Overloaded on purpose (not "copy paste, find a better way"): callers pass either
-         * a genuine Eigen::Matrix<T,...> lvalue (eg `acSbus_`) or an Eigen::Ref<const
+         * a genuine Eigen::Matrix<T,...> lvalue (eg `ac_cache_.inj`) or an Eigen::Ref<const
          * Matrix<T,...>> prvalue returned by a `get_..._solver()` accessor (eg
          * `get_V_solver()`). Both need their own overload because T only appears deduced
          * from the argument's own type: a Ref argument cannot deduce T through this
@@ -2090,16 +2078,24 @@ class LS2G_API LSGrid final
         // prepare_injection (CplxVect&/RealVect& overload), which reassigns/resizes it
         // -- not a template-deduction issue here (MatScalar/InjVect are always given
         // explicitly at the two call sites below), just resize-forwarding.
-        template<class MatScalar, class InjVect>
+        // Shared implementation of pre_process_solver (AC: complex Ybus / Sbus) and
+        // pre_process_dc_solver (DC: real Bbus / Pbus). The cache's scalar type
+        // selects the family; the type-specific steps (matrix init / fill, injection
+        // assembly) are tag-dispatched to the overloads just below.
+        template<class MatScalar>
         CplxVect _pre_process_solver_impl(const Eigen::Ref<const CplxVect> & Vinit,
-                                          InjVect & inj,
-                                          Eigen::SparseMatrix<MatScalar> & mat,
-                                          SolverBusIdVect & id_me_to_solver,
-                                          GlobalBusIdVect & id_solver_to_me,
-                                          GlobalBusIdVect & slack_bus_id_me,
-                                          SolverBusIdVect & slack_bus_id_solver,
+                                          SolverSideCache<MatScalar> & cache,
                                           const AlgoControl & solver_control,
                                           bool init_pv_vm_targets);
+
+        // Is `cache` this grid's own cache for its family, or someone else's?
+        // Overloaded rather than branched on a runtime flag: the family is already
+        // in the type, so this is one address comparison and no way to get it wrong.
+        [[nodiscard]] bool _is_own_cache(const AcSolverCache & c) const noexcept {return &c == &ac_cache_;}
+        [[nodiscard]] bool _is_own_cache(const DcSolverCache & c) const noexcept {return &c == &dc_cache_;}
+        /// this grid's own cache for the family `c` belongs to (`c` itself when owned)
+        [[nodiscard]] AcSolverCache & _own_cache_for(const AcSolverCache &) noexcept {return ac_cache_;}
+        [[nodiscard]] DcSolverCache & _own_cache_for(const DcSolverCache &) noexcept {return dc_cache_;}
         // matrix (re)initialization, overloaded per family (no `if constexpr`, C++14)
         void init_solver_matrix(Eigen::SparseMatrix<cplx_type> & mat, int nb_bus_solver){ init_Ybus(mat, nb_bus_solver); }
         void init_solver_matrix(Eigen::SparseMatrix<real_type> & mat, int nb_bus_solver){ init_Bbus(mat, nb_bus_solver); }
@@ -2119,7 +2115,7 @@ class LS2G_API LSGrid final
         void fillBdc(Eigen::SparseMatrix<real_type> & res, const SolverBusIdVect& id_me_to_solver);  // DC: real admittance matrix
         void fillSbus_me(Eigen::Ref<CplxVect> res, bool ac, const SolverBusIdVect& id_me_to_solver);
         // writes the pv / pq split into the caller-supplied vectors: the AC and the
-        // DC family each own theirs (bus_pv_ac_ / bus_pv_dc_, ...), and they are
+        // DC family each own theirs (ac_cache_.bus_pv / dc_cache_.bus_pv, ...), and they are
         // expressed in that family's own solver labelling.
         void fillpv_pq(const SolverBusIdVect& id_me_to_solver,
                        const GlobalBusIdVect& id_solver_to_me,
@@ -2201,21 +2197,35 @@ class LS2G_API LSGrid final
         // Has an AC powerflow ever built the AC solver-side data on this grid?
         // Used by the family-less get_pv_solver() / get_pq_solver() /
         // get_slack_weights_solver() to pick which family to answer for.
-        [[nodiscard]] bool _has_ac_cache() const noexcept {return id_ac_solver_to_me_.size() > 0;}
+        [[nodiscard]] bool _has_ac_cache() const noexcept {return ac_cache_.id_solver_to_me.size() > 0;}
 
         // Record that `family_control`'s cached data now matches the grid: its
         // flags go back to "nothing changed" and its connectivity snapshot is
         // refreshed. Called after every powerflow of that family (converged or
         // not: pre_process built the data against the current grid either way),
         // unless that family's reuse was turned off.
+        void _mark_cache_valid(SolverBusLayout & cache, AlgoControl & control){
+            control.tell_none_changed();
+            cache.last_bus_status = substations_.get_bus_status();
+        }
         void _mark_cache_valid(bool ac){
-            if(ac){
-                algo_controler_.ac_algo_controler().tell_none_changed();
-                last_bus_status_saved_ = substations_.get_bus_status();
-            } else {
-                algo_controler_.dc_algo_controler().tell_none_changed();
-                last_bus_status_dc_ = substations_.get_bus_status();
-            }
+            if(ac) _mark_cache_valid(ac_cache_, algo_controler_.ac_algo_controler());
+            else _mark_cache_valid(dc_cache_, algo_controler_.dc_algo_controler());
+        }
+
+        /**
+         * The opposite of _mark_cache_valid: this family must rebuild from scratch.
+         *
+         * The DATA is deliberately left in place -- `prevent_*_cache_reuse()` is
+         * also how a foreign build's published labelling is retired, and the NR
+         * extensions still have to be able to read it during that build. What goes
+         * is the claim that it is up to date: an empty snapshot fails
+         * `layout_is_usable`, so the next powerflow of this family rebuilds even if
+         * its control were somehow told "nothing changed".
+         */
+        void _retire_cache(SolverBusLayout & cache, AlgoControl & control){
+            cache.last_bus_status.clear();
+            control.tell_solver_need_reset();
         }
 
         // One family's half of init_bus_status(): flag a dimension change iff the
@@ -2272,19 +2282,11 @@ class LS2G_API LSGrid final
         int n_sub_;
         int max_nb_bus_per_sub_;
         SubstationContainer substations_;
-        std::vector<bool> last_bus_status_saved_;
         std::map<std::string, std::string> init_kwargs_;  // see get_init_kwargs()
 
-        // always have the length of the number of buses,
-        // id_me_to_model_[id_me] gives -1 if the bus "id_me" is deactivated, or "id_model" if it is activated.
-        SolverBusIdVect id_me_to_ac_solver_;
-        // convert the bus id from the model to the bus id of me.
-        // it has a variable size, that depends on the number of connected bus. if "id_model" is an id of a bus
-        // sent to the solver, then id_model_to_me_[id_model] is the bus id of this model of the grid.
-        GlobalBusIdVect id_ac_solver_to_me_;
-
-        SolverBusIdVect id_me_to_dc_solver_;
-        GlobalBusIdVect id_dc_solver_to_me_;
+        // The bus labelling, the matrices, the injections, the slack, the pv-pq
+        // split and each family's connectivity snapshot all live in ac_cache_ /
+        // dc_cache_, declared further down.
 
         // 2. powerline
         LineContainer powerlines_;
@@ -2318,23 +2320,20 @@ class LS2G_API LSGrid final
         // 9b. static var compensators (SVC)
         SvcContainer svcs_;
 
-        // 10. slack bus
-        // std::vector<int> slack_bus_id_;
-        GlobalBusIdVect slack_bus_id_ac_me_;  // slack bus id, gridmodel number
-        SolverBusIdVect slack_bus_id_ac_solver_;  // slack bus id, solver number
-        GlobalBusIdVect slack_bus_id_dc_me_;
-        SolverBusIdVect slack_bus_id_dc_solver_;
-        // AC family's slack weights (solver labelling). The DC twin is appended at
-        // the end of the class -- see the ABI note there.
-        RealVect slack_weights_ac_;
-
-        // as matrix, for the solver
-        Eigen::SparseMatrix<cplx_type> Ybus_ac_;
-        Eigen::SparseMatrix<real_type> Bbus_dc_;  // DC admittance matrix is real (susceptance B)
-        CplxVect acSbus_;
-        RealVect dcPbus_;  // DC power injection is real (active power P)
-        SolverBusIdVect bus_pv_ac_;  // id are the solver internal id and NOT the initial id
-        SolverBusIdVect bus_pq_ac_;  // id are the solver internal id and NOT the initial id
+        // ---- what each solver family cached -----------------------------------
+        // One object per family, not eighteen loose members. Everything a family
+        // solves with -- the compact bus labelling, its matrix, its injections,
+        // its slack, its pv-pq split -- plus the bookkeeping that says whether any
+        // of it may still be reused. They are one picture of the grid taken at one
+        // instant and expressed in ONE bus labelling, so they are built together,
+        // handed over together and thrown away together; see SolverSideCache.hpp
+        // for why that has to be structural rather than a convention.
+        // This is also where anything else a family needs to cache goes (remote /
+        // shared voltage-control layouts, HVDC droop data, ...): add a field there
+        // and it inherits the lifetime and the invalidation rules of everything
+        // already in it, instead of adding one more `_ac_` / `_dc_` pair here.
+        AcSolverCache ac_cache_;
+        DcSolverCache dc_cache_;
 
         // TODO have version of the stuff above for the public api, indexed with "me" and not "solver"
 
@@ -2342,54 +2341,9 @@ class LS2G_API LSGrid final
         AlgorithmSelector _algo;
         AlgorithmSelector _dc_algo;
 
-        // forced angle-reference slack bus (gridmodel id, -1 = none). Declared
-        // LAST so existing member offsets are unchanged (ABI-stable for the
-        // gpusim2grid cross-module LSGrid cast). See set_reference_slack_bus.
+        // forced angle-reference slack bus (gridmodel id, -1 = none).
+        // See set_reference_slack_bus.
         int _forced_ref_slack_bus_id = -1;
-
-        // ---- DC twins of the solver-side data ---------------------------------
-        // The AC and the DC solver each cache their own bus labelling, matrix and
-        // injection vector; these three used to be the exception -- one shared
-        // copy for both families, silently overwritten by whichever solved last.
-        // That is what made `unset_changes()` unsafe across families (a family
-        // could reuse its own maps while reading the other's pv / pq split) and
-        // it is what makes per-family cache reuse possible now that it is gone.
-        // Appended here, after _forced_ref_slack_bus_id, for the same ABI reason
-        // as above: the AC copies keep the offsets they always had.
-        RealVect slack_weights_dc_;
-        SolverBusIdVect bus_pv_dc_;  // id are the solver internal id and NOT the initial id
-        SolverBusIdVect bus_pq_dc_;  // id are the solver internal id and NOT the initial id
-        // bus connectivity each family's cache was last built with (the AC twin is
-        // `last_bus_status_saved_`, kept under its historical name because it is
-        // the one written to / read from StateRes -- see get_state / set_state,
-        // which restores it into BOTH families).
-        std::vector<bool> last_bus_status_dc_;
-
-        // May a powerflow reuse what the previous one of the same family built
-        // (Ybus / Sbus, the bus labelling, the pv-pq split, the slack weights)?
-        // ON by default: after every powerflow that converges, that family's grid
-        // is marked "nothing changed since" automatically, so the next one only
-        // re-stamps what the grid actually reports as modified. Turn a family off
-        // to force it to rebuild everything on every solve -- the answer is the
-        // same either way, so this is a debugging / paranoia switch, not a
-        // correctness one. See allow_cache_reuse() / prevent_cache_reuse().
-        bool allow_ac_cache_reuse_ = true;
-        bool allow_dc_cache_reuse_ = true;
-
-        // Set when a family's powerflow diverged. The DATA it built (Ybus / Sbus,
-        // the labelling, the pv-pq split) is still a correct picture of the grid
-        // -- divergence is a numerical failure, not a data one -- so it is kept
-        // and stays reusable. What is not reusable is the ALGORITHM's own state:
-        // a half-converged iterate, a factorization of a matrix it gave up on.
-        // That is reset on the spot, and this flag makes the next powerflow hand
-        // the algorithm an "everything changed" control so it rebuilds its
-        // internals (Jacobian sparsity, Bp/Bpp, the linear solver) from the
-        // cached matrices instead of assuming they are still there. The built-in
-        // algorithms would manage without it -- their reset() raises their own
-        // `need_factorize_`, which gates the same rebuilds -- but an external
-        // (plugin) solver is promised nothing beyond the AlgoControl it is given.
-        bool ac_algo_needs_rebuild_ = false;
-        bool dc_algo_needs_rebuild_ = false;
 };
 
 

--- a/src/core/LSGrid.hpp
+++ b/src/core/LSGrid.hpp
@@ -509,7 +509,11 @@ class LS2G_API LSGrid final
             sgens_.reconnect_connected_buses(substations_);
             storages_.reconnect_connected_buses(substations_);
             hvdc_lines_.reconnect_connected_buses(substations_);
-            const std::vector<bool> new_status = substations_.get_bus_status();
+            // by reference: every mutation of the bus status happens in the calls
+            // above, and _flag_dimension_change only reads. Taking it by value here
+            // copied the whole vector on every powerflow that reaches this function,
+            // to be read twice and thrown away.
+            const std::vector<bool> & new_status = substations_.get_bus_status();
 
             // Each family is compared against the connectivity ITS OWN cache was
             // built with: an AC powerflow that finds the AC snapshot up to date

--- a/src/core/LSGrid.hpp
+++ b/src/core/LSGrid.hpp
@@ -641,24 +641,36 @@ class LS2G_API LSGrid final
         void tell_solver_need_reset(){prevent_cache_reuse();}
 
         /**
-         * Inform the grid that a powerflow has been run and that every "past changes"
-         * can be "forgotten" : if a solver is re run, then some things are cached to
-         * avoid un necessary computation.
+         * Tell the grid that everything it built for its solvers still describes the
+         * grid, so the next powerflow of either family can re-stamp only what changed
+         * from now on.
          *
-         * Historical, manual counterpart of the automatic marking described above.
-         * When both families cache automatically (the default) there is nothing
-         * left for it to do and it returns immediately; it only has an effect on a
-         * family whose automatic reuse was turned off -- and even then that
-         * family's `allow_*_cache_reuse(false)` still wins, so the claim is
-         * recorded but the next powerflow of that family rebuilds anyway.
+         * THE USER-FACING, CHECKED ENTRY POINT. Same relationship to
+         * `_mark_cache_valid` as `compute_pf_with_input_validation` has to
+         * `compute_pf`: identical intent, but this one does not take the caller's
+         * word for it. It applies to BOTH families, as it always has -- that is the
+         * historical contract and code written before 1.0.0 relies on it.
          *
-         * Kept for backward compatibility: new code should simply not call it.
+         * Marking both families is also exactly what used to make it dangerous: a
+         * family that had never solved got marked "in sync" alongside one that had,
+         * and its next powerflow took the "nothing to rebuild" path with an empty bus
+         * labelling. So each family is now verified separately before the claim is
+         * recorded -- structurally (is the data there, and the right shape?) and
+         * against the grid's connectivity right now (does that labelling still
+         * describe it?). A family that cannot back the claim is not marked: it is
+         * retired, and rebuilds on its next powerflow. A wrong claim therefore costs
+         * time, never memory safety, and it costs it only to the family that was
+         * wrong.
+         *
+         * Since automatic reuse landed in 1.0.0 there is normally nothing for this to
+         * do -- every powerflow marks its own family on the way out. Kept for
+         * backward compatibility; new code should simply not call it.
          */
         void unset_changes(){
-            if(ac_cache_.allow_reuse && dc_cache_.allow_reuse) return;  // already done, after every powerflow
-            _mark_cache_valid(true);
-            _mark_cache_valid(false);
-        }  //should be used after the powerflow as run, so some vectors will not be recomputed if not needed.
+            const std::size_t nb_bus = substations_.nb_bus();
+            _declare_up_to_date(ac_cache_, algo_controler_.ac_algo_controler(), nb_bus);
+            _declare_up_to_date(dc_cache_, algo_controler_.dc_algo_controler(), nb_bus);
+        }
 
         void tell_recompute_ybus(){algo_controler_.ac_algo_controler().tell_recompute_ybus(); algo_controler_.dc_algo_controler().tell_recompute_ybus();}
         void tell_recompute_sbus(){algo_controler_.ac_algo_controler().tell_recompute_sbus(); algo_controler_.dc_algo_controler().tell_recompute_sbus();}
@@ -2215,6 +2227,41 @@ class LS2G_API LSGrid final
         void _mark_cache_valid(bool ac){
             if(ac) _mark_cache_valid(ac_cache_, algo_controler_.ac_algo_controler());
             else _mark_cache_valid(dc_cache_, algo_controler_.dc_algo_controler());
+        }
+
+        /**
+         * One family's half of `unset_changes()`: record the claim if the cache can
+         * back it, retire the cache if it cannot. Templated on the cache so it can
+         * ask `is_consistent`, which the family-agnostic SolverBusLayout cannot
+         * answer on its own (it does not know about the matrix).
+         *
+         * `allow_reuse` is deliberately NOT consulted. It says whether the next
+         * powerflow MAY reuse the cache; it says nothing about whether the cache
+         * currently describes the grid, which is the only question being asked here.
+         * A family with reuse turned off still gets an honest answer recorded, and
+         * the powerflow path still refuses to reuse it.
+         */
+        template<class Cache>
+        void _declare_up_to_date(Cache & cache, AlgoControl & control, std::size_t nb_bus_grid){
+            // `control.nothing_changed()` is the load-bearing test, and this function
+            // only READS it. The element containers are what declare a change, in
+            // their own modifiers; that is the authority on whether this family's
+            // cache still describes the grid, and nothing here second-guesses it or
+            // adds to it.
+            //
+            // A cache cannot answer the question by looking at itself: change a
+            // line's impedance, a transformer tap or a load's target and every size
+            // in the cache -- and every bus's connected/disconnected status -- is
+            // exactly what it was. Clearing the flags on a false claim is not a
+            // segfault, it is a converged, plausible, wrong answer, because the next
+            // powerflow re-solves the OLD system.
+            //
+            // `is_consistent` is the separate, structural question -- is the data
+            // there at all, and the right shape -- which is what stands between a
+            // claim about a family that never solved and an out-of-bounds read. It
+            // reads only sizes; it says nothing about what changed.
+            if(control.nothing_changed() && cache.is_consistent(nb_bus_grid)) _mark_cache_valid(cache, control);
+            else _retire_cache(cache, control);
         }
 
         /**

--- a/src/core/LSGrid.hpp
+++ b/src/core/LSGrid.hpp
@@ -1871,17 +1871,20 @@ class LS2G_API LSGrid final
         if you will perform a powerflow after it or not. (usually put ``true`` here).
 
         /**
-         * Build (or re-stamp) everything a solver family needs, into `cache`.
+         * Build (or re-stamp) this grid's OWN solver-side cache for the AC family,
+         * and hand the result to this grid's own algorithm.
          *
-         * `cache` is the whole output: bus labelling, matrix, injections, slack,
-         * pv-pq split. Passing it as ONE object is the point -- see
-         * SolverSideCache.hpp. Two kinds of caller:
-         *   - this grid itself (ac_pf / dc_pf / check_solution) passes ac_cache_ /
-         *     dc_cache_, so what comes out IS the family cache and may be reused by
-         *     the next powerflow of that family;
-         *   - anything else (the batch algorithms) passes a cache it owns. That
-         *     never reuses, and it leaves this grid's own cache of that family
-         *     marked for a full rebuild -- see the end of _pre_process_solver_impl.
+         * The cache is not a parameter: there is exactly one AC cache this can mean
+         * (`ac_cache_`), and this entry point is defined by the fact that `_algo` is
+         * about to solve what it produces. It therefore does the two things that only
+         * make sense for our own solve, around the shared build:
+         *   - it decides whether the previous build may be re-stamped rather than
+         *     rebuilt (the reuse policy: `allow_ac_cache_reuse`, the change flags);
+         *   - it resets / re-configures `_algo` to match what was rebuilt.
+         *
+         * To build a system out of this grid into a cache YOU own -- which is what the
+         * batch algorithms do -- call `build_solver_input` instead. That is a
+         * genuinely different operation, not this one with a flag: see there.
          *
          * `init_pv_vm_targets`: when true (every real powerflow), voltage-controlled
          * elements with no droop/slope (generators, HVDC converters, zero-slope SVCs
@@ -1894,13 +1897,47 @@ class LS2G_API LSGrid final
          * like a large spurious power mismatch at a strongly-meshed bus.
          */
         CplxVect pre_process_solver(const Eigen::Ref<const CplxVect> & Vinit,
-                                    AcSolverCache & cache,
                                     const AlgoControl & solver_control,
                                     bool init_pv_vm_targets = true);
 
-        /// DC counterpart: real Bbus / Pbus, no `init_pv_vm_targets` (always on).
+        /// DC counterpart: builds `dc_cache_` (real Bbus / Pbus) for `_dc_algo`, no
+        /// `init_pv_vm_targets` (always on).
         CplxVect pre_process_dc_solver(const Eigen::Ref<const CplxVect> & Vinit,
-                                       DcSolverCache & cache,
+                                       const AlgoControl & solver_control);
+
+        /**
+         * Build a complete AC solver input out of this grid, into a cache the CALLER
+         * owns, to be solved by the CALLER's own algorithm. This is what the batch
+         * algorithms (BaseBatchSolverSynch, working on a private copy of the grid) use.
+         *
+         * Not `pre_process_solver` with a different cache -- a different operation:
+         *
+         *  - It never re-stamps. `solver_control`, this grid's connectivity snapshot
+         *    and its change flags all describe THIS grid; none of them says anything
+         *    about what is in `out`. So `out` is always rebuilt from scratch. (Free in
+         *    practice: a caller handing over its own cache asks for a full rebuild
+         *    anyway -- but that is now a property of this function, not a courtesy of
+         *    the caller.)
+         *  - It leaves `_algo` / `_dc_algo` alone. They are this grid's, they hold a
+         *    factorization of this grid's own cache, and they will not run on `out`.
+         *  - It PUBLISHES the bus labelling and the pv-pq split into this grid's own
+         *    cache, then retires it. The NR extensions (MultiSlack, VoltageControl,
+         *    Hvdc) do not read the cache they were handed: they call back into the
+         *    grid through `lsgrid_ptr` (get_free_vm_slack_solver_buses,
+         *    fill_hvdc_droop_solver_data, fill_voltage_control_solver_data -- that
+         *    last one needs `bus_pq`). During the caller's solve those must answer in
+         *    the caller's labelling, or remote voltage control is silently dropped.
+         *    See the publication step at the end of `_build_foreign_cache`.
+         *
+         * Throws if handed this grid's own cache -- that is `pre_process_solver`.
+         */
+        CplxVect build_solver_input(const Eigen::Ref<const CplxVect> & Vinit,
+                                    AcSolverCache & out,
+                                    const AlgoControl & solver_control);
+
+        /// DC counterpart of `build_solver_input`: real Bbus / Pbus into `out`.
+        CplxVect build_dc_solver_input(const Eigen::Ref<const CplxVect> & Vinit,
+                                       DcSolverCache & out,
                                        const AlgoControl & solver_control);
 
         //for FDPF
@@ -2086,25 +2123,57 @@ class LS2G_API LSGrid final
         }
     
     protected:
-        // Shared implementation of pre_process_solver (AC: complex Ybus / Sbus) and
-        // pre_process_dc_solver (DC: real Bbus / Pbus). The matrix scalar type selects the
-        // family (cplx_type => AC, real_type => DC); the type-specific steps (matrix init / fill,
-        // injection assembly) are tag-dispatched to the overloads just below.
-        // inj stays a plain reference (not Eigen::Ref): it is forwarded straight into
-        // prepare_injection (CplxVect&/RealVect& overload), which reassigns/resizes it
-        // -- not a template-deduction issue here (MatScalar/InjVect are always given
-        // explicitly at the two call sites below), just resize-forwarding.
-        // Shared implementation of pre_process_solver (AC: complex Ybus / Sbus) and
-        // pre_process_dc_solver (DC: real Bbus / Pbus). The cache's scalar type
-        // selects the family; the type-specific steps (matrix init / fill, injection
-        // assembly) are tag-dispatched to the overloads just below.
+        /**
+         * THE BUILD. Everything a solver family needs, assembled out of this grid
+         * into `cache`: bus labelling, matrix, injections, slack, pv-pq split.
+         *
+         * Deliberately knows nothing about whose cache this is. No reuse policy, no
+         * algorithm, no publication -- those are the two entry points' business, and
+         * they are the ONLY thing that differs between them (`_pre_process_own_cache`
+         * and `_build_foreign_cache` below). The cache's scalar type selects the
+         * family; the type-specific steps (matrix init / fill, injection assembly)
+         * are tag-dispatched to the overloads further down.
+         *
+         * `force_full_rebuild` is the caller's half of the "may I re-stamp?" answer:
+         * the own-cache path passes its reuse policy, the foreign path passes true.
+         * It is a parameter and not a member read because it is exactly what the two
+         * entry points disagree about. Note it cannot simply be `redo_all`: that is
+         * recomputed inside, because init_bus_status() can raise
+         * has_dimension_changed() half way through.
+         */
         template<class MatScalar>
-        CplxVect _pre_process_solver_impl(const Eigen::Ref<const CplxVect> & Vinit,
-                                          SolverSideCache<MatScalar> & cache,
-                                          const AlgoControl & solver_control,
-                                          bool init_pv_vm_targets);
+        CplxVect _build_into_cache(const Eigen::Ref<const CplxVect> & Vinit,
+                                   SolverSideCache<MatScalar> & cache,
+                                   const AlgoControl & solver_control,
+                                   bool force_full_rebuild,
+                                   bool init_pv_vm_targets);
+
+        /**
+         * `pre_process_solver` / `pre_process_dc_solver` for either family: the reuse
+         * policy and this grid's algorithm, wrapped around `_build_into_cache`.
+         * `cache` is always ac_cache_ or dc_cache_ -- the public entry points are the
+         * only callers and they pass the member that matches MatScalar.
+         */
+        template<class MatScalar>
+        CplxVect _pre_process_own_cache(const Eigen::Ref<const CplxVect> & Vinit,
+                                        SolverSideCache<MatScalar> & cache,
+                                        const AlgoControl & solver_control,
+                                        bool init_pv_vm_targets);
+
+        /**
+         * `build_solver_input` / `build_dc_solver_input` for either family: a full
+         * rebuild into `out`, then publish the layout into our own cache for the NR
+         * extensions and retire it. Never touches `_algo` / `_dc_algo`.
+         */
+        template<class MatScalar>
+        CplxVect _build_foreign_cache(const Eigen::Ref<const CplxVect> & Vinit,
+                                      SolverSideCache<MatScalar> & out,
+                                      const AlgoControl & solver_control);
 
         // Is `cache` this grid's own cache for its family, or someone else's?
+        // No longer a dispatch -- which entry point you called is what decides that
+        // -- but the precondition check `build_solver_input` rejects a caller with:
+        // handing it our own cache means it wanted `pre_process_solver`.
         // Overloaded rather than branched on a runtime flag: the family is already
         // in the type, so this is one address comparison and no way to get it wrong.
         [[nodiscard]] bool _is_own_cache(const AcSolverCache & c) const noexcept {return &c == &ac_cache_;}

--- a/src/core/SolverSideCache.hpp
+++ b/src/core/SolverSideCache.hpp
@@ -1,0 +1,215 @@
+// Copyright (c) 2026, RTE (https://www.rte-france.com)
+// See AUTHORS.txt
+// This Source Code Form is subject to the terms of the Mozilla Public License, version 2.0.
+// If a copy of the Mozilla Public License, version 2.0 was not distributed with this file,
+// you can obtain one at http://mozilla.org/MPL/2.0/.
+// SPDX-License-Identifier: MPL-2.0
+// This file is part of LightSim2grid, LightSim2grid implements a c++ backend targeting the Grid2Op platform.
+
+#ifndef LS2G_SOLVER_SIDE_CACHE_H
+#define LS2G_SOLVER_SIDE_CACHE_H
+
+#include <type_traits>
+#include <vector>
+
+#include "Eigen/Core"
+#include "Eigen/Sparse"
+
+#include "TaggedIdVec.hpp"
+#include "Utils.hpp"
+#include "ls2g_api.hpp"
+
+namespace ls2g {
+
+// ---------------------------------------------------------------------------
+// WHY A SOLVER-SIDE CACHE IS ONE OBJECT
+//
+// The bus labelling, the matrix, the injections, the slack and the pv-pq split
+// are not independent things. They are one picture of the grid taken at one
+// instant, and all of it is expressed in ONE bus labelling -- the compact solver
+// numbering `id_me_to_solver` defines. Mix two instants, or two labellings, and
+// nothing complains: the sizes still match (the bus count rarely changes), the
+// powerflow still converges, and the answer is quietly wrong. No assertion can
+// catch it after the fact, because every number is individually plausible.
+//
+// They used to be nine (then twelve, then eighteen) separate members of LSGrid,
+// built by a function that took six of them as parameters and reached for the
+// other three itself. That is how a batch algorithm building into its own
+// vectors ended up writing its pv-pq split into the grid's cache, next to the
+// grid's own matrix. One object makes that class of mistake unspeakable rather
+// than merely unlikely: you cannot hand a function half of a struct.
+//
+// The split below is by TYPE, not by lifetime: SolverBusLayout is the part whose
+// type does not mention the family's scalar, SolverSideCache<MatScalar> adds the
+// two that do. Both halves are per family and are built, reused and retired as
+// one unit.
+// ---------------------------------------------------------------------------
+
+/**
+ * The half of a solver-side cache whose TYPE does not depend on the family: the
+ * bus labelling, the slack, the pv-pq split, and the bookkeeping that says
+ * whether any of it is still valid.
+ *
+ * Split out from SolverSideCache so that code which is generic over the family
+ * -- the batch algorithms, which run AC or DC but never both in one sweep -- can
+ * name and pass it without knowing which of Ybus/Bbus sits next to it. The VALUES
+ * are still per family: an AC and a DC cache each own a full one of these, they
+ * are never shared. That is the whole point; sharing them across families is what
+ * used to make a "nothing changed" claim unsound.
+ *
+ * New per-family state that is not a matrix or an injection vector (remote /
+ * shared voltage-control layouts, HVDC droop data, ...) belongs here.
+ */
+struct SolverBusLayout
+{
+    // ---- the bus labelling everything is expressed in ---------------------
+    /// grid ("me") bus id -> solver bus id; sized by the grid's total bus count,
+    /// `_deactivated_bus_id` wherever a bus carries nothing
+    SolverBusIdVect id_me_to_solver;
+    /// solver bus id -> grid bus id; sized by the number of buses actually solved
+    GlobalBusIdVect id_solver_to_me;
+
+    // ---- the slack ---------------------------------------------------------
+    GlobalBusIdVect slack_bus_id_me;      ///< slack buses, grid numbering
+    SolverBusIdVect slack_bus_id_solver;  ///< the same, solver numbering
+    RealVect slack_weights;               ///< distributed-slack share per solver bus
+
+    // ---- the pv / pq split -------------------------------------------------
+    SolverBusIdVect bus_pv;  ///< solver ids, NOT grid ids
+    SolverBusIdVect bus_pq;  ///< solver ids, NOT grid ids
+
+    // ---- what makes the above reusable, or not -----------------------------
+    /**
+     * The grid's bus connectivity at the moment this cache was built. A powerflow
+     * compares the grid's current connectivity against this to decide whether the
+     * labelling above still describes it; each family keeps its own, because a
+     * family that has not solved in a while may be several grid modifications
+     * behind the other one. Empty means "nothing built" -- which is also how a
+     * cache is retired without throwing its contents away (see the publication
+     * step at the end of LSGrid::_pre_process_solver_impl).
+     */
+    std::vector<bool> last_bus_status;
+    /**
+     * Durable "never reuse this" switch (LSGrid::allow_ac_cache_reuse etc.). The
+     * answer is identical either way, so this is a debugging switch and an escape
+     * hatch for code that mutates the grid behind LSGrid's back.
+     */
+    bool allow_reuse = true;
+    /**
+     * Set when this family's previous powerflow diverged and its algorithm was
+     * reset: the DATA is still a correct picture of the grid (divergence is a
+     * numerical failure, not a data one) but the algorithm must rebuild its own
+     * internals from it rather than skip on a "nothing changed" it cannot honour.
+     * Cleared once the algorithm has actually run.
+     */
+    bool algo_needs_rebuild = false;
+
+    /// number of buses in the solved system (0 when nothing was ever built)
+    [[nodiscard]] Eigen::Index nb_bus_solver() const noexcept {
+        return static_cast<Eigen::Index>(id_solver_to_me.size());
+    }
+
+    /// Back to "this family has never solved", for everything in this half.
+    void clear_layout(){
+        id_me_to_solver = SolverBusIdVect();
+        id_solver_to_me = GlobalBusIdVect();
+        slack_bus_id_me = GlobalBusIdVect();
+        slack_bus_id_solver = SolverBusIdVect();
+        slack_weights = RealVect();
+        bus_pv = SolverBusIdVect();
+        bus_pq = SolverBusIdVect();
+        last_bus_status.clear();
+    }
+
+    /// the family-agnostic half of is_usable(); see there for why this exists
+    [[nodiscard]] bool layout_is_usable(std::size_t nb_bus_grid) const noexcept {
+        const Eigen::Index nb_solver = nb_bus_solver();
+        if(!allow_reuse) return false;              // told never to reuse
+        if(nb_solver == 0) return false;            // never built
+        if(id_me_to_solver.size() != nb_bus_grid) return false;  // built for another grid size
+        if(slack_weights.size() != nb_solver) return false;
+        // every bus is pv, pq, or slack: the split can never outnumber the system
+        if(bus_pv.size() + bus_pq.size() > static_cast<std::size_t>(nb_solver)) return false;
+        // a snapshot that does not cover the grid means "retired", see last_bus_status
+        if(last_bus_status.size() != nb_bus_grid) return false;
+        return true;
+    }
+};
+
+/**
+ * One solver family's complete cache: the layout above, plus the two things whose
+ * type depends on the family.
+ *
+ * The template parameter picks the family: `cplx_type` is AC (complex admittance
+ * Ybus, complex injection Sbus), `real_type` is DC (real susceptance Bbus, real
+ * active injection Pbus). Everything else is inherited, which is why the two
+ * families share one definition instead of two hand-kept-in-sync copies.
+ */
+template<class MatScalar>
+struct SolverSideCache final : SolverBusLayout
+{
+    static_assert(std::is_same<MatScalar, cplx_type>::value ||
+                  std::is_same<MatScalar, real_type>::value,
+                  "SolverSideCache: MatScalar must be cplx_type (AC) or real_type (DC)");
+
+    /// complex Sbus for the AC family, real Pbus for the DC one
+    using InjVect = typename std::conditional<std::is_same<MatScalar, cplx_type>::value,
+                                              CplxVect, RealVect>::type;
+    using Matrix = Eigen::SparseMatrix<MatScalar>;
+
+    /// true for the AC family. A compile-time constant, usable wherever the old
+    /// runtime `is_ac` flag was threaded through by hand.
+    static constexpr bool is_ac = std::is_same<MatScalar, cplx_type>::value;
+
+    /// Ybus (AC, complex) / Bbus (DC, real), square, nb_bus_solver()
+    Matrix mat;
+    /// Sbus (AC, complex) / Pbus (DC, real), per unit, nb_bus_solver()
+    InjVect inj;
+
+    /// Back to "this family has never solved". Everything that describes a built
+    /// system goes, the two policy flags stay: `allow_reuse` is the caller's
+    /// standing choice, not derived state, and `algo_needs_rebuild` is about the
+    /// algorithm, which a caller resets separately when it means to.
+    void clear(){
+        clear_layout();
+        mat = Matrix();
+        inj = InjVect();
+    }
+
+    /**
+     * Is there really a system in here, of the shape the caller is about to claim
+     * is up to date, for a grid with `nb_bus_grid` buses?
+     *
+     * This is the one guard between a "nothing changed" claim and an out-of-bounds
+     * read. A powerflow's change flags only record what happened SINCE that family
+     * last solved; they cannot say whether it ever solved at all. Nothing stops a
+     * caller from asserting "nothing changed" -- `LSGrid::unset_changes()` does
+     * exactly that, for both families at once -- about a family whose data is still
+     * default-constructed. The "nothing to rebuild" path was then taken with an
+     * empty `id_me_to_solver` / `mat` / `inj`, and everything downstream indexes
+     * them with bus ids in the hundreds. Release wheels are -O3 -DNDEBUG, so that
+     * is a segfault, not an error.
+     *
+     * So the flags are never trusted alone: check that the data they describe is
+     * really there, and rebuild when it is not. A wrong "nothing changed" then
+     * costs time, never memory safety. A handful of integer comparisons, off any
+     * inner loop -- every size here is O(1) to read.
+     */
+    [[nodiscard]] bool is_usable(std::size_t nb_bus_grid) const noexcept {
+        if(!layout_is_usable(nb_bus_grid)) return false;
+        const Eigen::Index nb_solver = nb_bus_solver();
+        if(mat.rows() != nb_solver) return false;
+        if(mat.cols() != mat.rows()) return false;
+        if(inj.size() != nb_solver) return false;
+        return true;
+    }
+};
+
+/// the AC family: complex Ybus / Sbus
+using AcSolverCache = SolverSideCache<cplx_type>;
+/// the DC family: real Bbus / Pbus
+using DcSolverCache = SolverSideCache<real_type>;
+
+} // namespace ls2g
+
+#endif // LS2G_SOLVER_SIDE_CACHE_H

--- a/src/core/SolverSideCache.hpp
+++ b/src/core/SolverSideCache.hpp
@@ -121,10 +121,9 @@ struct SolverBusLayout
         last_bus_status.clear();
     }
 
-    /// the family-agnostic half of is_usable(); see there for why this exists
-    [[nodiscard]] bool layout_is_usable(std::size_t nb_bus_grid) const noexcept {
+    /// the family-agnostic half of is_consistent(); see there for why this exists
+    [[nodiscard]] bool layout_is_consistent(std::size_t nb_bus_grid) const noexcept {
         const Eigen::Index nb_solver = nb_bus_solver();
-        if(!allow_reuse) return false;              // told never to reuse
         if(nb_solver == 0) return false;            // never built
         if(id_me_to_solver.size() != nb_bus_grid) return false;  // built for another grid size
         if(slack_weights.size() != nb_solver) return false;
@@ -177,32 +176,47 @@ struct SolverSideCache final : SolverBusLayout
     }
 
     /**
-     * Is there really a system in here, of the shape the caller is about to claim
-     * is up to date, for a grid with `nb_bus_grid` buses?
+     * Is there really a system in here, of the shape a caller claiming "nothing
+     * changed" is about to be believed about, for a grid with `nb_bus_grid` buses?
      *
-     * This is the one guard between a "nothing changed" claim and an out-of-bounds
-     * read. A powerflow's change flags only record what happened SINCE that family
-     * last solved; they cannot say whether it ever solved at all. Nothing stops a
-     * caller from asserting "nothing changed" -- `LSGrid::unset_changes()` does
-     * exactly that, for both families at once -- about a family whose data is still
-     * default-constructed. The "nothing to rebuild" path was then taken with an
-     * empty `id_me_to_solver` / `mat` / `inj`, and everything downstream indexes
-     * them with bus ids in the hundreds. Release wheels are -O3 -DNDEBUG, so that
-     * is a segfault, not an error.
+     * This answers "is the DATA there and self-consistent", not "may it be reused"
+     * (`allow_reuse`) and not "has the grid changed since" -- that last one is not a
+     * question a cache can answer about itself, and it is not this object's job:
+     * the element containers declare every change through AlgoControl as they are
+     * modified, and AlgoControl::nothing_changed() is what reads it back.
      *
-     * So the flags are never trusted alone: check that the data they describe is
-     * really there, and rebuild when it is not. A wrong "nothing changed" then
-     * costs time, never memory safety. A handful of integer comparisons, off any
-     * inner loop -- every size here is O(1) to read.
+     * It exists because a powerflow's change flags only record what happened SINCE
+     * that family last solved; they cannot say whether it ever solved at all. A
+     * caller asserting "nothing changed" about a family whose data is still
+     * default-constructed used to take the "nothing to rebuild" path with an empty
+     * `id_me_to_solver` / `mat` / `inj`, and everything downstream indexes them with
+     * bus ids in the hundreds. Release wheels are -O3 -DNDEBUG, so that is a
+     * segfault, not an error.
+     *
+     * Every size here is O(1) to read, so this is a handful of integer comparisons.
+     * It is still off the powerflow path: the only way into the library to claim
+     * "nothing changed" without having built anything is LSGrid::unset_changes(),
+     * and that is where this is checked. The powerflow path keeps it as a debug
+     * assertion -- free in release, and it fires in the C++ suite (which CI runs
+     * under ASan and valgrind) if a future caller finds another way in.
      */
-    [[nodiscard]] bool is_usable(std::size_t nb_bus_grid) const noexcept {
-        if(!layout_is_usable(nb_bus_grid)) return false;
+    [[nodiscard]] bool is_consistent(std::size_t nb_bus_grid) const noexcept {
+        if(!layout_is_consistent(nb_bus_grid)) return false;
         const Eigen::Index nb_solver = nb_bus_solver();
         if(mat.rows() != nb_solver) return false;
         if(mat.cols() != mat.rows()) return false;
         if(inj.size() != nb_solver) return false;
         return true;
     }
+
+    /**
+     * The powerflow path's question: may the next solve of this family reuse what
+     * is in here? Just the switch -- see is_consistent() for why nothing else is
+     * needed here, and _pre_process_solver_impl for the debug assertion that keeps
+     * that reasoning honest.
+     */
+    [[nodiscard]] bool may_be_reused() const noexcept { return allow_reuse; }
+
 };
 
 /// the AC family: complex Ybus / Sbus

--- a/src/core/Utils.hpp
+++ b/src/core/Utils.hpp
@@ -127,6 +127,24 @@ class AlgoControl final
             one_el_change_bus_ = true;
         }
 
+        /**
+         * Is there nothing outstanding -- has every change this control tracks
+         * already been consumed by a solve?
+         *
+         * The exact negation of tell_all_changed(), and the only honest way to ask
+         * "is a cache built against this grid still valid?". A cache cannot answer
+         * that by looking at itself: changing a line's impedance, a tap, or an
+         * injection leaves every vector size and every bus status exactly as it was.
+         * Only these flags know. See LSGrid::unset_changes().
+         */
+        [[nodiscard]] bool nothing_changed() const noexcept {
+            return !change_dimension_ && !pv_changed_ && !pq_changed_ &&
+                   !slack_participate_changed_ && !need_reset_solver_ &&
+                   !need_recompute_sbus_ && !need_recompute_ybus_ && !v_changed_ &&
+                   !slack_weight_changed_ && !ybus_some_coeffs_zero_ &&
+                   !ybus_change_sparsity_pattern_ && !one_el_change_bus_;
+        }
+
         void tell_none_changed(){
             change_dimension_ = false;
             pv_changed_ = false;

--- a/src/core/batch_algorithm/BaseBatchSolverSynch.cpp
+++ b/src/core/batch_algorithm/BaseBatchSolverSynch.cpp
@@ -36,7 +36,7 @@ bool BaseBatchSolverSynch::compute_one_powerflow(
 /**
  V is modified at each call !
  Explicit version: operates on the passed solver / control / accumulators so it
- can run concurrently (one solver per thread). The member Bbus_ is read-only here.
+ can run concurrently (one solver per thread). The member dc_cache_.mat is read-only here.
 **/
 bool BaseBatchSolverSynch::compute_one_powerflow(
     AlgorithmSelector & algo,
@@ -69,17 +69,17 @@ bool BaseBatchSolverSynch::compute_one_powerflow(
             max_iter,
             tol);
     } else {
-        // native real DC entry point: Bbus_ is the (constant) real admittance built in
+        // native real DC entry point: dc_cache_.mat is the (constant) real admittance built in
         // prepare_solver_input_base; Pbus is the real part of the (possibly per-step)
-        // injection. ContingencyAnalysis leaves Sbus_ empty in DC (it relies on the
-        // member Pbus_ built once), so fall back to Pbus_ when no complex Sbus is given.
+        // injection. ContingencyAnalysis leaves ac_cache_.inj empty in DC (it relies on the
+        // member dc_cache_.inj built once), so fall back to dc_cache_.inj when no complex Sbus is given.
         // Split into two branches (rather than a ternary) so the common/no-Sbus case
-        // binds Pbus_ directly instead of unifying both branches into a fresh copy.
+        // binds dc_cache_.inj directly instead of unifying both branches into a fresh copy.
         if(Sbus.size() == 0){
-            conv = algo.compute_pf_dc(Bbus_, V, Pbus_, slack_ids, slack_weights, bus_pv, bus_pq);
+            conv = algo.compute_pf_dc(dc_cache_.mat, V, dc_cache_.inj, slack_ids, slack_weights, bus_pv, bus_pq);
         } else {
             const RealVect Pbus = Sbus.real();
-            conv = algo.compute_pf_dc(Bbus_, V, Pbus, slack_ids, slack_weights, bus_pv, bus_pq);
+            conv = algo.compute_pf_dc(dc_cache_.mat, V, Pbus, slack_ids, slack_weights, bus_pv, bus_pq);
         }
     }
     if(conv && !algo.lazy_v()){
@@ -110,24 +110,24 @@ bool BaseBatchSolverSynch::warmup_solver(
     bool conv;
     if(algo.ac_solver_used()){
         conv = algo.compute_pf(
-            Ybus_,
+            ac_cache_.mat,
             Vinit_solver,
-            Sbus_,
-            slack_ids_solver_.as_eigen(),
-            slack_weights_,
-            bus_pv_.as_eigen(),
-            bus_pq_.as_eigen(),
+            ac_cache_.inj,
+            active_layout().slack_bus_id_solver.as_eigen(),
+            active_layout().slack_weights,
+            active_layout().bus_pv.as_eigen(),
+            active_layout().bus_pq.as_eigen(),
             max_iter,
             tol);
     } else {
         conv = algo.compute_pf_dc(
-            Bbus_,
+            dc_cache_.mat,
             Vinit_solver,
-            Pbus_,
-            slack_ids_solver_.as_eigen(),
-            slack_weights_,
-            bus_pv_.as_eigen(),
-            bus_pq_.as_eigen());
+            dc_cache_.inj,
+            active_layout().slack_bus_id_solver.as_eigen(),
+            active_layout().slack_weights,
+            active_layout().bus_pv.as_eigen(),
+            active_layout().bus_pq.as_eigen());
     }
     // subsequent per-contingency solves reuse the factorization
     control.tell_none_changed();

--- a/src/core/batch_algorithm/BaseBatchSolverSynch.hpp
+++ b/src/core/batch_algorithm/BaseBatchSolverSynch.hpp
@@ -526,11 +526,11 @@ class LS2G_API BaseBatchSolverSynch : protected BaseConstants
             _algo_controler.tell_all_changed();
             CplxVect res;
             if(ac_solver_used){
-                res = _grid_model.pre_process_solver(Vinit, ac_cache_, _algo_controler);
+                res = _grid_model.build_solver_input(Vinit, ac_cache_, _algo_controler);
                 nb_buses_solver_ = static_cast<int>(ac_cache_.mat.cols());
             } else {
                 // native real DC path: build the real Bbus / Pbus
-                res = _grid_model.pre_process_dc_solver(Vinit, dc_cache_, _algo_controler);
+                res = _grid_model.build_dc_solver_input(Vinit, dc_cache_, _algo_controler);
                 nb_buses_solver_ = static_cast<int>(dc_cache_.mat.cols());
             }
             return res;

--- a/src/core/batch_algorithm/BaseBatchSolverSynch.hpp
+++ b/src/core/batch_algorithm/BaseBatchSolverSynch.hpp
@@ -422,7 +422,7 @@ class LS2G_API BaseBatchSolverSynch : protected BaseConstants
         // explicit version: operates on the passed solver / control and writes
         // its book-keeping into the passed accumulators. This is what the
         // multi-threaded ContingencyAnalysis uses (one solver per thread). The
-        // read-only member Bbus_ is only read here (safe to share across threads).
+        // read-only member dc_cache_.mat is only read here (safe to share across threads).
         // V stays plain -- same AC/DC forwarding reason as the member overload above.
         bool compute_one_powerflow(AlgorithmSelector & algo,
                                    AlgoControl & control,
@@ -443,7 +443,7 @@ class LS2G_API BaseBatchSolverSynch : protected BaseConstants
         // Warm up a (freshly built) solver so its symbolic factorization / DC
         // internal Ybus / sparsity pattern match the member solver after the
         // n-powerflow. Mirrors the n-powerflow block of _finish_preprocessing
-        // (works on the member Ybus_ / Bbus_ / Sbus_ / Pbus_ — all read-only).
+        // (works on the member ac_cache_.mat / dc_cache_.mat / ac_cache_.inj / dc_cache_.inj — all read-only).
         // `control` is left in the "nothing changed" state on return so the
         // subsequent per-contingency solves reuse the factorization.
         bool warmup_solver(AlgorithmSelector & algo,
@@ -487,60 +487,52 @@ class LS2G_API BaseBatchSolverSynch : protected BaseConstants
         }
     protected:
 
+        /**
+         * The family-agnostic half of whichever cache this sweep is building into.
+         *
+         * A batch runs AC or DC for its whole life, so exactly one of ac_cache_ /
+         * dc_cache_ is ever populated. Most of this class does not care which --
+         * the bus labelling, the slack and the pv-pq split have the same type
+         * either way -- so it reads them through here rather than branching at
+         * every use. `_ac_solver_used` is set by prepare_solver_input_base, and
+         * defaults to the AC side so that a read before any prep sees an empty
+         * layout rather than a dangling one.
+         */
+        [[nodiscard]] SolverBusLayout & active_layout() noexcept {
+            return _ac_solver_used ? static_cast<SolverBusLayout &>(ac_cache_)
+                                   : static_cast<SolverBusLayout &>(dc_cache_);
+        }
+        [[nodiscard]] const SolverBusLayout & active_layout() const noexcept {
+            return _ac_solver_used ? static_cast<const SolverBusLayout &>(ac_cache_)
+                                   : static_cast<const SolverBusLayout &>(dc_cache_);
+        }
+
         CplxVect prepare_solver_input_base(const Eigen::Ref<const CplxVect> & Vinit, bool ac_solver_used){
-            // clear previous data
-            Sbus_ = CplxVect();
-            Ybus_ = Eigen::SparseMatrix<cplx_type>();
-            Pbus_ = RealVect();
-            Bbus_ = Eigen::SparseMatrix<real_type>();
-            id_solver_to_me_.clear();
-            id_me_to_solver_.clear();
-            slack_ids_solver_ = SolverBusIdVect();
-            slack_ids_me_ = GlobalBusIdVect();
+            // Which family this batch runs, for active_layout(). Fixed for the whole
+            // sweep (it comes from the algorithm), but recorded here rather than
+            // asked of _algo on every access.
+            _ac_solver_used = ac_solver_used;
+
+            // clear previous data: the whole cache, in one call, because it is one
+            // object -- there is no way to forget a field
+            ac_cache_.clear();
+            dc_cache_.clear();
             nb_buses_solver_ = -1;
 
-            // fill the data correctly
+            // fill the data correctly. One call fills the ENTIRE cache -- labelling,
+            // matrix, injections, slack, pv-pq split, slack weights -- into vectors
+            // this batch owns. Nothing of it is left in _grid_model to be collected
+            // afterwards.
             _algo_controler.tell_all_changed();
             CplxVect res;
             if(ac_solver_used){
-                res = _grid_model.pre_process_solver(
-                    Vinit,
-                    Sbus_,
-                    Ybus_,
-                    id_me_to_solver_,
-                    id_solver_to_me_,
-                    slack_ids_me_,
-                    slack_ids_solver_,
-                    ac_solver_used,
-                    _algo_controler);
-                nb_buses_solver_ = static_cast<int>(Ybus_.cols());
+                res = _grid_model.pre_process_solver(Vinit, ac_cache_, _algo_controler);
+                nb_buses_solver_ = static_cast<int>(ac_cache_.mat.cols());
             } else {
                 // native real DC path: build the real Bbus / Pbus
-                res = _grid_model.pre_process_dc_solver(
-                    Vinit,
-                    Pbus_,
-                    Bbus_,
-                    id_me_to_solver_,
-                    id_solver_to_me_,
-                    slack_ids_me_,
-                    slack_ids_solver_,
-                    _algo_controler);
-                nb_buses_solver_ = static_cast<int>(Bbus_.cols());
+                res = _grid_model.pre_process_dc_solver(Vinit, dc_cache_, _algo_controler);
+                nb_buses_solver_ = static_cast<int>(dc_cache_.mat.cols());
             }
-
-            // extract relevant information
-            // ask for the family this batch actually solved with: the grid keeps
-            // one pv-pq split and one set of slack weights PER family, and the
-            // family-less accessors answer for AC whenever an AC powerflow has run
-            // on this grid -- which is not necessarily the one we just built.
-            const SolverBusIdVect & gm_bus_pv = ac_solver_used ? _grid_model.get_ac_pv_solver() : _grid_model.get_dc_pv_solver();
-            const SolverBusIdVect & gm_bus_pq = ac_solver_used ? _grid_model.get_ac_pq_solver() : _grid_model.get_dc_pq_solver();
-            const RealVect gm_bus_sw = ac_solver_used ? _grid_model.get_ac_slack_weights_solver() : _grid_model.get_dc_slack_weights_solver();
-
-            // TODO copies are made here, which is not ideal
-            bus_pv_ = gm_bus_pv;  // was _to_intvect()
-            bus_pq_ = gm_bus_pq;  // was _to_intvect()
-            slack_weights_ = gm_bus_sw;
             return res;
         }
 
@@ -565,7 +557,7 @@ class LS2G_API BaseBatchSolverSynch : protected BaseConstants
 
         // Vinit_solver as Eigen::Ref relies on the reassignment below
         // (Vinit_solver = _algo.get_V()) always being same-size as the caller's
-        // Vinit_solver: both trace back to the same Ybus_/Bbus_ solver-space
+        // Vinit_solver: both trace back to the same ac_cache_.mat/dc_cache_.mat solver-space
         // dimension (nb_buses_solver_) for the duration of one call, so this holds
         // structurally, not by luck. No virtual dispatch here to enforce it --
         // if that invariant is ever broken, Eigen::Ref's operator= will assert
@@ -604,7 +596,7 @@ class LS2G_API BaseBatchSolverSynch : protected BaseConstants
                 // (needed to init the underlying solver with the correct sparsity pattern in particular)
                 _algo_controler.tell_all_changed();
                 _algo.tell_solver_control(_algo_controler);
-                _grid_model.get_generators().set_vm(Vinit_solver, id_me_to_solver_);
+                _grid_model.get_generators().set_vm(Vinit_solver, active_layout().id_me_to_solver);
                 CplxVect Vinit_solver2 = Vinit_solver;
                 bool conv;
                 // the "n" powerflow warm-up solve always needs the full complex V: its
@@ -613,30 +605,30 @@ class LS2G_API BaseBatchSolverSynch : protected BaseConstants
                 // so it must never be lazy, even when the per-row sweep that follows will be.
                 _algo.set_lazy_v(false);
                 if(_algo.ac_solver_used()){
-                    // Sbus_ is already per-unit (pre_process_solver / fillSbus_me divides by
+                    // ac_cache_.inj is already per-unit (pre_process_solver / fillSbus_me divides by
                     // sn_mva when != 1), same convention as LSGrid::ac_pf's acSbus_ -- so tol
                     // (a physical MW/MVAr tolerance) must be converted the same way LSGrid::ac_pf
                     // does (`tol / sn_mva_`), or this initial solve accepts a per-unit mismatch
                     // up to sn_mva times looser than what the caller asked for.
                     conv = _algo.compute_pf(
-                        Ybus_,
+                        ac_cache_.mat,
                         Vinit_solver2,
-                        Sbus_,
-                        slack_ids_solver_.as_eigen(),
-                        slack_weights_,
-                        bus_pv_.as_eigen(),
-                        bus_pq_.as_eigen(),
+                        ac_cache_.inj,
+                        active_layout().slack_bus_id_solver.as_eigen(),
+                        active_layout().slack_weights,
+                        active_layout().bus_pv.as_eigen(),
+                        active_layout().bus_pq.as_eigen(),
                         max_iter,
                         tol / _grid_model.get_sn_mva());
                 } else {
                     conv = _algo.compute_pf_dc(
-                        Bbus_,
+                        dc_cache_.mat,
                         Vinit_solver2,
-                        Pbus_,
-                        slack_ids_solver_.as_eigen(),
-                        slack_weights_,
-                        bus_pv_.as_eigen(),
-                        bus_pq_.as_eigen());
+                        dc_cache_.inj,
+                        active_layout().slack_bus_id_solver.as_eigen(),
+                        active_layout().slack_weights,
+                        active_layout().bus_pv.as_eigen(),
+                        active_layout().bus_pq.as_eigen());
                 }
 
                 // check if we init the n-1 cases with results from the n cases
@@ -648,14 +640,14 @@ class LS2G_API BaseBatchSolverSynch : protected BaseConstants
                     // and never changes across the sweep except where a row explicitly re-seeds it
                     // (BaseBatchSweep::_apply_step_gen_v) -- this is the shared base every row's
                     // magnitude is reconstructed from, see _dc_vm_row_grid.
-                    // Grid buses outside id_solver_to_me_ (eg an unused substation's second bus)
+                    // Grid buses outside active_layout().id_solver_to_me (eg an unused substation's second bus)
                     // default to 0, not 1: they are never part of the solved system, and the legacy
                     // (eager) _voltages was CplxMat::Zero(...)-initialized and never wrote them --
                     // 0 magnitude reproduces that "untouched column reads back as exact complex 0"
                     // contract regardless of theta (also 0 there, for the same reason).
                     _dc_base_vm_solver_ = Vinit_solver.array().abs();
                     _dc_base_vm_grid_ = RealVect::Zero(static_cast<Eigen::Index>(nb_total_bus));
-                    _dc_base_vm_grid_(id_solver_to_me_.as_eigen()) = _dc_base_vm_solver_;
+                    _dc_base_vm_grid_(active_layout().id_solver_to_me.as_eigen()) = _dc_base_vm_solver_;
                 }
 
                 // everything init from n-case above
@@ -691,9 +683,9 @@ class LS2G_API BaseBatchSolverSynch : protected BaseConstants
             if(_dc_gen_v_.rows() == 0) return _dc_base_vm_grid_;
             CplxVect tmp = _dc_base_vm_solver_.cast<cplx_type>();
             const RealVect row = _dc_gen_v_.row(i);
-            _grid_model.get_generators().set_vm(tmp, id_me_to_solver_, row);
+            _grid_model.get_generators().set_vm(tmp, active_layout().id_me_to_solver, row);
             RealVect res = _dc_base_vm_grid_;
-            res(id_solver_to_me_.as_eigen()) = tmp.array().abs();
+            res(active_layout().id_solver_to_me.as_eigen()) = tmp.array().abs();
             return res;
         }
 
@@ -809,23 +801,21 @@ class LS2G_API BaseBatchSolverSynch : protected BaseConstants
         // solver control
         AlgoControl _algo_controler;
 
-        // internal data
-        CplxVect Sbus_;
-        Eigen::SparseMatrix<cplx_type> Ybus_;
-        // DC counterparts (real): the DC solver works on the real system Bbus . theta = Pbus
-        RealVect Pbus_;
-        Eigen::SparseMatrix<real_type> Bbus_;
-        GlobalBusIdVect id_solver_to_me_;
-        SolverBusIdVect id_me_to_solver_;
-        SolverBusIdVect slack_ids_solver_;
-        GlobalBusIdVect slack_ids_me_;
+        // ---- what this batch solves, one object per family --------------------
+        // A batch runs AC or DC, never both, so only one of these is ever built --
+        // `active_layout()` picks it. They belong to the BATCH, not to
+        // `_grid_model`: LSGrid::pre_process_solver fills whichever cache it is
+        // handed, all of it, so nothing this batch builds can end up half in the
+        // grid's cache and half in ours. That used to be exactly what happened --
+        // the pv-pq split and the slack weights were not parameters, so they were
+        // written into the grid's members while everything else came here, and had
+        // to be fetched back out afterwards (three copies, and a grid left holding
+        // a mixture). See SolverSideCache.hpp.
+        AcSolverCache ac_cache_;
+        DcSolverCache dc_cache_;
+        /// which of the two above this sweep is building into; see active_layout()
+        bool _ac_solver_used = true;
         int nb_buses_solver_;
-
-        // TODO everything is copied here
-        // not optimal...
-        SolverBusIdVect bus_pv_;
-        SolverBusIdVect bus_pq_;
-        RealVect slack_weights_;
 
 };
 

--- a/src/core/batch_algorithm/BaseBatchSweep.cpp
+++ b/src/core/batch_algorithm/BaseBatchSweep.cpp
@@ -43,8 +43,8 @@ void BaseBatchSweep<YbusPolicy, SbusPolicy, INIT>::_run_one_step(
     if(invertible){
         conv = compute_one_powerflow(algo, control, nb_solved, nb_converged, timer_solver,
                                      Ybus, V, _step_sbus(i),
-                                     slack_ids_solver_.as_eigen(), slack_weights_,
-                                     bus_pv_.as_eigen(), bus_pq_.as_eigen(),
+                                     active_layout().slack_bus_id_solver.as_eigen(), active_layout().slack_weights,
+                                     active_layout().bus_pv.as_eigen(), active_layout().bus_pq.as_eigen(),
                                      max_iter, tol_solver);
     } else {
         conv = false;
@@ -123,14 +123,14 @@ void BaseBatchSweep<YbusPolicy, SbusPolicy, INIT>::_run_range(
                 continue;
             }
             if(_dc_lazy_storage_used_){
-                _thetas.row(i)(id_solver_to_me_.as_eigen()) = algo.get_Va().array();
+                _thetas.row(i)(active_layout().id_solver_to_me.as_eigen()) = algo.get_Va().array();
                 // marks this row as actually solved -- see _dc_row_solved_ / _dc_vm_row_grid:
                 // a row that never reaches here (eg an islanding DC contingency, which
                 // diverges and is skipped above) must reconstruct as exact complex 0, not
                 // as its (never written, so 0) theta paired with a nonzero base magnitude.
                 if(static_cast<size_t>(i) < _dc_row_solved_.size()) _dc_row_solved_[i] = 1;
             } else {
-                _voltages.row(i)(id_solver_to_me_.as_eigen()) = V.array();
+                _voltages.row(i)(active_layout().id_solver_to_me.as_eigen()) = V.array();
             }
         }
     } catch(...) {
@@ -156,7 +156,7 @@ void BaseBatchSweep<YbusPolicy, SbusPolicy, INIT>::_compute_threaded(
         _algo.set_lazy_v(use_dc_lazy_v);
         int step_diverge = -1;
         std::exception_ptr err;
-        _run_range(0, nb_steps, _algo, _algo_controler, Ybus_, Vinit_solver,
+        _run_range(0, nb_steps, _algo, _algo_controler, ac_cache_.mat, Vinit_solver,
                   ac_solver_used, max_iter, tol_, _nb_solved, _nb_converged, _timer_solver, _timer_modif_Ybus,
                   step_diverge, err, false);
         if(err) std::rethrow_exception(err);
@@ -166,7 +166,7 @@ void BaseBatchSweep<YbusPolicy, SbusPolicy, INIT>::_compute_threaded(
 
     // multi-threaded path: every thread owns its solver and its solver control.
     // The admittance matrix is NOT copied per thread: the topology is fixed here,
-    // so Ybus_/Bbus_ stay read-only for the whole loop and are simply shared.
+    // so ac_cache_.mat/dc_cache_.mat stay read-only for the whole loop and are simply shared.
     auto timer_thread = CustTimer();
     std::vector<std::unique_ptr<AlgorithmSelector> > algos(nb_thread);
     std::vector<AlgoControl> controls(nb_thread);
@@ -192,7 +192,7 @@ void BaseBatchSweep<YbusPolicy, SbusPolicy, INIT>::_compute_threaded(
                               &init_thread, &algos, &controls, &th_nb_solved, &th_nb_converged,
                               &th_timer_solver, &th_timer_modif_ybus, &th_diverge, &th_err, &Vinit_solver](){
             init_thread(t);
-            _run_range(b, e, *algos[t], controls[t], Ybus_, Vinit_solver, ac_solver_used, max_iter, tol_,
+            _run_range(b, e, *algos[t], controls[t], ac_cache_.mat, Vinit_solver, ac_solver_used, max_iter, tol_,
                       th_nb_solved[t], th_nb_converged[t], th_timer_solver[t], th_timer_modif_ybus[t], th_diverge[t], th_err[t], true);
         });
     }
@@ -202,7 +202,7 @@ void BaseBatchSweep<YbusPolicy, SbusPolicy, INIT>::_compute_threaded(
         size_t b, e;
         split_range(nb_steps, nb_thread, 0, b, e);
         init_thread(0);
-        _run_range(b, e, *algos[0], controls[0], Ybus_, Vinit_solver, ac_solver_used, max_iter, tol_,
+        _run_range(b, e, *algos[0], controls[0], ac_cache_.mat, Vinit_solver, ac_solver_used, max_iter, tol_,
                   th_nb_solved[0], th_nb_converged[0], th_timer_solver[0], th_timer_modif_ybus[0], th_diverge[0], th_err[0], true);
     }
 
@@ -237,16 +237,16 @@ void BaseBatchSweep<YbusPolicy, SbusPolicy, INIT>::_compute_threaded(
 
     if(std::min(static_cast<int>(nb_steps), std::max(1, _nb_thread)) <= 1){
         // single-threaded path: reuse the (already warmed-up) member solver, member
-        // Ybus_ and the member accumulators -> identical to the legacy code.
+        // ac_cache_.mat and the member accumulators -> identical to the legacy code.
         _algo.set_lazy_v(use_dc_lazy_v);
         std::exception_ptr err;
         int step_diverge = -1;
         if(mask_mode){
-            _maybe_run_range_masked(0, nb_steps, _algo, _algo_controler, Ybus_, Vinit_solver,
+            _maybe_run_range_masked(0, nb_steps, _algo, _algo_controler, ac_cache_.mat, Vinit_solver,
                                     ac_solver_used, max_iter, tol, sn_mva,
                                     _timer_modif_Ybus, _nb_solved, _nb_converged, _timer_solver, step_diverge, err, false);
         } else {
-            _run_range(0, nb_steps, _algo, _algo_controler, Ybus_, Vinit_solver, ac_solver_used,
+            _run_range(0, nb_steps, _algo, _algo_controler, ac_cache_.mat, Vinit_solver, ac_solver_used,
                       max_iter, tol_, _nb_solved, _nb_converged, _timer_solver, _timer_modif_Ybus, step_diverge, err, false);
         }
         if(err) std::rethrow_exception(err);
@@ -275,7 +275,7 @@ void BaseBatchSweep<YbusPolicy, SbusPolicy, INIT>::_compute_threaded(
         algos[t] = make_thread_algo();
         algos[t]->set_lazy_v(use_dc_lazy_v);
         controls[t] = _algo_controler;
-        ybus_copies[t] = Ybus_;
+        ybus_copies[t] = ac_cache_.mat;
     };
 
     auto timer_thread = CustTimer();

--- a/src/core/batch_algorithm/BaseBatchSweep.hpp
+++ b/src/core/batch_algorithm/BaseBatchSweep.hpp
@@ -599,17 +599,17 @@ class LS2G_API BaseBatchSweep: public BaseBatchSolverSynch
                  typename std::enable_if<Y::supports_contingency && !S::supports_vary, int>::type = 0>
         IntVect is_grid_connected_after_contingency(){
             const bool ac_solver_used = _algo.ac_solver_used();
-            const bool inputs_ready = (ac_solver_used ? Ybus_.cols() != 0 : Bbus_.cols() != 0);
+            const bool inputs_ready = (ac_solver_used ? ac_cache_.mat.cols() != 0 : dc_cache_.mat.cols() != 0);
             if(!inputs_ready || ybus_policy_.li_coeffs.size() != ybus_policy_.li_defaults.size()){
                 const size_t nb_total_bus = _grid_model.total_bus();
                 CplxVect Vinit = CplxVect::Constant(static_cast<Eigen::Index>(nb_total_bus),
                                                     {_grid_model.get_init_vm_pu(), 0.});
                 prepare_solver_input_base(Vinit, ac_solver_used);
-                ybus_policy_.init_li_coeffs(_grid_model, ac_solver_used, id_me_to_solver_, n_line_);
+                ybus_policy_.init_li_coeffs(_grid_model, ac_solver_used, active_layout().id_me_to_solver, n_line_);
             }
             IntVect res = IntVect::Constant(ybus_policy_.li_coeffs.size(), 0);
             if(ac_solver_used){
-                Eigen::SparseMatrix<cplx_type> Ybus = Ybus_;
+                Eigen::SparseMatrix<cplx_type> Ybus = ac_cache_.mat;
                 int cont_id = 0;
                 for(const auto & coeffs_modif: ybus_policy_.li_coeffs){
                     if(YbusPolicy::Contingency::remove_from_Ybus(Ybus, coeffs_modif, true, _algo)) res(cont_id) = 1;
@@ -618,7 +618,7 @@ class LS2G_API BaseBatchSweep: public BaseBatchSolverSynch
                     ++cont_id;
                 }
             } else {
-                Eigen::SparseMatrix<real_type> Bbus = Bbus_;
+                Eigen::SparseMatrix<real_type> Bbus = dc_cache_.mat;
                 int cont_id = 0;
                 for(const auto & coeffs_modif: ybus_policy_.li_coeffs){
                     for(const auto & c: coeffs_modif) Bbus.coeffRef(c.row_id, c.col_id) -= std::real(c.value);
@@ -633,17 +633,17 @@ class LS2G_API BaseBatchSweep: public BaseBatchSolverSynch
                  typename std::enable_if<Y::supports_contingency && !S::supports_vary, int>::type = 0>
         int pick_reference_slack(){
             const bool ac_solver_used = _algo.ac_solver_used();
-            const bool inputs_ready = (ac_solver_used ? Ybus_.cols() != 0 : Bbus_.cols() != 0);
+            const bool inputs_ready = (ac_solver_used ? ac_cache_.mat.cols() != 0 : dc_cache_.mat.cols() != 0);
             if(!inputs_ready || ybus_policy_.li_coeffs.size() != ybus_policy_.li_defaults.size()){
                 const size_t nb_total_bus = _grid_model.total_bus();
                 CplxVect Vinit = CplxVect::Constant(static_cast<Eigen::Index>(nb_total_bus),
                                                     {_grid_model.get_init_vm_pu(), 0.});
                 prepare_solver_input_base(Vinit, ac_solver_used);
-                ybus_policy_.init_li_coeffs(_grid_model, ac_solver_used, id_me_to_solver_, n_line_);
+                ybus_policy_.init_li_coeffs(_grid_model, ac_solver_used, active_layout().id_me_to_solver, n_line_);
             }
             _select_ref_slack_and_masks();
-            if(slack_ids_me_.size() == 0) return -1;
-            return slack_ids_me_[static_cast<int>(0)].cast_int();
+            if(active_layout().slack_bus_id_me.size() == 0) return -1;
+            return active_layout().slack_bus_id_me[static_cast<int>(0)].cast_int();
         }
 
         // ================= legacy bundled compute_Vs / get_sbuses ================
@@ -759,7 +759,7 @@ class LS2G_API BaseBatchSweep: public BaseBatchSolverSynch
             }
         }
         RealVect _masked_slack_weights(const std::vector<int> & masked) const {
-            RealVect w = slack_weights_;
+            RealVect w = active_layout().slack_weights;
             if(masked.empty()) return w;
             const real_type orig_sum = w.sum();
             for(int b : masked) if(b >= 0 && b < w.size()) w(b) = 0.;
@@ -815,7 +815,7 @@ class LS2G_API BaseBatchSweep: public BaseBatchSolverSynch
 
         // pre-pass run before the (n-)powerflow: fills _li_masked (the masked bus
         // set of each contingency), chooses the reference slack that minimises the
-        // number of skipped contingencies (reordering slack_ids_me_ so it is index 0)
+        // number of skipped contingencies (reordering active_layout().slack_bus_id_me so it is index 0)
         // and fills _skip_mask. Keyed entirely off ybus_policy_.li_coeffs, which is
         // representation-agnostic (populated from li_defaults on ContingencyAnalysis,
         // from line_mask/trafo_mask on ScenarioSweep) -- shared by both. Called from
@@ -829,7 +829,7 @@ class LS2G_API BaseBatchSweep: public BaseBatchSolverSynch
             _skip_mask.assign(nb_cont, 0);
 
             if(_algo.ac_solver_used()){
-                Eigen::SparseMatrix<cplx_type> Ybus = Ybus_;
+                Eigen::SparseMatrix<cplx_type> Ybus = ac_cache_.mat;
                 size_t cont_id = 0;
                 for(const auto & coeffs_modif: ybus_policy_.li_coeffs){
                     for(const auto & c: coeffs_modif) Ybus.coeffRef(c.row_id, c.col_id) -= c.value;
@@ -838,7 +838,7 @@ class LS2G_API BaseBatchSweep: public BaseBatchSolverSynch
                     ++cont_id;
                 }
             } else {
-                Eigen::SparseMatrix<real_type> Bbus = Bbus_;
+                Eigen::SparseMatrix<real_type> Bbus = dc_cache_.mat;
                 size_t cont_id = 0;
                 for(const auto & coeffs_modif: ybus_policy_.li_coeffs){
                     for(const auto & c: coeffs_modif) Bbus.coeffRef(c.row_id, c.col_id) -= std::real(c.value);
@@ -848,14 +848,14 @@ class LS2G_API BaseBatchSweep: public BaseBatchSolverSynch
                 }
             }
 
-            const Eigen::Index nb_slack = slack_ids_me_.size();
+            const Eigen::Index nb_slack = active_layout().slack_bus_id_me.size();
             std::vector<int> candidates;
             for(Eigen::Index i = 0; i < nb_slack; ++i){
-                const int b = slack_ids_me_[static_cast<int>(i)].cast_int();
-                if(b >= 0 && b < slack_weights_.size() && slack_weights_(b) > 0.) candidates.push_back(b);
+                const int b = active_layout().slack_bus_id_me[static_cast<int>(i)].cast_int();
+                if(b >= 0 && b < active_layout().slack_weights.size() && active_layout().slack_weights(b) > 0.) candidates.push_back(b);
             }
             if(candidates.empty()){
-                for(Eigen::Index i = 0; i < nb_slack; ++i) candidates.push_back(slack_ids_me_[static_cast<int>(i)].cast_int());
+                for(Eigen::Index i = 0; i < nb_slack; ++i) candidates.push_back(active_layout().slack_bus_id_me[static_cast<int>(i)].cast_int());
             }
             if(candidates.empty()) return;
 
@@ -868,7 +868,7 @@ class LS2G_API BaseBatchSweep: public BaseBatchSolverSynch
             for(int bus : candidates){
                 int strand = 0;
                 for(const auto & masked : _li_masked) if(is_masked(masked, bus)) ++strand;
-                const real_type weight = (bus < slack_weights_.size()) ? slack_weights_(bus) : 0.;
+                const real_type weight = (bus < active_layout().slack_weights.size()) ? active_layout().slack_weights(bus) : 0.;
                 const bool better = (best_strand < 0) ||
                                     (strand < best_strand) ||
                                     (strand == best_strand && weight > best_weight) ||
@@ -881,10 +881,10 @@ class LS2G_API BaseBatchSweep: public BaseBatchSolverSynch
                 reordered.reserve(static_cast<size_t>(nb_slack));
                 reordered.push_back(best_bus);
                 for(Eigen::Index i = 0; i < nb_slack; ++i){
-                    const int b = slack_ids_me_[static_cast<int>(i)].cast_int();
+                    const int b = active_layout().slack_bus_id_me[static_cast<int>(i)].cast_int();
                     if(b != best_bus) reordered.push_back(b);
                 }
-                slack_ids_me_ = GlobalBusIdVect(reordered);
+                active_layout().slack_bus_id_me = GlobalBusIdVect(reordered);
             }
 
             for(size_t cont_id = 0; cont_id < nb_cont; ++cont_id){
@@ -917,12 +917,12 @@ class LS2G_API BaseBatchSweep: public BaseBatchSolverSynch
         template<class Y = YbusPolicy, class S = SbusPolicy,
                  typename std::enable_if<Y::supports_contingency && !S::supports_vary, int>::type = 0>
         void _prepare_ybus_varying(bool ac_solver_used, Eigen::Index) {
-            ybus_policy_.init_li_coeffs(_grid_model, ac_solver_used, id_me_to_solver_, n_line_);
+            ybus_policy_.init_li_coeffs(_grid_model, ac_solver_used, active_layout().id_me_to_solver, n_line_);
         }
         template<class Y = YbusPolicy, class S = SbusPolicy,
                  typename std::enable_if<Y::supports_contingency && S::supports_vary, int>::type = 0>
         void _prepare_ybus_varying(bool ac_solver_used, Eigen::Index nb_steps) {
-            ybus_policy_.init_li_coeffs_from_masks(_grid_model, ac_solver_used, id_me_to_solver_, n_line_, nb_steps);
+            ybus_policy_.init_li_coeffs_from_masks(_grid_model, ac_solver_used, active_layout().id_me_to_solver, n_line_, nb_steps);
         }
 
         // ----- Sbus-varying preparation: 2-way --------------------------------
@@ -930,8 +930,8 @@ class LS2G_API BaseBatchSweep: public BaseBatchSolverSynch
         void _prepare_sbus_varying(bool, Eigen::Index) {}
         template<class S = SbusPolicy, typename std::enable_if<S::supports_vary, int>::type = 0>
         void _prepare_sbus_varying(bool ac_solver_used, Eigen::Index nb_steps) {
-            const CplxVect complete = ac_solver_used ? CplxVect(Sbus_) : CplxVect(Pbus_.template cast<cplx_type>());
-            sbus_policy_.assemble(_grid_model, ac_solver_used, nb_buses_solver_, id_me_to_solver_,
+            const CplxVect complete = ac_solver_used ? CplxVect(ac_cache_.inj) : CplxVect(dc_cache_.inj.template cast<cplx_type>());
+            sbus_policy_.assemble(_grid_model, ac_solver_used, nb_buses_solver_, active_layout().id_me_to_solver,
                                   complete, _grid_model.get_sn_mva(), nb_steps, algo_name());
         }
 
@@ -964,7 +964,7 @@ class LS2G_API BaseBatchSweep: public BaseBatchSolverSynch
         template<class S = SbusPolicy, typename std::enable_if<S::supports_vary, int>::type = 0>
         CplxVect _step_sbus(size_t i) const { return sbus_policy_.sbuses.row(i); }
         template<class S = SbusPolicy, typename std::enable_if<!S::supports_vary, int>::type = 0>
-        CplxVect _step_sbus(size_t) const { return Sbus_; }
+        CplxVect _step_sbus(size_t) const { return ac_cache_.inj; }
 
         // ----- per-step generator vm seeding: 2-way (SbusPolicy::Vary::gen_v row
         // applied via GeneratorContainer::set_vm, vs. a no-op leaving V's magnitude
@@ -983,7 +983,7 @@ class LS2G_API BaseBatchSweep: public BaseBatchSolverSynch
                 // a RowMajor matrix row is not contiguous the way a plain RealVect
                 // is, so bind it to a real RealVect before handing it to set_vm's
                 // Eigen::Ref<const RealVect> parameter (same pattern as _step_sbus).
-            _grid_model.get_generators().set_vm(V, id_me_to_solver_, target_vm_pu_row);
+            _grid_model.get_generators().set_vm(V, active_layout().id_me_to_solver, target_vm_pu_row);
         }
 
         // ----- sbus_policy_.gen_v, generically (2-way, same split as above): feeds
@@ -1028,16 +1028,16 @@ class LS2G_API BaseBatchSweep: public BaseBatchSolverSynch
             }
             const std::vector<int> * masked_ids_use = (masked_ids != nullptr && !masked_ids->empty()) ? masked_ids : nullptr;
 
-            batch_sweep_detail::check_bus_voltage_violations(V, id_me_to_solver_, _grid_model.get_bus_vmin_kv(), _grid_model.get_bus_vmax_kv(),
+            batch_sweep_detail::check_bus_voltage_violations(V, active_layout().id_me_to_solver, _grid_model.get_bus_vmin_kv(), _grid_model.get_bus_vmax_kv(),
                                          _grid_model.get_bus_vn_kv(), _grid_model.get_substations(),
                                          _violation_threshold_, masked_ids_use, _violations[i]);
             batch_sweep_detail::check_current_violations(_grid_model.get_powerlines_as_data(), ViolationElementType::LINE,
-                                     V, id_me_to_solver_, _grid_model.get_bus_vn_kv(), ac_solver_used, sn_mva,
+                                     V, active_layout().id_me_to_solver, _grid_model.get_bus_vn_kv(), ac_solver_used, sn_mva,
                                      _grid_model.get_powerlines_as_data().get_limit_a1_ka(),
                                      _grid_model.get_powerlines_as_data().get_limit_a2_ka(),
                                      _violation_threshold_, skip_lines, _violations[i]);
             batch_sweep_detail::check_current_violations(_grid_model.get_trafos_as_data(), ViolationElementType::TRAFO,
-                                     V, id_me_to_solver_, _grid_model.get_bus_vn_kv(), ac_solver_used, sn_mva,
+                                     V, active_layout().id_me_to_solver, _grid_model.get_bus_vn_kv(), ac_solver_used, sn_mva,
                                      _grid_model.get_trafos_as_data().get_limit_a1_ka(),
                                      _grid_model.get_trafos_as_data().get_limit_a2_ka(),
                                      _violation_threshold_, skip_trafos, _violations[i]);
@@ -1078,16 +1078,16 @@ class LS2G_API BaseBatchSweep: public BaseBatchSolverSynch
             if(!_compute_limit_violations_) return;
             _converged_n_ = true;
             const std::vector<int> no_skip;
-            batch_sweep_detail::check_bus_voltage_violations(V_n, id_me_to_solver_, _grid_model.get_bus_vmin_kv(), _grid_model.get_bus_vmax_kv(),
+            batch_sweep_detail::check_bus_voltage_violations(V_n, active_layout().id_me_to_solver, _grid_model.get_bus_vmin_kv(), _grid_model.get_bus_vmax_kv(),
                                          _grid_model.get_bus_vn_kv(), _grid_model.get_substations(),
                                          _violation_threshold_, nullptr, _violations_n_);
             batch_sweep_detail::check_current_violations(_grid_model.get_powerlines_as_data(), ViolationElementType::LINE,
-                                     V_n, id_me_to_solver_, _grid_model.get_bus_vn_kv(), _algo.ac_solver_used(), _grid_model.get_sn_mva(),
+                                     V_n, active_layout().id_me_to_solver, _grid_model.get_bus_vn_kv(), _algo.ac_solver_used(), _grid_model.get_sn_mva(),
                                      _grid_model.get_powerlines_as_data().get_limit_a1_ka(),
                                      _grid_model.get_powerlines_as_data().get_limit_a2_ka(),
                                      _violation_threshold_, no_skip, _violations_n_);
             batch_sweep_detail::check_current_violations(_grid_model.get_trafos_as_data(), ViolationElementType::TRAFO,
-                                     V_n, id_me_to_solver_, _grid_model.get_bus_vn_kv(), _algo.ac_solver_used(), _grid_model.get_sn_mva(),
+                                     V_n, active_layout().id_me_to_solver, _grid_model.get_bus_vn_kv(), _algo.ac_solver_used(), _grid_model.get_sn_mva(),
                                      _grid_model.get_trafos_as_data().get_limit_a1_ka(),
                                      _grid_model.get_trafos_as_data().get_limit_a2_ka(),
                                      _violation_threshold_, no_skip, _violations_n_);
@@ -1127,9 +1127,9 @@ class LS2G_API BaseBatchSweep: public BaseBatchSolverSynch
                            bool & conv, bool & invertible);
 
         // per-range worker: mask-mode path (ContingencyAnalysis AND ScenarioSweep --
-        // shared, using _step_sbus(cont_id) instead of a hardcoded fixed Sbus_ so it
+        // shared, using _step_sbus(cont_id) instead of a hardcoded fixed ac_cache_.inj so it
         // picks up per-row injections on ScenarioSweep; a no-op change for
-        // ContingencyAnalysis, whose overload of _step_sbus still returns Sbus_).
+        // ContingencyAnalysis, whose overload of _step_sbus still returns ac_cache_.inj).
         // Only ever called from _maybe_run_range_masked below, itself only ever
         // called from compute() (non-template, .cpp-confined) -- safe to stay
         // declared here / defined out-of-line in BaseBatchSweep.cpp.
@@ -1163,13 +1163,13 @@ class LS2G_API BaseBatchSweep: public BaseBatchSolverSynch
                         _apply_step_gen_v(cont_id, V);
                         if(masked.empty()){
                             conv = compute_one_powerflow(algo, control, nb_solved, nb_converged, timer_solver, Ybus, V, _step_sbus(cont_id),
-                                                         slack_ids_solver_.as_eigen(), slack_weights_,
-                                                         bus_pv_.as_eigen(), bus_pq_.as_eigen(), max_iter, tol / sn_mva);
+                                                         active_layout().slack_bus_id_solver.as_eigen(), active_layout().slack_weights,
+                                                         active_layout().bus_pv.as_eigen(), active_layout().bus_pq.as_eigen(), max_iter, tol / sn_mva);
                         } else {
                             const RealVect sw = _masked_slack_weights(masked);
                             conv = compute_one_powerflow(algo, control, nb_solved, nb_converged, timer_solver, Ybus, V, _step_sbus(cont_id),
-                                                         slack_ids_solver_.as_eigen(), sw,
-                                                         bus_pv_.as_eigen(), bus_pq_.as_eigen(), max_iter, tol / sn_mva);
+                                                         active_layout().slack_bus_id_solver.as_eigen(), sw,
+                                                         active_layout().bus_pv.as_eigen(), active_layout().bus_pq.as_eigen(), max_iter, tol / sn_mva);
                         }
                         if(needs_solver_init){ control.tell_none_changed(); needs_solver_init = false; }
                         algo.set_masked_buses(std::vector<int>());
@@ -1188,7 +1188,7 @@ class LS2G_API BaseBatchSweep: public BaseBatchSolverSynch
                         div_reason = LimitViolationType::NOT_SIMULATED;
                     }
 
-                    if(do_store) _voltages.row(cont_id)(id_solver_to_me_.as_eigen()) = V.array();
+                    if(do_store) _voltages.row(cont_id)(active_layout().id_solver_to_me.as_eigen()) = V.array();
                     else if(first_diverging_step < 0) first_diverging_step = static_cast<int>(cont_id);
 
                     _converged_mask_[cont_id] = do_store ? 1 : 0;
@@ -1231,7 +1231,7 @@ class LS2G_API BaseBatchSweep: public BaseBatchSolverSynch
             throw std::logic_error("unreachable: handle_disconnected_grid cannot be set on this instantiation");
         }
 
-        // ----- threading spawn: 2-way (per-thread Ybus copy vs shared Ybus_) ------
+        // ----- threading spawn: 2-way (per-thread Ybus copy vs shared ac_cache_.mat) ------
         // Only ever called from compute() (non-template, .cpp-confined): safe to
         // stay declared here / defined out-of-line in BaseBatchSweep.cpp.
         template<class Y = YbusPolicy, typename std::enable_if<!Y::supports_contingency, int>::type = 0>

--- a/src/core/batch_algorithm/SbusPolicy.cpp
+++ b/src/core/batch_algorithm/SbusPolicy.cpp
@@ -63,7 +63,7 @@ CplxVect SbusPolicy::Vary::constant_sbus_pu(const LSGrid & grid_model,
                                             const char * algo_name) const
 {
     // the complete per-unit injection, straight from the gridmodel (the caller's own
-    // Sbus_ (ac) / Pbus_.cast<cplx_type>() (dc))
+    // ac_cache_.inj (ac) / dc_cache_.inj.cast<cplx_type>() (dc))
     CplxVect res = complete_sbus_pu;
     if(static_cast<int>(res.size()) != nb_buses_solver){
         std::ostringstream exc_;

--- a/src/core/batch_algorithm/SbusPolicy.hpp
+++ b/src/core/batch_algorithm/SbusPolicy.hpp
@@ -29,7 +29,7 @@ struct LS2G_API SbusPolicy
 {
     /** the injection is fixed for the whole batch (ContingencyAnalysis): no state, no
         work -- the `BaseBatchSweep` per-step loop simply reuses the fixed member
-        `Sbus_`/`Pbus_` for every row. **/
+        `ac_cache_.inj`/`dc_cache_.inj` for every row. **/
     struct NOOP {
         static constexpr bool supports_vary = false;
         // no-op: lets BaseBatchSweep::clear() (a plain, always-compiled member) call
@@ -118,8 +118,8 @@ struct LS2G_API SbusPolicy
          * setpoint, the hvdc injections and (dc only) the phase-shifter term.
          *
          * Computed as `complete - accounted_for`: `complete_sbus_pu` is the complete
-         * per-unit injection the gridmodel built (the caller's own Sbus_ (ac) /
-         * Pbus_.cast<cplx_type>() (dc), read-only here), minus the same
+         * per-unit injection the gridmodel built (the caller's own ac_cache_.inj (ac) /
+         * dc_cache_.inj.cast<cplx_type>() (dc), read-only here), minus the same
          * reconstruction the per-step matrices perform, evaluated at the gridmodel's
          * own target values. Deriving it this way -- instead of listing the elements
          * -- is what keeps it from falling out of date when a new element type starts

--- a/src/tests/test_batch_voltage_control.cpp
+++ b/src/tests/test_batch_voltage_control.cpp
@@ -11,8 +11,9 @@
 // the solver: they are pulled out of the LSGrid itself, through the `lsgrid_ptr`
 // the algorithm holds, by LSGrid::get_free_vm_slack_solver_buses /
 // fill_hvdc_droop_solver_data / fill_voltage_control_solver_data. Those three read
-// the grid's *member* solver-side labelling (id_me_to_ac_solver_,
-// id_ac_solver_to_me_, slack_bus_id_ac_solver_).
+// the grid's own AC cache (ac_cache_: id_me_to_solver, id_solver_to_me,
+// slack_bus_id_solver -- and bus_pq, which fill_voltage_control_solver_data needs
+// to know which buses own a Q equation).
 //
 // LSGrid::ac_pf passes those very members to pre_process_solver, so they are always
 // current there. The batch algorithms (TimeSeries / ContingencyAnalysis /
@@ -314,6 +315,26 @@ TEST_CASE("a batch on an already-solved grid regulates too", "[batch][vctrl]")
     LSGrid grid = make_remote_gen_grid();
     single_shot(grid);   // solved BEFORE the batch copies it
     check_same_voltages(one_step_timeseries(grid, 2), ref);
+}
+
+TEST_CASE("the source grid still solves correctly after a batch ran on it", "[batch][vctrl]")
+{
+    // Every batch prep calls pre_process_solver with the batch's OWN cache, and that
+    // call publishes the batch's labelling and pv-pq split into the grid it was
+    // called on -- next to a matrix it did not publish. On the batch's private copy
+    // that mixture is harmless (the copy never runs a powerflow of its own); the
+    // point here is the contract that makes it harmless anywhere, namely that such a
+    // build always retires that grid's cache. Solve the source grid on both sides of
+    // a batch and it must not move.
+    LSGrid ref_grid = make_remote_gen_grid();
+    const CplxVect ref = single_shot(ref_grid);
+
+    LSGrid grid = make_remote_gen_grid();
+    check_same_voltages(single_shot(grid), ref);
+    check_same_voltages(one_step_timeseries(grid, 2), ref);
+    check_same_voltages(single_shot(grid), ref);   // ... and again, after the batch
+    check_same_voltages(empty_contingency(grid), ref);
+    check_same_voltages(single_shot(grid), ref);
 }
 
 TEST_CASE("two generators sharing one regulated bus share it in a batch too", "[batch][vctrl]")

--- a/src/tests/test_cache_reuse.cpp
+++ b/src/tests/test_cache_reuse.cpp
@@ -301,65 +301,95 @@ TEST_CASE("a 'nothing changed' claim never makes a powerflow read data that was 
     }
 }
 
-TEST_CASE("the structural half of the guard is what stands between unset_changes and an OOB read",
+TEST_CASE("unset_changes never records a claim the cache cannot back",
           "[LSGrid][cache_reuse][unset_changes]")
 {
-    // The sections above all reach `unset_changes()` through
-    // `allow_cache_reuse(false)`, ie with BOTH families told never to reuse. The
-    // family that then runs is caught by the FIRST test in
-    // `SolverSideCache::is_usable` (`if(!allow_reuse) return false;`) before any of
-    // the structural comparisons matter, so those sections pass even with the rest
-    // of `is_usable` deleted.
-    //
-    // Turning off only the OTHER family is what exercises it. `unset_changes()`
-    // returns early only when both families cache automatically, so switching one
-    // off re-arms it -- and it marks BOTH families "in sync", including the one
-    // still allowed to reuse and whose solver-side data may never have been built.
-    // For that family nothing but the structural comparisons is left: with them
-    // removed, each of the three sequences below indexes a default-constructed
-    // id map / matrix / injection vector with bus ids in the hundreds. Under
+    // `unset_changes()` marks BOTH families -- that is its historical contract and
+    // code written before 1.0.0 relies on it. It is also what used to make it
+    // dangerous: a family that had never solved got marked "in sync" next to one
+    // that had, and its next powerflow took the "nothing to rebuild" path with an
+    // empty bus labelling, indexing it with bus ids in the hundreds. Under
     // -O3 -DNDEBUG (what the wheels ship) that is a segfault, not an error.
     //
-    // So: this is the test to look at before "the cache is reused by default now,
-    // `is_usable` can stop checking". It can, but only once `unset_changes()` stops
-    // making the claim on a family that cannot back it.
+    // It still marks both families. What changed is that each one is verified first,
+    // so the claim is only ever RECORDED where it is true; a family that cannot back
+    // it is retired instead and rebuilds on its next powerflow. The powerflow path
+    // no longer re-checks, which is the whole point -- so these sections are what
+    // stands between `unset_changes()` and an out-of-bounds read.
     LSGrid ref_ac = make_grid();
     LSGrid ref_dc = make_grid();
     const CplxVect v_ac_ref = solve_ac(ref_ac);
     const CplxVect v_dc_ref = solve_dc(ref_dc);
 
-    SECTION("DC still automatic, never solved, and unset_changes marks it in sync"){
+    SECTION("a family that never solved is retired, not marked"){
         LSGrid grid = make_grid();
-        grid.allow_ac_cache_reuse(false);   // only AC: unset_changes() is no longer a no-op
-        REQUIRE(grid.get_allow_dc_cache_reuse());
-        grid.unset_changes();               // claims DC is in sync -- it has built nothing
-        REQUIRE_FALSE(grid.get_dc_algo_controler().need_reset_solver());
+        grid.unset_changes();   // neither family has built anything
 
-        const CplxVect v = solve_dc(grid);
-        REQUIRE(v.size() == 14);
-        CHECK((v - v_dc_ref).norm() < 1e-9);
+        CHECK(grid.get_ac_algo_controler().need_reset_solver());
+        CHECK(grid.get_dc_algo_controler().need_reset_solver());
+        CHECK((solve_ac(grid) - v_ac_ref).norm() < 1e-9);
+        CHECK((solve_dc(grid) - v_dc_ref).norm() < 1e-9);
     }
-    SECTION("AC still automatic, never solved, and unset_changes marks it in sync"){
+    SECTION("the family that did solve is marked, the other is retired"){
         LSGrid grid = make_grid();
-        grid.allow_dc_cache_reuse(false);
-        REQUIRE(grid.get_allow_ac_cache_reuse());
+        REQUIRE(solve_ac(grid).size() == 14);   // AC has a live cache, DC has nothing
         grid.unset_changes();
-        REQUIRE_FALSE(grid.get_ac_algo_controler().need_reset_solver());
 
-        const CplxVect v = solve_ac(grid);
-        REQUIRE(v.size() == 14);
-        CHECK((v - v_ac_ref).norm() < 1e-9);
+        CHECK_FALSE(grid.get_ac_algo_controler().need_reset_solver());  // true claim, recorded
+        CHECK(grid.get_dc_algo_controler().need_reset_solver());        // false claim, refused
+        CHECK((solve_dc(grid) - v_dc_ref).norm() < 1e-9);
+        CHECK((solve_ac(grid) - v_ac_ref).norm() < 1e-9);
     }
-    SECTION("the other family solved first, so the grid is warm but this family is not"){
+    SECTION("and the other way round"){
         LSGrid grid = make_grid();
-        REQUIRE(solve_ac(grid).size() == 14);  // AC cache is live, DC has nothing
+        REQUIRE(solve_dc(grid).size() == 14);
+        grid.unset_changes();
+
+        CHECK_FALSE(grid.get_dc_algo_controler().need_reset_solver());
+        CHECK(grid.get_ac_algo_controler().need_reset_solver());
+        CHECK((solve_ac(grid) - v_ac_ref).norm() < 1e-9);
+    }
+    SECTION("a pending topology change is not papered over"){
+        // The dangerous direction, and the reason unset_changes() refreshes the bus
+        // status before comparing: called with a real change outstanding, "forget
+        // past changes" would drop it and solve the OLD system with the new grid.
+        // The connectivity comparison is what refuses.
+        LSGrid grid = make_grid();
+        REQUIRE(solve_ac(grid).size() == 14);
+        grid.deactivate_powerline(4);
+        grid.unset_changes();
+        CHECK(grid.get_ac_algo_controler().need_reset_solver());
+
+        LSGrid ref = make_grid();
+        ref.deactivate_powerline(4);
+        CHECK((solve_ac(grid) - solve_ac(ref)).norm() < 1e-9);
+    }
+    SECTION("a genuinely up-to-date cache is left alone, however often it is claimed"){
+        LSGrid grid = make_grid();
+        REQUIRE(solve_ac(grid).size() == 14);
+        for(int i = 0; i < 3; ++i){
+            grid.unset_changes();
+            CHECK_FALSE(grid.get_ac_algo_controler().need_reset_solver());
+            CHECK((solve_ac(grid) - v_ac_ref).norm() < 1e-9);
+        }
+    }
+    SECTION("turning one family's reuse off does not make the other unsafe"){
+        // the sequence that used to segfault: both families marked, only one built
+        LSGrid grid = make_grid();
         grid.allow_ac_cache_reuse(false);
         grid.unset_changes();
-        REQUIRE_FALSE(grid.get_dc_algo_controler().need_reset_solver());
+        CHECK((solve_dc(grid) - v_dc_ref).norm() < 1e-9);
 
-        const CplxVect v = solve_dc(grid);
-        REQUIRE(v.size() == 14);
-        CHECK((v - v_dc_ref).norm() < 1e-9);
+        LSGrid grid2 = make_grid();
+        grid2.allow_dc_cache_reuse(false);
+        grid2.unset_changes();
+        CHECK((solve_ac(grid2) - v_ac_ref).norm() < 1e-9);
+
+        LSGrid grid3 = make_grid();
+        REQUIRE(solve_ac(grid3).size() == 14);
+        grid3.allow_ac_cache_reuse(false);
+        grid3.unset_changes();
+        CHECK((solve_dc(grid3) - v_dc_ref).norm() < 1e-9);
     }
 }
 

--- a/src/tests/test_cache_reuse.cpp
+++ b/src/tests/test_cache_reuse.cpp
@@ -301,6 +301,152 @@ TEST_CASE("a 'nothing changed' claim never makes a powerflow read data that was 
     }
 }
 
+TEST_CASE("the structural half of the guard is what stands between unset_changes and an OOB read",
+          "[LSGrid][cache_reuse][unset_changes]")
+{
+    // The sections above all reach `unset_changes()` through
+    // `allow_cache_reuse(false)`, ie with BOTH families told never to reuse. The
+    // family that then runs is caught by the FIRST test in
+    // `SolverSideCache::is_usable` (`if(!allow_reuse) return false;`) before any of
+    // the structural comparisons matter, so those sections pass even with the rest
+    // of `is_usable` deleted.
+    //
+    // Turning off only the OTHER family is what exercises it. `unset_changes()`
+    // returns early only when both families cache automatically, so switching one
+    // off re-arms it -- and it marks BOTH families "in sync", including the one
+    // still allowed to reuse and whose solver-side data may never have been built.
+    // For that family nothing but the structural comparisons is left: with them
+    // removed, each of the three sequences below indexes a default-constructed
+    // id map / matrix / injection vector with bus ids in the hundreds. Under
+    // -O3 -DNDEBUG (what the wheels ship) that is a segfault, not an error.
+    //
+    // So: this is the test to look at before "the cache is reused by default now,
+    // `is_usable` can stop checking". It can, but only once `unset_changes()` stops
+    // making the claim on a family that cannot back it.
+    LSGrid ref_ac = make_grid();
+    LSGrid ref_dc = make_grid();
+    const CplxVect v_ac_ref = solve_ac(ref_ac);
+    const CplxVect v_dc_ref = solve_dc(ref_dc);
+
+    SECTION("DC still automatic, never solved, and unset_changes marks it in sync"){
+        LSGrid grid = make_grid();
+        grid.allow_ac_cache_reuse(false);   // only AC: unset_changes() is no longer a no-op
+        REQUIRE(grid.get_allow_dc_cache_reuse());
+        grid.unset_changes();               // claims DC is in sync -- it has built nothing
+        REQUIRE_FALSE(grid.get_dc_algo_controler().need_reset_solver());
+
+        const CplxVect v = solve_dc(grid);
+        REQUIRE(v.size() == 14);
+        CHECK((v - v_dc_ref).norm() < 1e-9);
+    }
+    SECTION("AC still automatic, never solved, and unset_changes marks it in sync"){
+        LSGrid grid = make_grid();
+        grid.allow_dc_cache_reuse(false);
+        REQUIRE(grid.get_allow_ac_cache_reuse());
+        grid.unset_changes();
+        REQUIRE_FALSE(grid.get_ac_algo_controler().need_reset_solver());
+
+        const CplxVect v = solve_ac(grid);
+        REQUIRE(v.size() == 14);
+        CHECK((v - v_ac_ref).norm() < 1e-9);
+    }
+    SECTION("the other family solved first, so the grid is warm but this family is not"){
+        LSGrid grid = make_grid();
+        REQUIRE(solve_ac(grid).size() == 14);  // AC cache is live, DC has nothing
+        grid.allow_ac_cache_reuse(false);
+        grid.unset_changes();
+        REQUIRE_FALSE(grid.get_dc_algo_controler().need_reset_solver());
+
+        const CplxVect v = solve_dc(grid);
+        REQUIRE(v.size() == 14);
+        CHECK((v - v_dc_ref).norm() < 1e-9);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// 3b. a cache is one object, and it belongs to one owner
+// ---------------------------------------------------------------------------
+
+TEST_CASE("a build into someone else's cache never leaves this grid solving a mixture",
+          "[LSGrid][cache_reuse][batch]")
+{
+    // `pre_process_solver` serves two kinds of caller: this grid (ac_pf / dc_pf /
+    // check_solution pass ac_cache_ / dc_cache_) and a foreign builder -- the batch
+    // algorithms, which pass a cache they own.
+    //
+    // For the foreign one, the grid's own cache is still an output: the NR
+    // extensions are not built from what the solver was handed, they are pulled out
+    // of the LSGrid through `lsgrid_ptr`, and they read the labelling AND the pv-pq
+    // split (see fill_voltage_control_solver_data's use of bus_pq). So the build has
+    // to publish there. What it must never do is leave that publication looking like
+    // a cache: the labelling and the split would be the caller's while the matrix
+    // and the injections are still this grid's, which is the right size, passes
+    // every structural check, converges, and is wrong.
+    //
+    // Retiring the snapshot is what prevents it, and that is what these sections
+    // pin. Note what is NOT tested here: that the nine parts cannot be handed over
+    // separately in the first place. That is not a runtime property any more, it is
+    // the type -- SolverSideCache is one object, so there is nothing to mismatch.
+    SECTION("AC"){
+        LSGrid grid = make_grid();
+        const CplxVect v_before = solve_ac(grid);
+        REQUIRE(v_before.size() == 14);
+        REQUIRE_FALSE(grid.get_ac_algo_controler().need_reset_solver());  // cache is live
+
+        // exactly what a batch does: its own cache, its own control
+        ls2g::AcSolverCache foreign;
+        const ls2g::AlgoControl foreign_control;  // default ctor: everything changed
+        grid.pre_process_solver(flat_start(grid), foreign, foreign_control);
+
+        // it built the WHOLE cache into the caller's object ...
+        CHECK(foreign.mat.rows() == 14);
+        CHECK(foreign.mat.cols() == 14);
+        CHECK(foreign.inj.size() == 14);
+        CHECK(foreign.slack_weights.size() == 14);
+        CHECK(foreign.bus_pq.size() > 0);
+        CHECK(foreign.id_solver_to_me.size() == 14);
+        // ... published the labelling and the split the NR extensions read back ...
+        CHECK(grid.get_ac_pq_solver().size() == foreign.bus_pq.size());
+        CHECK(grid.get_ac_pv_solver().size() == foreign.bus_pv.size());
+        // ... and retired this grid's own cache rather than leaving it a mixture
+        CHECK(grid.get_ac_algo_controler().need_reset_solver());
+
+        // so the grid's own next powerflow is unaffected by the detour
+        CHECK((solve_ac(grid) - v_before).norm() < 1e-9);
+    }
+    SECTION("DC"){
+        LSGrid grid = make_grid();
+        const CplxVect v_before = solve_dc(grid);
+        REQUIRE(v_before.size() == 14);
+        REQUIRE_FALSE(grid.get_dc_algo_controler().need_reset_solver());
+
+        ls2g::DcSolverCache foreign;
+        const ls2g::AlgoControl foreign_control;
+        grid.pre_process_dc_solver(flat_start(grid), foreign, foreign_control);
+
+        CHECK(foreign.mat.rows() == 14);
+        CHECK(foreign.inj.size() == 14);
+        CHECK(grid.get_dc_pq_solver().size() == foreign.bus_pq.size());
+        CHECK(grid.get_dc_algo_controler().need_reset_solver());
+
+        CHECK((solve_dc(grid) - v_before).norm() < 1e-9);
+    }
+    SECTION("one family's foreign build leaves the other family's cache alone"){
+        LSGrid grid = make_grid();
+        const CplxVect v_ac_before = solve_ac(grid);
+        const CplxVect v_dc_before = solve_dc(grid);
+
+        ls2g::DcSolverCache foreign;
+        const ls2g::AlgoControl foreign_control;
+        grid.pre_process_dc_solver(flat_start(grid), foreign, foreign_control);
+
+        CHECK(grid.get_dc_algo_controler().need_reset_solver());
+        CHECK_FALSE(grid.get_ac_algo_controler().need_reset_solver());  // AC untouched
+        CHECK((solve_ac(grid) - v_ac_before).norm() < 1e-9);
+        CHECK((solve_dc(grid) - v_dc_before).norm() < 1e-9);
+    }
+}
+
 // ---------------------------------------------------------------------------
 // 4. nothing cached ever crosses a serialization boundary
 // ---------------------------------------------------------------------------

--- a/src/tests/test_cache_reuse.cpp
+++ b/src/tests/test_cache_reuse.cpp
@@ -426,7 +426,7 @@ TEST_CASE("a build into someone else's cache never leaves this grid solving a mi
         // exactly what a batch does: its own cache, its own control
         ls2g::AcSolverCache foreign;
         const ls2g::AlgoControl foreign_control;  // default ctor: everything changed
-        grid.pre_process_solver(flat_start(grid), foreign, foreign_control);
+        grid.build_solver_input(flat_start(grid), foreign, foreign_control);
 
         // it built the WHOLE cache into the caller's object ...
         CHECK(foreign.mat.rows() == 14);
@@ -452,7 +452,7 @@ TEST_CASE("a build into someone else's cache never leaves this grid solving a mi
 
         ls2g::DcSolverCache foreign;
         const ls2g::AlgoControl foreign_control;
-        grid.pre_process_dc_solver(flat_start(grid), foreign, foreign_control);
+        grid.build_dc_solver_input(flat_start(grid), foreign, foreign_control);
 
         CHECK(foreign.mat.rows() == 14);
         CHECK(foreign.inj.size() == 14);
@@ -461,6 +461,41 @@ TEST_CASE("a build into someone else's cache never leaves this grid solving a mi
 
         CHECK((solve_dc(grid) - v_before).norm() < 1e-9);
     }
+    SECTION("a foreign build ignores a 'nothing changed' control"){
+        // The own / foreign distinction used to be a runtime flag inside ONE
+        // function (`own_cache = _is_own_cache(cache)`); it is now which of two
+        // functions you call, and `build_solver_input` hardcodes a full rebuild
+        // instead of consulting the reuse policy.
+        //
+        // This is the section that would catch that being undone. `solver_control`,
+        // the connectivity snapshot and the change flags all describe THIS grid and
+        // say nothing about the caller's cache -- so honouring a "nothing changed"
+        // claim about a foreign cache means re-stamping only part of it and leaving
+        // the rest from whatever was there before. Here "before" is nothing at all,
+        // so a foreign build that believed the claim would hand back an empty
+        // labelling and an empty matrix; with a non-empty one it would be worse than
+        // empty, because every size would still look right.
+        LSGrid grid = make_grid();
+        const CplxVect v_before = solve_ac(grid);
+        REQUIRE(v_before.size() == 14);
+
+        ls2g::AcSolverCache foreign;   // nothing has ever been built into it
+        ls2g::AlgoControl lying_control;
+        lying_control.tell_none_changed();   // ... and a control that says so is fine
+        grid.build_solver_input(flat_start(grid), foreign, lying_control);
+
+        // built in full regardless of what the control claimed
+        CHECK(foreign.mat.rows() == 14);
+        CHECK(foreign.mat.cols() == 14);
+        CHECK(foreign.inj.size() == 14);
+        CHECK(foreign.slack_weights.size() == 14);
+        CHECK(foreign.bus_pq.size() > 0);
+        CHECK(foreign.id_solver_to_me.size() == 14);
+        CHECK(foreign.id_me_to_solver.size() == grid.total_bus());
+
+        // and the grid's own next powerflow is still unaffected by the detour
+        CHECK((solve_ac(grid) - v_before).norm() < 1e-9);
+    }
     SECTION("one family's foreign build leaves the other family's cache alone"){
         LSGrid grid = make_grid();
         const CplxVect v_ac_before = solve_ac(grid);
@@ -468,7 +503,7 @@ TEST_CASE("a build into someone else's cache never leaves this grid solving a mi
 
         ls2g::DcSolverCache foreign;
         const ls2g::AlgoControl foreign_control;
-        grid.pre_process_dc_solver(flat_start(grid), foreign, foreign_control);
+        grid.build_dc_solver_input(flat_start(grid), foreign, foreign_control);
 
         CHECK(grid.get_dc_algo_controler().need_reset_solver());
         CHECK_FALSE(grid.get_ac_algo_controler().need_reset_solver());  // AC untouched


### PR DESCRIPTION
One commit, fresh from `dev_0.13.2`. Replaces #184, which took the opposite approach (add checks that the eighteen loose members agree) and is closed.

## The problem, concretely

`pre_process_solver` fills in containers you hand it. Two callers hand it different ones:

```cpp
// LSGrid::ac_pf -- passes the grid's own members
pre_process_solver(Vinit, acSbus_, Ybus_ac_, id_me_to_ac_solver_, ...);

// BaseBatchSolverSynch::prepare_solver_input_base -- passes the BATCH's members
_grid_model.pre_process_solver(Vinit, Sbus_, Ybus_, id_me_to_solver_, ...);
```

Six of the nine outputs were parameters. **Three were not.** At the top of `_pre_process_solver_impl`:

```cpp
RealVect & slack_weights = is_ac ? slack_weights_ac_ : slack_weights_dc_;
SolverBusIdVect & bus_pv = is_ac ? bus_pv_ac_ : bus_pv_dc_;
SolverBusIdVect & bus_pq = is_ac ? bus_pq_ac_ : bus_pq_dc_;
```

Hardcoded to the grid's members whatever the caller passed for the rest. One call, output split across two objects. The tell was already sitting in the batch:

```cpp
bus_pv_ = _grid_model.get_ac_pv_solver();   // reach back into the grid to collect
bus_pq_ = _grid_model.get_ac_pq_solver();   // the other half of my own output
slack_weights_ = _grid_model.get_ac_slack_weights_solver();
// TODO copies are made here, which is not ideal
```

Three consequences, all silent:

1. **A batch build wrote its pv-pq split and slack weights into the grid's cache**, next to a `Ybus` built for a different bus labelling — and the grid went on claiming that mixture was reusable. Checked against `dev_0.13.2`: `need_reset_solver()` stays **false** across such a build.
2. **The reuse guard sized one owner's containers against the other's.** Sizes agree far more often than labellings do, so a caller reusing its containers with a "nothing changed" control would have skipped `fillpv_pq` and stamped *this grid's* split onto *its* system — converged, plausible, wrong.
3. **`_algo.reset()` / `tell_solver_control()` fired on the grid's own algorithm** for a solve it would never perform, discarding a factorization its next powerflow would have reused.

**Nothing reaches any of this today.** The batch works on a private `LSGrid` copy and always calls `tell_all_changed()` first. Both are accidents; neither is written down as a requirement, and the obvious next optimisation in there (keep `Ybus` across scenarios) removes the second one.

## The fix: make them one object

`src/core/SolverSideCache.hpp`, split by **type**, not lifetime:

| | contents |
|---|---|
| `SolverBusLayout` | labelling, slack, pv-pq split, connectivity snapshot, `allow_reuse`, `algo_needs_rebuild` — everything whose type doesn't mention the family's scalar |
| `SolverSideCache<T>` | the above, plus `mat` and `inj`. `cplx_type` → AC (Ybus/Sbus), `real_type` → DC (Bbus/Pbus) |

The split exists so the batch — which runs AC *or* DC, never both — can name the family-agnostic half: 82 of its 150 call sites don't care which family, and go through `active_layout()` instead of a ternary at every use.

`LSGrid` holds `ac_cache_` / `dc_cache_`. `pre_process_solver` / `pre_process_dc_solver` take **one cache reference**. There is no way to hand either function half of one.

## What this deletes rather than adds

- The reuse guard is `cache.is_usable(nb_bus)` — one place, instead of eight comparisons written inline against a mix of two objects' members.
- "Is this my cache?" is `&c == &ac_cache_`, two overloads picked by the family's own type. #184 needed nine pointer comparisons and a throw on a partial match; that whole function is gone.
- `_mark_cache_valid` / `prevent_*_cache_reuse` / `init_bus_status` lose their `if(ac) x_ac_ else x_dc_` bodies.
- `BaseBatchSolverSynch`'s eleven loose members become its own two caches; the read-back above, and its three copies, are gone.

It's also the extension point: remote / shared voltage-control layouts, HVDC droop data — add a field and it inherits the lifetime, invalidation and consistency rules of everything already there.

`DualAlgoControl` deliberately stays put. It's threaded through every element-container mutator signature and is already correctly per-family.

## Behaviour changes (all in the foreign-build path)

- A build into a caller's cache **never reuses**. `solver_control`, the snapshot `init_bus_status()` raises its flags against, and those flags all describe *this* grid and say nothing about someone else's cache.
- It **retires** this grid's cache for that family afterwards. The labelling and the split still have to be published — the NR extensions read them back through `lsgrid_ptr` rather than from what the solver was handed, **including `bus_pq`**, which `fill_voltage_control_solver_data` needs and which the old write-through supplied *by accident*. Publishing the matrix too would mean copying it, so what remains is a view for the extensions, not a cache: snapshot cleared, control raised, next own powerflow rebuilds.
- The grid's own algorithm is no longer reset or reconfigured for a solve it will never perform.

## ⚠️ ABI

**This changes `LSGrid`'s member layout.** The note that sat on `_forced_ref_slack_bus_id` ("declared LAST so existing member offsets are unchanged — ABI-stable for the gpusim2grid cross-module `LSGrid` cast") cannot survive regrouping scattered members. `docs/solver_plugin.rst` already requires the same version of headers at runtime ("different `BaseAlgo` layout ... undefined behaviour"), and 1.0.0 already carries several `[BREAKING]` entries — so this is flagged in the changelog rather than worked around. **gpusim2grid must be rebuilt against these headers.**

## Cost — measured

Callgrind slope, 200→1200 powerflows on the exotic-elements IEEE14 grid (so construction cancels):

| | dev_0.13.2 | this branch | delta |
|---|---|---|---|
| AC powerflow | 839 340 instr/pf | 839 541 | +200 (+0.024 %) |
| DC, warm cache | 28 095 instr/pf | 28 309 | +214 (+0.76 %) |

The DC row is the floor — the cheapest powerflow this library can run.

Roughly two thirds of that is **not this change**: a per-function diff of the two profiles puts **+74/pf in `compute_results_tsc_rxha_no_amps`** and **+60/pf in an `Eigen::Ref` helper**, neither of which the diff touches — inlining decisions that moved when the translation unit was recompiled. Wall clock shows nothing: run-to-run spread on one unchanged binary (2464 → 2744 ns on the same DC case) exceeds the gap between the two binaries.

## Tests

- **`test_cache_reuse.cpp`, "the structural half … `unset_changes`"** — the existing `[unset_changes]` sections all reach it through `allow_cache_reuse(false)`, i.e. *both* families off, so the family that runs is stopped by `is_usable`'s first line (`if(!allow_reuse)`) and those sections pass with the rest of `is_usable` deleted. Leaving **one** family automatic is what exercises the structural checks. Verified: gutting `is_usable` to `return allow_reuse;` makes it **SIGSEGV**.
- **`test_cache_reuse.cpp`, "a build into someone else's cache …"** — a foreign build fills the caller's cache completely, publishes what the extensions read, and retires the grid's. The `need_reset_solver()` assertion is the one that separates this from `dev_0.13.2`.
- **`test_batch_voltage_control.cpp`** — the source grid solves identically on both sides of a `TimeSeries` and a `ContingencyAnalysis`.

**210 test cases / 5815 assertions** pass under Release, C++14 (`LS2G_CXX_STANDARD=14`), ASan+UBSan, and valgrind (0 errors, no leaks).

The python layer could **not** be exercised locally (no pybind11 / numpy on the machine this ran on) — CircleCI's `test_legacy_*` jobs cover it. No python-visible API changed; `pre_process_solver` was never bound, and every `&LSGrid::` symbol the bindings reference still resolves.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UtvkqXMvgCig75gruZCs7u

---
_Generated by [Claude Code](https://claude.ai/code/session_01UtvkqXMvgCig75gruZCs7u)_