### PR TITLE
Derive the voltage-control plan once per powerflow, in one class

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,6 +3,23 @@ Change Log
 
 [TODO]
 --------
+- Several inputs of the voltage-control plan can only be set at construction, so a caller
+  cannot change them on a live grid at all. None of them is a missing-flag bug -- there is no
+  setter to raise a flag from -- but each is a missing capability, and adding the setter means
+  adding ``tell_voltage_control_changed()`` (or, where it moves who is in a group,
+  ``tell_pv_changed()``) with it:
+
+  * a generator's ``voltage_regulator_on_``: no way to take a machine out of voltage
+    regulation, or put it back, without rebuilding the container (``init_generators_full``).
+    ``set_gen_regulated_bus`` exists and does raise what it must, so only the on/off is missing.
+  * an hvdc converter station's ``voltage_regulator_on_``: same, through ``init_hvdc_lines``.
+  * an SVC's ``regulation_mode_`` (OFF / VOLTAGE / REACTIVE_POWER) and its
+    ``regulated_bus_id_``: neither has a setter, so an SVC cannot be switched between modes,
+    nor pointed at another bus, after ``init_svcs``.
+  * remote regulation BY an hvdc converter station is not modelled at all: the container
+    stores no regulated bus for a station, so a regulating one always regulates the bus it
+    stands on. A station only ever joins a control group somebody else created (see
+    ``VoltageControlPlan::build_groups``).
 - ``SubstationContainer::sub_vn_kv_`` is dead state: its only writers (``init_sub()``
   and the two-argument constructor) are called from nowhere, and nothing reads it
   back, so it is empty on every grid every loader produces and in every binary file
@@ -200,18 +217,32 @@ TODO: a "combine mode" axis for ``ScenarioSweepCPP`` choosing between the curren
   ``LSGrid::get_group_controlled_buses`` / ``get_free_vm_slack_solver_buses`` /
   ``fill_voltage_control_solver_data`` are unchanged in signature and behaviour and now build a
   throw-away plan -- they are the on-demand form, for callers outside a solve.
-- [ADDED] ``AlgoControl::tell_voltage_control_changed()`` /
-  ``has_voltage_control_changed()`` / ``need_recompute_voltage_control()``, and a call to the
-  first from every element modifier that can move an input of the plan: a generator's regulated
-  bus, voltage setpoint, status, bus, slack role or pseudo-off state; an SVC's or an hvdc
-  converter station's status or bus; a station's setpoint. Its own flag rather than a reuse of
-  ``tell_pv_changed()``, because the two questions genuinely differ -- a remote regulator moving
-  its setpoint changes no bus' pv/pq class at all (that is the point of the bordered
-  formulation), and most of what makes a bus PV or PQ has nothing to do with a control group.
-  Raised on the AC family only: a DC solve has no voltage control, so there is no DC plan to
-  invalidate. ``need_recompute_voltage_control()`` is the union a powerflow asks, deliberately
-  conservative (it also fires on anything that re-labels the buses or re-splits them), and
-  all-or-nothing: the three layers are rebuilt together or not at all.
+- [ADDED] ``AlgoControl::need_recompute_pv_pq()`` -- must the pv/pq split be rebuilt: the
+  system was rebuilt from scratch, the bus set changed, the bus labelling changed, the slack
+  set moved, or a bus changed class -- and ``need_recompute_voltage_control()``, which is that
+  plus one term. Since the split IS a layer of the voltage-control plan
+  (``VoltageControlPlan::build_pv_pq``), whatever rebuilds the split rebuilds the plan: who is
+  in a control group and which bus it regulates are exactly the inputs the split reads, and
+  there is no way to change one without changing the other. ``LSGrid::_build_into_cache`` asks
+  those two and nothing else, so what the powerflow asks and what a test asks cannot drift.
+- [ADDED] ``AlgoControl::tell_voltage_control_changed()`` / ``has_voltage_control_changed()``:
+  the one term the pv/pq flags do not carry, a voltage SETPOINT. Moving a remote regulator's
+  target changes no bus' pv/pq class at all -- that is the point of the bordered formulation,
+  the regulated bus stays PQ -- so nothing else would notice. Raised from exactly two places
+  (``GeneratorContainer::change_v_nothrow`` and ``ConverterStationContainer::change_v``), on
+  the AC family only and only for an element that actually regulates: a DC solve has no
+  voltage control, and ``target_vm_pu_`` of a non-regulating machine is never read.
+- [FIXED] ``GeneratorContainer::set_regulated_bus`` raised ``tell_recompute_sbus()`` and
+  ``tell_pv_changed()`` unconditionally. ``fillSbus`` never reads ``regulated_bus_id_`` -- and
+  what it stamps for a regulating generator, active power only, is the same wherever that
+  generator regulates -- so the injections cannot have moved; and for a generator that does
+  not regulate at all the field is inert, so neither can the pv/pq split. Both are now raised
+  only when the machine regulates, and the Sbus one is gone.
+- [FIXED] ``ConverterStationContainer::_deactivate`` / ``_reactivate`` raised
+  ``tell_pv_changed()`` for every station. Only a REGULATING station pins a bus
+  (``ConverterStationContainer::fillpv`` skips the others), so only that one can move the
+  pv/pq split. ``tell_recompute_sbus()`` stays unconditional and is correct: a station IS in
+  Sbus, whether it regulates or not.
 - [IMPROVED] the voltage-control plan is derived **once per powerflow** instead of four times.
   ``LSGrid::_build_into_cache`` builds it around ``fillpv_pq`` -- layer 1 is an input to the
   pv-pq split, layers 2 and 3 are expressed in it -- and the NR extensions read it through

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -218,13 +218,28 @@ TODO: a "combine mode" axis for ``ScenarioSweepCPP`` choosing between the curren
   ``fill_voltage_control_solver_data`` are unchanged in signature and behaviour and now build a
   throw-away plan -- they are the on-demand form, for callers outside a solve.
 - [ADDED] ``AlgoControl::need_recompute_pv_pq()`` -- must the pv/pq split be rebuilt: the
-  system was rebuilt from scratch, the bus set changed, the bus labelling changed, the slack
-  set moved, or a bus changed class -- and ``need_recompute_voltage_control()``, which is that
-  plus one term. Since the split IS a layer of the voltage-control plan
+  system was rebuilt from scratch, the bus set changed, the slack set moved, or a bus changed
+  class -- and ``need_recompute_voltage_control()``, which is that plus one term. Since the split IS a layer of the voltage-control plan
   (``VoltageControlPlan::build_pv_pq``), whatever rebuilds the split rebuilds the plan: who is
   in a control group and which bus it regulates are exactly the inputs the split reads, and
   there is no way to change one without changing the other. ``LSGrid::_build_into_cache`` asks
   those two and nothing else, so what the powerflow asks and what a test asks cannot drift.
+- [IMPROVED] ``AlgoControl::need_recompute_pv_pq()`` no longer lists
+  ``ybus_change_sparsity_pattern_``. That flag means "the bus LABELLING may have moved", and
+  it is raised only by branch-side mutations (reconnecting a line or a trafo, moving one of
+  its ends) -- every one of which goes through ``GenericContainer::_apply_and_track_buses``,
+  which raises ``change_dimension_`` exactly when the mutation empties or fills a bus, i.e.
+  exactly when the labelling moves. When no bus crossed, ``id_me_to_solver`` comes back
+  identical and a branch is neither a voltage controller nor a slack, so the split it produces
+  is the same one. Measured rather than argued: ``src/tests/test_cache_reuse.cpp`` (tag
+  ``[pv_pq]``) reaches a state where this flag is the ONLY one of the six raised, solves on
+  the reused cache, solves again cold and compares -- and the predicate was built both ways.
+  With the term dropped those cases stay green; the same experiment on
+  ``slack_participate_changed_`` fails them (``GeneratorContainer::fillpv`` skips a bus that is
+  in the slack set, and so does the PQ loop after it), which is why that term stays. Worth
+  **-0.9% / -1.8% / -0.7% / -0.4%** of a topology-changing cached powerflow on
+  case30 / case118 / case1354pegase / case9241pegase, on top of the plan caching above, with
+  bit-identical answers.
 - [ADDED] ``AlgoControl::tell_voltage_control_changed()`` / ``has_voltage_control_changed()``:
   the one term the pv/pq flags do not carry, a voltage SETPOINT. Moving a remote regulator's
   target changes no bus' pv/pq class at all -- that is the point of the bordered formulation,

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -139,6 +139,57 @@ TODO: a "combine mode" axis for ``ScenarioSweepCPP`` choosing between the curren
 
 [1.0.1] 2026-xx-yy
 --------------------
+- [ADDED] ``ls2g::VoltageControlPlan`` (``src/core/VoltageControlPlan.hpp``): everything one AC
+  solve needs to know about the "fancy" voltage controllers -- remote-regulating generators,
+  several machines regulating one bus, and voltage-mode SVCs -- as ONE object instead of three
+  functions on ``LSGrid``. They were never three answers: the controller list is derived from the
+  free-Vm slack set, which is derived from the group layout, and each of the three used to walk
+  the containers again where it happened to be needed. It is a member of ``SolverBusLayout``,
+  i.e. of a solver-side cache, because it is expressed in that cache's bus labelling AND its
+  pv-pq split: a plan carried across a relabelling is not stale data, it is a different grid.
+  ``LSGrid::get_group_controlled_buses`` / ``get_free_vm_slack_solver_buses`` /
+  ``fill_voltage_control_solver_data`` are unchanged in signature and behaviour and now build a
+  throw-away plan -- they are the on-demand form, for callers outside a solve.
+- [ADDED] ``AlgoControl::tell_voltage_control_changed()`` /
+  ``has_voltage_control_changed()`` / ``need_recompute_voltage_control()``, and a call to the
+  first from every element modifier that can move an input of the plan: a generator's regulated
+  bus, voltage setpoint, status, bus, slack role or pseudo-off state; an SVC's or an hvdc
+  converter station's status or bus; a station's setpoint. Its own flag rather than a reuse of
+  ``tell_pv_changed()``, because the two questions genuinely differ -- a remote regulator moving
+  its setpoint changes no bus' pv/pq class at all (that is the point of the bordered
+  formulation), and most of what makes a bus PV or PQ has nothing to do with a control group.
+  Raised on the AC family only: a DC solve has no voltage control, so there is no DC plan to
+  invalidate. ``need_recompute_voltage_control()`` is the union a powerflow asks, deliberately
+  conservative (it also fires on anything that re-labels the buses or re-splits them), and
+  all-or-nothing: the three layers are rebuilt together or not at all.
+- [IMPROVED] the voltage-control plan is derived **once per powerflow** instead of four times.
+  ``LSGrid::_build_into_cache`` builds it around ``fillpv_pq`` -- layer 1 is an input to the
+  pv-pq split, layers 2 and 3 are expressed in it -- and the NR extensions read it through
+  ``LSGrid::get_ac_voltage_control_plan()`` instead of calling back into the grid.
+  ``Base::update_state`` re-derived the free-Vm slack set and ``VoltageControl::update_state``
+  re-derived it a second time plus the whole controller list, each walking every generator of
+  the grid and building ``std::set``s as it went. A solve that changed none of the plan's inputs
+  -- which an ordinary grid2op step does not, moving a load's P and Q raises
+  ``need_recompute_sbus`` and nothing else -- now keeps the one the previous solve built.
+  **-3.7% / -8.1% / -3.1% / -2.2%** of an ordinary cached powerflow on
+  case30 / case118 / case1354pegase / case9241pegase (-6.1% / -16.4% / -7.3% / -5.4% of an
+  identical re-solve), and -6.8% / -2.6% / -0.4% on the new ``_fancy`` grids, with bit-identical
+  answers. It also removes a class of bug rather than only a cost: the three layers are now
+  built from one another instead of from three independent walks of the containers, so they
+  cannot disagree, and a foreign build (the batch algorithms) publishes the plan it just built
+  rather than leaving the extensions to re-derive one from the published labelling.
+- [ADDED] ``benchmarks/cache_profiling/make_grids.py`` also writes a ``_fancy`` variant of
+  case118, case1354pegase and case9241pegase: pairs of generators re-pointed at a common
+  neighbouring load bus (a control group) plus voltage-mode SVCs. The plain pandapower cases
+  have no remote voltage control and no SVC at all, so nothing that concerns the bordered
+  VoltageControl block showed up in the audit. Recorded there while measuring: on
+  case9241pegase_fancy (40 groups, 30 SVCs) **86% of a cached solve is** ``klu_refactor``,
+  against 55% on the plain case -- the 80 reactive-injection columns each couple a generator's
+  bus to a regulated bus a branch away, and KLU's ordering pays for the fill-in.
+- [ADDED] ``src/tests/test_voltage_control_plan_cache.cpp``: every input of the plan is mutated
+  on a grid that has already solved (so a stale plan is there to be wrongly reused) AND on a
+  fresh grid built in the final state, and the two solves must agree. A reused stale plan does
+  not throw and does not look wrong -- it converges, on the previous scenario's controllers.
 - [ADDED] ``benchmarks/cache_profiling/``: an instruction-count audit of the CACHED powerflow
   path -- a solve that follows a successful one, which is what every grid2op step after the
   first runs. A standalone C++ driver (no python, no pybind11) lets callgrind collect ONLY the

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -139,6 +139,56 @@ TODO: a "combine mode" axis for ``ScenarioSweepCPP`` choosing between the curren
 
 [1.0.1] 2026-xx-yy
 --------------------
+- [FIXED] a grid using voltage control that the selected algorithm cannot implement -- a
+  generator or an hvdc converter station regulating a bus other than its own, several
+  machines regulating one bus, or a voltage-mode SVC -- was **solved anyway, to a wrong
+  answer**, by the fast-decoupled and Gauss-Seidel algorithms. Those hold no ``NRSystem``,
+  hence no ``VoltageControl`` extension, so no bordered block was ever built; but the pv/pq
+  split took the regulated bus out of PV all the same, leaving its magnitude pinned by
+  nothing. The solve converged, looked plausible, and on a case118 with eight control
+  groups landed **0.36 pu** away from the Newton-Raphson answer, missing every setpoint by
+  0.127 pu. ``BaseAlgo::supports_remote_voltage_control()`` existed to prevent exactly this
+  and had **no caller anywhere**. ``LSGrid::ac_pf`` now refuses such a grid, in the same
+  place and the same shape as the angle-droop guard right above it, naming every concerned
+  generator, SVC and converter station. It does not silently rewrite the grid: turning the
+  regulator off changes the reactive dispatch and pointing it at its own bus needs a
+  setpoint nobody has (the one it carries targets a *different* bus), so which of the two
+  to do is the caller's decision, not the library's.
+- [IMPROVED] ``LSGrid::fillpv_pq`` is gone: the pv/pq split is layer 2 of
+  ``VoltageControlPlan``. Its one subtlety -- a bus a control GROUP regulates must keep its
+  own Vm unknown -- is keyed on layer 1, and layer 4 is then keyed on the split, so the
+  three belong to one object and one build order rather than to a call sequence that has to
+  be got right. What stays on ``LSGrid`` is naming the containers to ask
+  (``_pv_capable_containers()``), which is what owning them means -- and that also settles
+  the standing ``TODO have a function to dispatch that to all type of elements``: the rule
+  is now "ask every container", not "ask these eight, in this order".
+- [IMPROVED] an algorithm with no bordered block builds no voltage-control plan at all:
+  layers 1, 3 and 4 are skipped and layer 2 produces the classical split. Deriving them
+  once per powerflow (see above) had made them the business of the cache rather than of
+  the extension that wanted them, which meant fast-decoupled and Gauss-Seidel paid for two
+  container walks whose result nobody reads -- **+2.2% / +0.57%** of a rebuild on case118 /
+  case9241pegase. Now **-0.09% / -0.05%** against the same baseline, and flat on an
+  ordinary step.
+- [FIXED] ``LSGrid::change_algorithm(const std::string&)`` did not call
+  ``init_fdpf_coeffs()``, which its ``AlgorithmType`` overload does: selecting a
+  fast-decoupled solver **by name** threw ``"the FDPF coefficients are not cached"`` on the
+  first powerflow, while selecting the very same solver by enum worked. Added
+  ``AlgorithmSelector::is_fdpf()`` (no argument) next to ``supports_hvdc_droop()`` and
+  ``supports_remote_voltage_control()`` and used it: the type-keyed ``is_fdpf(type)`` cannot
+  answer for a solver reached through the registry or for a plugin, both being
+  ``AlgorithmType::Custom``.
+- [IMPROVED] ``AlgorithmSelector::get_prt_solver`` and ``check_right_solver`` take a
+  ``const char *`` instead of a ``const std::string &``. All fifty-odd call sites pass a
+  string literal and the names are longer than libstdc++'s small-string buffer
+  (``"supports_remote_voltage_control"`` is 31 characters), so every call -- ``get_V``,
+  ``get_Va``, ``get_Vm``, ``compute_pf``, ``tell_solver_control`` and the capability
+  queries, several times per powerflow -- did one ``malloc`` and one ``free`` to build a
+  string only the error path ever reads. **-1,855 to -2,078 instructions per solve**, on
+  every grid and every algorithm.
+- [IMPROVED] the profiling driver derives its iteration budget from the algorithm family
+  (``BaseAlgo::is_fdpf``): 10 for Newton-Raphson and DC as before, 100 for fast-decoupled,
+  which needs ~50 on case118 and so diverged outright at 10. Together with the fix above
+  this is what makes the fast-decoupled algorithms profilable at all.
 - [ADDED] ``ls2g::VoltageControlPlan`` (``src/core/VoltageControlPlan.hpp``): everything one AC
   solve needs to know about the "fancy" voltage controllers -- remote-regulating generators,
   several machines regulating one bus, and voltage-mode SVCs -- as ONE object instead of three

--- a/benchmarks/cache_profiling/README.md
+++ b/benchmarks/cache_profiling/README.md
@@ -183,15 +183,15 @@ raises `need_recompute_sbus` and nothing else).
 
 A/B against the tree as it was, KLU, answers compared bit for bit:
 
-| grid | `inj` (an ordinary step) | `idem` (the floor) |
-|---|---:|---:|
-| case30 | **-4.9%** | -7.9% |
-| case118 | **-8.3%** | -16.9% |
-| case118_fancy | **-7.0%** | -18.6% |
-| case1354pegase | **-3.2%** | -7.3% |
-| case1354pegase_fancy | **-2.6%** | -3.9% |
-| case9241pegase | **-2.2%** | -5.4% |
-| case9241pegase_fancy | **-0.4%** | -0.8% |
+| grid | `inj` (an ordinary step) | `idem` (the floor) | `topo` (a line toggled) |
+|---|---:|---:|---:|
+| case30 | **-4.9%** | -7.9% | -2.3% |
+| case118 | **-8.3%** | -16.9% | -4.9% |
+| case118_fancy | **-7.0%** | -18.6% | -4.0% |
+| case1354pegase | **-3.2%** | -7.3% | -1.9% |
+| case1354pegase_fancy | **-2.6%** | -3.9% | -1.7% |
+| case9241pegase | **-2.2%** | -5.4% | -1.4% |
+| case9241pegase_fancy | **-0.4%** | -0.8% | -0.5% |
 
 The two phases save the *same* number of instructions, to the last one (8,040 on
 case30 up to 2.3M on case9241pegase): what is removed is a fixed per-solve cost,
@@ -206,6 +206,39 @@ took its `error_msg` by `const std::string &` and every call site passes a liter
 longer than libstdc++'s small-string buffer, so `get_V` / `get_Va` / `get_Vm` /
 `compute_pf` / `tell_solver_control` each did a malloc and a free per solve to build
 a string only the error path reads. `const char *` now.
+
+Part of the `topo` column is a third find, and it is the one the benchmark was used
+to *settle* rather than to report. `need_recompute_pv_pq()` listed
+`ybus_change_sparsity_pattern_` -- "the bus labelling may have moved" -- among the
+reasons to rebuild the pv/pq split. It is raised only by branch-side mutations
+(reconnecting a line or a trafo, moving one of its ends), and every one of those
+goes through `GenericContainer::_apply_and_track_buses`, which raises
+`change_dimension_` exactly when the mutation empties or fills a bus -- which is
+exactly when the labelling moves. So the term was subsumed. The argument was checked
+against the grid before it was believed: `src/tests/test_cache_reuse.cpp` reaches a
+state where this flag is the ONLY one of the six raised, solves warm and cold and
+compares, and the predicate was then built both ways. Dropping the term leaves those
+cases green; dropping `slack_participate_changed_` the same way makes them fail, so
+that one stays. What the drop is worth, on its own, on a solve whose cache a
+topology change retired:
+
+| grid | `topo`, term kept | `topo`, term dropped |
+|---|---:|---:|
+| case30 | 440,089 | 436,057 (**-0.9%**) |
+| case118 | 1,470,391 | 1,444,534 (**-1.8%**) |
+| case118_fancy | 2,443,695 | 2,409,714 (**-1.4%**) |
+| case1354pegase | 20,163,544 | 20,013,614 (**-0.7%**) |
+| case1354pegase_fancy | 28,649,453 | 28,470,141 (**-0.6%**) |
+| case9241pegase | 182,113,949 | 181,393,356 (**-0.4%**) |
+| case9241pegase_fancy | 536,874,742 | 536,025,060 (**-0.2%**) |
+
+(the `topo` phase toggles one line, so only every other solve raises the flag at
+all; the answers are bit-identical on all seven grids). A note for whoever measures
+next: the driver links `liblightsim2grid_core.so` with a RUNPATH into its own build
+directory, so two binaries copied out of the SAME build tree load whatever library
+that tree holds at run time, not the one they were built with. A/B either from two
+separate build directories, or with `LD_LIBRARY_PATH` -- which wins over RUNPATH --
+pointing at a saved copy of each library.
 
 ### Algorithms that cannot do voltage control
 

--- a/benchmarks/cache_profiling/README.md
+++ b/benchmarks/cache_profiling/README.md
@@ -38,7 +38,9 @@ Phases, one callgrind run each:
 
 ```bash
 # 1. the grids, dumped from pandapower to lightsim2grid's binary format, so the
-#    profile contains no python and no conversion code
+#    profile contains no python and no conversion code. Two families: the plain
+#    pandapower cases, and a `_fancy` variant of the bigger ones carrying remote
+#    voltage-control groups and voltage-mode SVCs (see `make_fancy` there).
 python make_grids.py grids
 
 # 2. the driver, built straight against src/core -- no python, no pybind11
@@ -115,6 +117,7 @@ Acted on (each A/B'd, answers compared; see the changelog for the details):
 | `1/\|V\|` from `Vm_` instead of a `hypot` pass over `V_` | -2.1% | -2.5% | -2.2% | -1.6% |
 | read each branch status bit once, not five times | -1.5% | -1.2% | -1.0% | -0.9% |
 | take the per-bus mismatch off the algorithm | -2.1% | -2.1% | — | -1.4% |
+| derive the voltage-control plan once per solve, not four times | -3.7% | -8.1% | -3.1% | -2.2% |
 
 Measured and **declined**, recorded here so they are not re-proposed:
 
@@ -137,6 +140,63 @@ Measured and **declined**, recorded here so they are not re-proposed:
   count, and -17%/-20% on case118/case1354pegase; it loses on case30, where the
   iteration it adds costs more than the factorization it skips. Out of scope: a
   different algorithm, not a cheaper way to run this one.
+
+### The `_fancy` grids
+
+`make_grids.py` also writes a `_fancy` variant of case118, case1354pegase and
+case9241pegase: a few *pairs* of generators re-pointed at a common neighbouring
+load bus (a control **group**, solved by the bordered VoltageControl block) plus
+a few voltage-mode SVCs. Setpoints are the base case's own solved magnitudes, and
+each candidate is kept only if the grid still converges with it -- the same
+chunk-and-verify workaround `benchmarks/make_exotic_grid.cpp` uses, for the same
+reason (see the remote-voltage-control entry in the changelog's TODO).
+
+They exist because the plain pandapower cases have **no** remote voltage control
+and no SVC at all: the controller list is empty on every one of them, so nothing
+that concerns the bordered block shows up. Two things they measured:
+
+| grid | groups | SVCs | `idem` | `inj` | vs. the plain case (`idem`) |
+|---|---:|---:|---:|---:|---:|
+| case118_fancy | 8 | 4 | 385,022 | 1,173,068 | +16% |
+| case1354pegase_fancy | 20 | 10 | 10,293,316 | 15,583,429 | +138% |
+| case9241pegase_fancy | 40 | 30 | 318,321,358 | 596,998,625 | +686% |
+
+That last column is not the plan, and not the bordered rows either: on
+case9241pegase_fancy **86% of a cached solve is `klu_refactor`** (against 55% on
+the plain case). Forty two-member groups add 80 reactive-injection columns, each
+coupling a generator's bus to a regulated bus a branch away, and KLU's ordering
+pays for the fill-in that creates. Worth knowing before remote control is enabled
+at scale on a large grid; out of scope here.
+
+### Deriving the voltage-control plan once per solve
+
+The "fancy" voltage controllers are described by three derived sets -- which buses
+a control GROUP regulates, which slack buses keep a free Vm unknown, and the
+controller list itself -- and each of them used to be re-derived where it happened
+to be needed: by `fillpv_pq`, by `Base::update_state`, and twice by
+`VoltageControl::update_state` (which re-ran the free-Vm slack pass of its own).
+Four walks of every generator of the grid per powerflow, each building `std::set`s
+as it went. They are now one object (`VoltageControlPlan`), built once into the
+solver-side cache and read from there, and kept across a solve that changed none
+of its inputs -- which an ordinary grid2op step does not (moving a load's P and Q
+raises `need_recompute_sbus` and nothing else).
+
+A/B against the tree as it was, KLU, answers compared bit for bit:
+
+| grid | `inj` (an ordinary step) | `idem` (the floor) |
+|---|---:|---:|
+| case30 | **-3.7%** | -6.1% |
+| case118 | **-8.1%** | -16.4% |
+| case118_fancy | **-6.8%** | -18.2% |
+| case1354pegase | **-3.1%** | -7.3% |
+| case1354pegase_fancy | **-2.6%** | -3.9% |
+| case9241pegase | **-2.2%** | -5.4% |
+| case9241pegase_fancy | **-0.4%** | -0.8% |
+
+The proportion falls with grid size because the work removed is O(generators)
+while the solve it is measured against is dominated by KLU -- and it falls
+furthest on the fancy pegase case for exactly the reason the table above gives.
+In absolute terms it is 2.3M instructions per solve on case9241pegase.
 
 Measured and **not worth attacking**: the build side of the cache
 (`_build_into_cache` is ~1% of a case9241pegase solve, most of it the Sbus refill

--- a/benchmarks/cache_profiling/README.md
+++ b/benchmarks/cache_profiling/README.md
@@ -117,7 +117,7 @@ Acted on (each A/B'd, answers compared; see the changelog for the details):
 | `1/\|V\|` from `Vm_` instead of a `hypot` pass over `V_` | -2.1% | -2.5% | -2.2% | -1.6% |
 | read each branch status bit once, not five times | -1.5% | -1.2% | -1.0% | -0.9% |
 | take the per-bus mismatch off the algorithm | -2.1% | -2.1% | — | -1.4% |
-| derive the voltage-control plan once per solve, not four times | -3.7% | -8.1% | -3.1% | -2.2% |
+| derive the voltage-control plan once per solve, not four times | -4.9% | -8.3% | -3.2% | -2.2% |
 
 Measured and **declined**, recorded here so they are not re-proposed:
 
@@ -185,18 +185,53 @@ A/B against the tree as it was, KLU, answers compared bit for bit:
 
 | grid | `inj` (an ordinary step) | `idem` (the floor) |
 |---|---:|---:|
-| case30 | **-3.7%** | -6.1% |
-| case118 | **-8.1%** | -16.4% |
-| case118_fancy | **-6.8%** | -18.2% |
-| case1354pegase | **-3.1%** | -7.3% |
+| case30 | **-4.9%** | -7.9% |
+| case118 | **-8.3%** | -16.9% |
+| case118_fancy | **-7.0%** | -18.6% |
+| case1354pegase | **-3.2%** | -7.3% |
 | case1354pegase_fancy | **-2.6%** | -3.9% |
 | case9241pegase | **-2.2%** | -5.4% |
 | case9241pegase_fancy | **-0.4%** | -0.8% |
 
-The proportion falls with grid size because the work removed is O(generators)
-while the solve it is measured against is dominated by KLU -- and it falls
-furthest on the fancy pegase case for exactly the reason the table above gives.
-In absolute terms it is 2.3M instructions per solve on case9241pegase.
+The two phases save the *same* number of instructions, to the last one (8,040 on
+case30 up to 2.3M on case9241pegase): what is removed is a fixed per-solve cost,
+paid before the Newton loop starts. `inj` reads smaller only because it is a
+1.5x-2.7x bigger solve. The proportion falls with grid size because the work
+removed is O(generators) while the solve it is measured against is dominated by
+KLU -- and it falls furthest on the fancy pegase case for the reason the table
+above gives.
+
+About 1.9k of the per-solve figure is a second, unrelated find: `AlgorithmSelector`
+took its `error_msg` by `const std::string &` and every call site passes a literal
+longer than libstdc++'s small-string buffer, so `get_V` / `get_Va` / `get_Vm` /
+`compute_pf` / `tell_solver_control` each did a malloc and a free per solve to build
+a string only the error path reads. `const char *` now.
+
+### Algorithms that cannot do voltage control
+
+The plan is only ever read by the `Base` and `VoltageControl` components of
+NRSystem, i.e. by the Newton-Raphson algorithms. Deriving it once per powerflow --
+into the cache, rather than lazily in the extension that wanted it -- therefore made
+the fast-decoupled and Gauss-Seidel algorithms pay for two container walks nobody
+reads: **+2.20% / +0.57%** of a rebuild on case118 / case9241pegase (`nocache`,
+FDPF_XB_KLU), and nothing on an ordinary step, where the plan is reused anyway.
+
+They now build no plan at all -- and, more to the point, they no longer take a
+group-regulated bus out of PV, which was a *wrong answer* rather than a slow one
+(0.36 pu on case118_fancy). Against the same pre-change baseline:
+
+| grid | phase | before | after |
+|---|---|---:|---:|
+| case118 | `inj` | 1,017,431 | 1,017,063 (**-0.04%**) |
+| case118 | `nocache` | 1,851,440 | 1,849,757 (**-0.09%**) |
+| case9241pegase | `inj` | 135,854,646 | 135,886,270 (+0.02%) |
+| case9241pegase | `nocache` | 218,035,000 | 217,924,056 (**-0.05%**) |
+
+Profiling those at all needed two fixes of its own: `change_algorithm` by NAME did
+not call `init_fdpf_coeffs()` (so an FDPF solver selected the way this driver selects
+it threw on the first solve), and the driver's iteration budget was a hard-coded 10
+where fast-decoupled needs ~50. Both are fixed; `max_iter` is now derived from
+`BaseAlgo::is_fdpf`.
 
 Measured and **not worth attacking**: the build side of the cache
 (`_build_into_cache` is ~1% of a case9241pegase solve, most of it the Sbus refill

--- a/benchmarks/cache_profiling/make_grids.py
+++ b/benchmarks/cache_profiling/make_grids.py
@@ -12,12 +12,24 @@ Dump a few pandapower reference grids as lightsim2grid binary (``.lsb``) files, 
 that the C++ profiling driver (``profile_cached_pf.cpp``) can load them without
 needing python, pandapower or the conversion code in the profile.
 
+Two families are written:
+
+* the plain pandapower cases, which have no remote voltage control and no SVC:
+  every generator regulates its own bus, the ordinary PV path;
+* a ``_fancy`` variant of the bigger ones, where a few *pairs* of generators are
+  re-pointed at a common neighbouring load bus (a control GROUP: the bordered
+  VoltageControl formulation, one voltage row and one reactive-sharing row per
+  group) and a few voltage-mode SVCs are added. That is the configuration the
+  voltage-control plan (``VoltageControlPlan``) is actually built for, and the
+  only one where the size of its controller list is not zero.
+
     python make_grids.py [output_dir]
 """
 
 import os
 import sys
 
+import numpy as np
 import pandapower.networks as pn
 
 from lightsim2grid.network import init_from_pandapower
@@ -32,6 +44,117 @@ GRIDS = [
     ("case9241pegase", pn.case9241pegase),
 ]
 
+# (file stem, pandapower factory, nb of control groups, nb of SVCs) -- see
+# `make_fancy` for what is actually built, and why the counts are upper bounds.
+FANCY_GRIDS = [
+    ("case118_fancy", pn.case118, 8, 4),
+    ("case1354pegase_fancy", pn.case1354pegase, 20, 10),
+    ("case9241pegase_fancy", pn.case9241pegase, 40, 30),
+]
+
+MAX_ITER = 10
+TOL = 1e-8
+
+
+def _adjacency(net, nb_bus):
+    """bus -> set of buses one branch away, from the pandapower tables."""
+    adj = {b: set() for b in range(nb_bus)}
+    for f, t in zip(net.line.from_bus.values, net.line.to_bus.values):
+        adj[int(f)].add(int(t))
+        adj[int(t)].add(int(f))
+    for f, t in zip(net.trafo.hv_bus.values, net.trafo.lv_bus.values):
+        adj[int(f)].add(int(t))
+        adj[int(t)].add(int(f))
+    return adj
+
+
+def _solves(grid):
+    # from the SAME flat start the profiling driver uses (`grid.get_init_vm_pu()`,
+    # not 1.0): a candidate accepted from a different initial point is a candidate
+    # that can still diverge under the driver.
+    v0 = np.full(grid.total_bus(), grid.get_init_vm_pu(), dtype=complex)
+    return grid.ac_pf(v0, MAX_ITER, TOL).shape[0] > 0
+
+
+def _build(net, groups, svc_buses, vm):
+    """One candidate grid: `groups` = [(gen_a, gen_b, regulated_bus)], `svc_buses` a list."""
+    grid = init_from_pandapower(net)
+    for gen_a, gen_b, reg_bus in groups:
+        for gen_id in (gen_a, gen_b):
+            grid.set_gen_regulated_bus(gen_id, reg_bus)
+            # both members of a group must agree on the setpoint to the last bit,
+            # or fill_voltage_control_solver_data rejects the configuration
+            grid.change_v_gen(gen_id, float(vm[reg_bus]))
+    nb_svc = len(svc_buses)
+    if nb_svc:
+        buses = np.array(svc_buses, dtype=np.int32)
+        grid.init_svcs([1] * nb_svc,                       # RegulationMode::VOLTAGE
+                       np.array([vm[b] for b in svc_buses]),
+                       np.zeros(nb_svc),                   # q setpoint (unused in voltage mode)
+                       np.zeros(nb_svc),                   # slope: none
+                       np.full(nb_svc, -50.), np.full(nb_svc, 50.),
+                       buses,                              # regulated bus: its own
+                       buses)
+    return grid
+
+
+def make_fancy(net, nb_groups, nb_svc):
+    """
+    A copy of `net` with up to `nb_groups` two-generator control groups and up to
+    `nb_svc` voltage-mode SVCs, that still converges.
+
+    Setpoints are the BASE case's own solved magnitudes, so the added controllers
+    ask the grid for what it was doing anyway; without that the pegase cases
+    diverge outright. Even so, not every pair can be moved onto a neighbouring
+    bus and keep the grid solvable, so each candidate is accepted only if the
+    grid still converges with it -- which is why the counts above are upper
+    bounds and the function reports what it actually built. (Same chunk-and-verify
+    workaround as ``benchmarks/make_exotic_grid.cpp``, for the same reason: see the
+    remote-voltage-control entry in the changelog's TODO section.)
+    """
+    base = init_from_pandapower(net)
+    nb_bus = base.total_bus()
+    v0 = np.full(nb_bus, base.get_init_vm_pu(), dtype=complex)
+    vm = np.abs(base.ac_pf(v0, MAX_ITER, TOL))
+    if vm.size == 0:
+        raise RuntimeError("the base case does not converge")
+
+    gens = base.get_generators()
+    gen_buses = {gens[i].bus_id for i in range(len(gens))}
+    load_buses = {load.bus_id for load in base.get_loads()}
+    adj = _adjacency(net, nb_bus)
+    # a group needs two ACTIVE local regulators to enrol; the slack is left alone
+    candidates = [i for i in range(len(gens))
+                  if gens[i].connected and not gens[i].is_slack and gens[i].voltage_regulator_on]
+
+    groups, taken, i = [], set(), 0
+    while len(groups) < nb_groups and i + 1 < len(candidates):
+        gen_a, gen_b = candidates[i], candidates[i + 1]
+        i += 2
+        # a load bus next to one of the two, not already regulated by a group
+        common = [b for b in sorted(adj[gens[gen_a].bus_id] | adj[gens[gen_b].bus_id])
+                  if b in load_buses and b not in gen_buses and b not in taken]
+        if not common:
+            continue
+        reg_bus = common[0]
+        if _solves(_build(net, groups + [(gen_a, gen_b, reg_bus)], [], vm)):
+            groups.append((gen_a, gen_b, reg_bus))
+            taken.add(reg_bus)
+
+    svc_buses = []
+    for bus in sorted(load_buses - gen_buses):
+        if len(svc_buses) >= nb_svc:
+            break
+        if bus in taken:
+            continue
+        if _solves(_build(net, groups, svc_buses + [bus], vm)):
+            svc_buses.append(bus)
+
+    grid = _build(net, groups, svc_buses, vm)
+    if not _solves(grid):
+        raise RuntimeError("the fancy grid does not converge")
+    return grid, len(groups), len(svc_buses)
+
 
 def main(out_dir):
     os.makedirs(out_dir, exist_ok=True)
@@ -43,6 +166,13 @@ def main(out_dir):
         print(f"{name}: {grid.total_bus()} buses, "
               f"{len(net.line)} lines, {len(net.trafo)} trafos, "
               f"{len(net.load)} loads -> {path}")
+    for name, factory, nb_groups, nb_svc in FANCY_GRIDS:
+        net = factory()
+        grid, got_groups, got_svc = make_fancy(net, nb_groups, nb_svc)
+        path = os.path.join(out_dir, f"{name}.lsb")
+        grid.save_binary(path)
+        print(f"{name}: {grid.total_bus()} buses, {got_groups} control groups "
+              f"({2 * got_groups} generators), {got_svc} voltage-mode SVCs -> {path}")
 
 
 if __name__ == "__main__":

--- a/benchmarks/cache_profiling/profile_cached_pf.cpp
+++ b/benchmarks/cache_profiling/profile_cached_pf.cpp
@@ -66,7 +66,17 @@ using ls2g::AlgorithmType;
 
 namespace {
 
-const int MAX_ITER = 10;
+// Iteration budget, per algorithm family. Newton-Raphson converges a cached solve
+// in 1 to 3 iterations and 10 is already generous; the fast-decoupled ones trade a
+// cheap iteration for many more of them (~50 on case118) and diverge outright at 10,
+// which is why the audit could not profile them at all until this was derived rather
+// than fixed. Asked of the selected solver (BaseAlgo::is_fdpf), so it is right for a
+// plugin too.
+int max_iter_for(const LSGrid & grid)
+{
+    return grid.get_algo().is_fdpf() ? 100 : 10;
+}
+
 const real_type TOL = 1e-8;
 
 // Move every load ~2% around its base value, in a way that changes on every
@@ -166,6 +176,7 @@ int main(int argc, char ** argv)
         return 3;
     }
 
+    const int max_iter = max_iter_for(grid);
     const int nb_bus = static_cast<int>(grid.total_bus());
     const RealVect p0 = grid.get_loads().get_target_p();
     const RealVect q0 = grid.get_loads().get_target_q();
@@ -177,7 +188,7 @@ int main(int argc, char ** argv)
         CALLGRIND_START_INSTRUMENTATION;
         CALLGRIND_ZERO_STATS;
         CALLGRIND_TOGGLE_COLLECT;
-        const CplxVect V = grid.ac_pf(V0, MAX_ITER, TOL);
+        const CplxVect V = grid.ac_pf(V0, max_iter, TOL);
         CALLGRIND_TOGGLE_COLLECT;
         CALLGRIND_STOP_INSTRUMENTATION;
         if(V.size() == 0){ std::cerr << "cold solve diverged\n"; return 4; }
@@ -197,12 +208,12 @@ int main(int argc, char ** argv)
     if(phase == "inj_nores") grid.deactivate_result_computation();
 
     // ---- warm up: the solve that fills the cache, never collected -----------
-    CplxVect V = grid.ac_pf(V0, MAX_ITER, TOL);
+    CplxVect V = grid.ac_pf(V0, max_iter, TOL);
     if(V.size() == 0){ std::cerr << "warm-up solve diverged\n"; return 4; }
 
     // A second uncollected solve, so that what we measure is really the steady
     // state (the first cached solve still refactorizes from a cold KLU object).
-    V = grid.ac_pf(V, MAX_ITER, TOL);
+    V = grid.ac_pf(V, max_iter, TOL);
     if(V.size() == 0){ std::cerr << "second warm-up solve diverged\n"; return 4; }
 
     // `topo` needs a line whose opening leaves the grid solvable -- on the
@@ -215,9 +226,9 @@ int main(int argc, char ** argv)
         for(int line_id = 0; line_id < scan_max; ++line_id){
             if(!grid.get_lines_status()[line_id]) continue;
             grid.deactivate_powerline(line_id);
-            const CplxVect Vtry = grid.ac_pf(V, MAX_ITER, TOL);
+            const CplxVect Vtry = grid.ac_pf(V, max_iter, TOL);
             grid.reactivate_powerline(line_id);
-            const CplxVect Vback = grid.ac_pf(V, MAX_ITER, TOL);
+            const CplxVect Vback = grid.ac_pf(V, max_iter, TOL);
             if(Vtry.size() != 0 && Vback.size() != 0){ topo_line_id = line_id; break; }
         }
         if(topo_line_id < 0){
@@ -225,7 +236,7 @@ int main(int argc, char ** argv)
             return 5;
         }
         std::cout << "topo: toggling line " << topo_line_id << "\n";
-        V = grid.ac_pf(V, MAX_ITER, TOL);
+        V = grid.ac_pf(V, max_iter, TOL);
     }
 
     // The A/B trace: one entry per measured solve. Filled outside the collected
@@ -260,16 +271,16 @@ int main(int argc, char ** argv)
             CplxVect Vdc_init = CplxVect::Constant(nb_bus, 1.);
             CALLGRIND_TOGGLE_COLLECT;
             grid.deactivate_result_computation();
-            const CplxVect Vdc = grid.dc_pf(Vdc_init, MAX_ITER, TOL);
+            const CplxVect Vdc = grid.dc_pf(Vdc_init, max_iter, TOL);
             grid.reactivate_result_computation();
-            const CplxVect Vac = (Vdc.size() != 0) ? grid.ac_pf(Vdc, MAX_ITER, TOL)
+            const CplxVect Vac = (Vdc.size() != 0) ? grid.ac_pf(Vdc, max_iter, TOL)
                                                    : CplxVect();
             CALLGRIND_TOGGLE_COLLECT;
             if(Vac.size() == 0){ std::cerr << "dcac diverged at step " << step << "\n"; return 4; }
             V = Vac;
         } else {
             CALLGRIND_TOGGLE_COLLECT;
-            const CplxVect Vnew = grid.ac_pf(V, MAX_ITER, TOL);
+            const CplxVect Vnew = grid.ac_pf(V, max_iter, TOL);
             CALLGRIND_TOGGLE_COLLECT;
             if(Vnew.size() == 0){ std::cerr << "diverged at step " << step << "\n"; return 4; }
             V = Vnew;

--- a/src/core/AlgorithmSelector.hpp
+++ b/src/core/AlgorithmSelector.hpp
@@ -142,6 +142,15 @@ class LS2G_API AlgorithmSelector final
         bool supports_remote_voltage_control() const {
             return get_prt_solver("supports_remote_voltage_control", false)->supports_remote_voltage_control();
         }
+        // The no-argument form of is_fdpf(AlgorithmType) above. The type-keyed one
+        // cannot answer for a solver selected BY NAME -- an FDPF built-in reached
+        // through the registry, or a plugin implementing the method -- because their
+        // type is the catch-all Custom. LSGrid::change_algorithm(const std::string&)
+        // needs this one: an FDPF solve reads Bp / Bpp, which only
+        // LSGrid::init_fdpf_coeffs() fills, and without it the first solve throws.
+        bool is_fdpf() const {
+            return get_prt_solver("is_fdpf", false)->is_fdpf();
+        }
 
         // Convenience accessors for the two FDPF SparseLU variants.
         // These exist mainly for internal diagnostic use (exposed as AlgorithmSelector.get_fdpf_*).
@@ -393,19 +402,25 @@ class LS2G_API AlgorithmSelector final
         }
 
     protected:
-        const BaseAlgo* get_prt_solver(const std::string& error_msg, bool check_right_solver_ = true) const {
+        const BaseAlgo* get_prt_solver(const char * error_msg, bool check_right_solver_ = true) const {
             if (check_right_solver_) check_right_solver(error_msg);
             if (!_algo) throw std::runtime_error("AlgorithmSelector: no solver is active (not initialized?)");
             return _algo.get();
         }
-        BaseAlgo* get_prt_solver(const std::string& error_msg, bool check_right_solver_ = true) {
+        BaseAlgo* get_prt_solver(const char * error_msg, bool check_right_solver_ = true) {
             if (check_right_solver_) check_right_solver(error_msg);
             if (!_algo) throw std::runtime_error("AlgorithmSelector: no solver is active (not initialized?)");
             return _algo.get();
         }
 
     private:
-        void check_right_solver(const std::string& error_msg) const {
+        // `error_msg` is a `const char*`, not a `const std::string&`: every one of the
+        // fifty-odd call sites passes a string literal, and the names are longer than
+        // libstdc++'s small-string buffer ("supports_remote_voltage_control" is 31
+        // chars), so a reference parameter meant one malloc + one free per call -- on
+        // get_V, get_Va, get_Vm, compute_pf and the capability queries, i.e. several
+        // times per powerflow, to build a string only the error path ever reads.
+        void check_right_solver(const char * error_msg) const {
             if (_algo_type != _algo_type_used_for_nr) {
                 std::ostringstream exc_;
                 exc_ << "AlgorithmSelector: Solver mismatch when calling '";

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -310,6 +310,7 @@ add_library(lightsim2grid_core SHARED
     "${CMAKE_CURRENT_SOURCE_DIR}/DataConverter.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/SubstationContainer.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/BinaryArchive.cpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/VoltageControlPlan.cpp"
     ${SOURCES}
 )
 

--- a/src/core/LSGrid.cpp
+++ b/src/core/LSGrid.cpp
@@ -727,6 +727,7 @@ CplxVect LSGrid::ac_pf(const Eigen::Ref<const CplxVect> & Vinit,
         exc_ << "fast-decoupled ones). Please `change_algorithm` or disable the droop.";
         throw std::runtime_error(exc_.str());
     }
+    if(!_algo.supports_remote_voltage_control()) _throw_if_voltage_control_needed();
     bool conv = false;
     CplxVect res = CplxVect();
 
@@ -905,6 +906,53 @@ void LSGrid::fill_voltage_control_solver_data(VoltageControlSolverData & data, b
                            ac_cache_.id_me_to_solver, ac_cache_.id_solver_to_me,
                            ac_cache_.slack_bus_id_solver, ac_cache_.bus_pq);
     data = plan.controllers();
+}
+
+void LSGrid::_throw_if_voltage_control_needed() const
+{
+    // The selected algorithm has no bordered block (fast-decoupled, Gauss-Seidel, a
+    // plugin that does not claim the capability). Silently dropping the controllers
+    // would not be a slower answer, it would be a WRONG one and a plausible-looking
+    // one: taking the regulated bus out of PV leaves nothing pinning its magnitude,
+    // and the solve converges somewhere else entirely (measured at 0.36 pu away on a
+    // case118 with eight control groups). Leaving the bus PV instead is no better --
+    // the setpoint would be applied to the wrong bus.
+    //
+    // Nor is there an honest way to rewrite the grid on the caller's behalf: turning
+    // the regulator off changes the reactive dispatch, and pointing it at its own bus
+    // needs a setpoint nobody has (the one it carries is the target for a DIFFERENT
+    // bus). So: refuse, and name everything affected so the caller can decide.
+    VoltageControlPlan plan;
+    plan.build_groups(generators_, svcs_);
+    const VoltageControlPlan::Unsupported bad = plan.list_unsupported(generators_, svcs_, hvdc_lines_);
+    if(bad.empty()) return;
+
+    std::ostringstream exc_;
+    exc_ << "LSGrid::ac_pf: this grid uses voltage control that only the Newton-Raphson "
+            "algorithms implement (a generator or an hvdc converter station regulating a "
+            "bus other than its own, several machines regulating the same bus, or a "
+            "voltage-mode SVC), and the selected algorithm '" << _algo.get_name()
+         << "' does not. Concerned elements:";
+    if(!bad.gen_ids.empty()){
+        exc_ << " generator(s)";
+        for(int gen_id : bad.gen_ids) exc_ << " " << gen_id;
+        exc_ << " (regulating a remote bus);";
+    }
+    if(!bad.svc_ids.empty()){
+        exc_ << " SVC(s)";
+        for(int svc_id : bad.svc_ids) exc_ << " " << svc_id;
+        exc_ << " (voltage mode);";
+    }
+    if(!bad.station_ids.empty()){
+        exc_ << " hvdc converter station(s)";
+        for(const auto & station : bad.station_ids) exc_ << " " << station.first << "/side" << station.second;
+        exc_ << " (enrolled in a control group);";
+    }
+    exc_ << " Please `change_algorithm` to a Newton-Raphson one, or take those elements "
+            "out of voltage control (`set_gen_regulated_bus` back to their own bus, or "
+            "turn the regulator / the SVC off) -- lightsim2grid will not do it for you, "
+            "because either choice changes the answer.";
+    throw std::runtime_error(exc_.str());
 }
 
 std::set<int> LSGrid::get_group_controlled_buses() const
@@ -1142,7 +1190,8 @@ CplxVect LSGrid::_build_into_cache(
     SolverSideCache<MatScalar> & cache,
     const AlgoControl & solver_control,
     bool force_full_rebuild,
-    bool init_pv_vm_targets)
+    bool init_pv_vm_targets,
+    bool supports_voltage_control)
 {
     bool redo_all =
             force_full_rebuild ||
@@ -1216,27 +1265,25 @@ CplxVect LSGrid::_build_into_cache(
         fill_solver_matrix(cache.mat, cache.id_me_to_solver);
     }
     // ---- the voltage-control plan, built at most once per powerflow -------------
-    // The "fancy" voltage controllers -- remote regulation, several machines on one
-    // regulated bus, SVCs -- are three layers of one derived object (see
-    // VoltageControlPlan), and the pv-pq split below is sandwiched between them:
-    // layer 1 (which buses a GROUP regulates, grid ids) is an INPUT to fillpv_pq,
-    // layers 2 and 3 are expressed in the labelling and the split it produces. So
-    // the plan is built here, around that call, and the NR extensions read it
-    // instead of asking the grid to re-derive it. It used to be re-derived four
-    // times per solve: once by fillpv_pq, once by Base::update_state, and twice by
-    // VoltageControl::update_state (which re-ran the free-Vm slack pass of its own).
+    // How every bus' magnitude is pinned, and by what, is ONE derived object in four
+    // layers (see VoltageControlPlan): which buses a control GROUP regulates, the
+    // pv/pq split that layout perturbs, the free-Vm slack buses, and the controller
+    // list the bordered block is built from. Each layer is built out of the one
+    // before it, so they are built here, together, and the NR extensions read the
+    // result instead of asking the grid to re-derive it. They used to be derived in
+    // four different places, three of them walking every generator of the grid.
     //
-    // All three layers stand or fall together -- see
+    // All the layers stand or fall together -- see
     // AlgoControl::need_recompute_voltage_control() for the (deliberately
     // conservative) question that decides, and note it is asked ONCE here rather
-    // than per layer: rebuilding layer 1 without layers 2 and 3 would leave the
-    // controller list keyed on a group layout it was not built from.
+    // than per layer: rebuilding layer 1 without the rest would leave the controller
+    // list keyed on a group layout it was not built from.
     //
-    // Layer 1 is built for BOTH families. It is where the DC split needs it too --
-    // `fillpv_pq` is the same function for both, and a DC cache whose plan were left
-    // empty would classify a group-regulated bus as PV where the AC one does not --
-    // and it costs a DC build nothing it was not already paying: this is exactly the
-    // walk `fillpv_pq` used to make for itself. Layers 2 and 3 are AC only.
+    // `supports_voltage_control` is the algorithm's own answer (BaseAlgo::
+    // supports_remote_voltage_control): false for fast-decoupled and Gauss-Seidel,
+    // which hold no NRSystem and so read neither layer 3 nor layer 4. For them the
+    // plan stays empty and layer 2 produces the classical split -- and ac_pf has
+    // already refused the grid if it really has controllers.
     const bool rebuild_split =
             redo_all || converter_changed ||
             solver_control.has_slack_participate_changed() ||
@@ -1244,17 +1291,28 @@ CplxVect LSGrid::_build_into_cache(
             solver_control.has_pq_changed();
     const bool rebuild_voltage_control =
             rebuild_split || solver_control.need_recompute_voltage_control();
-    if (rebuild_voltage_control) cache.voltage_control.build_groups(generators_, svcs_);
+    // The DC family keeps the group step of layer 2 unconditionally, which is what it
+    // has always done. It is not obviously RIGHT -- a DC solve has no voltage at all,
+    // so a bus a group regulates arguably has no business being reclassified there --
+    // but `pv` is read by BaseDCAlgo (retrieve_pv_with_slack / extract_slack_bus_id),
+    // so changing it changes DC answers, and that is a question of its own and not
+    // this one's. Gating it on the AC algorithm's capability, which is what
+    // `supports_voltage_control` carries, would have done exactly that by accident.
+    const bool is_ac_family = SolverSideCache<MatScalar>::is_ac;
+    if (rebuild_voltage_control){
+        cache.voltage_control.build_groups(generators_, svcs_,
+                                           !is_ac_family || supports_voltage_control);
+    }
     if (rebuild_split) {
-            init_slack_bus(cache.id_me_to_solver, cache.id_solver_to_me, cache.slack_bus_id_me, cache.slack_bus_id_solver);
-            fillpv_pq(cache.id_me_to_solver, cache.id_solver_to_me, cache.slack_bus_id_solver,
-                      cache.voltage_control.group_controlled_buses(), cache.bus_pv, cache.bus_pq);
-        }
-    if (rebuild_voltage_control && SolverSideCache<MatScalar>::is_ac){
-        // `is_ac` is a compile-time constant, so the DC instantiation of this template
-        // does not even contain this call: a DC cache carries layer 1 and two empty
-        // solver-side layers, which is the correct answer -- a DC solve has no voltage
-        // control, and nothing reads a DC plan's controller list.
+        init_slack_bus(cache.id_me_to_solver, cache.id_solver_to_me, cache.slack_bus_id_me, cache.slack_bus_id_solver);
+        cache.voltage_control.build_pv_pq(_pv_capable_containers(),
+                                          cache.id_me_to_solver, cache.id_solver_to_me,
+                                          cache.slack_bus_id_solver, cache.bus_pv, cache.bus_pq);
+    }
+    // Layers 3 and 4 are AC only, and only for an algorithm that reads them: `is_ac`
+    // is a compile-time constant, so the DC instantiation of this template does not
+    // even contain the call.
+    if (rebuild_voltage_control && supports_voltage_control && is_ac_family){
         cache.voltage_control.build_solver_side(generators_, svcs_, hvdc_lines_,
                                                 cache.id_me_to_solver, cache.id_solver_to_me,
                                                 cache.slack_bus_id_solver, cache.bus_pq);
@@ -1372,7 +1430,13 @@ CplxVect LSGrid::_pre_process_own_cache(
         else _dc_algo.reset();
     }
 
-    CplxVect V = _build_into_cache(Vinit, cache, solver_control, cache_unusable, init_pv_vm_targets);
+    // The algorithm that is about to run on this cache is OURS, so it is ours to ask
+    // whether the voltage-control layers are worth building at all. `_algo` -- the AC
+    // one -- is what is asked in both families: the layers themselves are AC-only, and
+    // the DC family's use of layer 1 is deliberately left alone (see _build_into_cache).
+    const bool supports_voltage_control = _algo.supports_remote_voltage_control();
+    CplxVect V = _build_into_cache(Vinit, cache, solver_control, cache_unusable,
+                                   init_pv_vm_targets, supports_voltage_control);
 
     // `cache.algo_needs_rebuild` is set when this family's previous powerflow
     // diverged and its algorithm was reset (see process_results). Every built-in
@@ -1435,9 +1499,15 @@ CplxVect LSGrid::_build_foreign_cache(
 
     // A foreign build never re-stamps: `solver_control` and the flags it carries
     // all describe THIS grid, and say nothing about what is in `out`.
+    // `supports_voltage_control` is true unconditionally here, and deliberately not
+    // read off `_algo`: the caller solves `out` with an algorithm of its OWN, which
+    // this grid knows nothing about. Building the plan is what preserves the batch
+    // path exactly as it was; a caller whose algorithm cannot consume it simply does
+    // not read it.
     CplxVect V = _build_into_cache(Vinit, out, solver_control,
                                    /*force_full_rebuild=*/true,
-                                   /*init_pv_vm_targets=*/true);
+                                   /*init_pv_vm_targets=*/true,
+                                   /*supports_voltage_control=*/true);
 
     // `_algo` / `_dc_algo` are deliberately untouched: they are THIS grid's, they
     // hold a factorization of THIS grid's cache, and the caller solves `out` with
@@ -1789,82 +1859,19 @@ void LSGrid::fillSbus_me(Eigen::Ref<CplxVect> Sbus, bool ac, const SolverBusIdVe
     trafos_.hack_Sbus_for_dc_phase_shifter(Sbus, ac, id_me_to_solver);
 }
 
-void LSGrid::fillpv_pq(const SolverBusIdVect& id_me_to_solver,
-                          const GlobalBusIdVect& id_solver_to_me,
-                          const SolverBusIdVect & slack_bus_id_solver,
-                          const std::set<int> & group_reg,
-                          SolverBusIdVect & bus_pv_out,
-                          SolverBusIdVect & bus_pq_out)
+// LSGrid::fillpv_pq is gone: the pv/pq split is layer 2 of the voltage-control plan
+// (VoltageControlPlan::build_pv_pq), because its one subtlety -- a bus a control
+// GROUP regulates must stay out of PV -- is keyed on layer 1 and is what layer 4 is
+// then built against. What is left on this side is naming the containers to ask,
+// which is what owning them means: see _pv_capable_containers().
+
+std::vector<const GenericContainer *> LSGrid::_pv_capable_containers() const
 {
-    // Nothing to do if neither pv, nor pq nor the dimension of the problem has changed
-
-    // init pq and pv vector
-    // TODO remove the order here..., i could be faster in this piece of code (looping once through the buses)
-    const int nb_bus = static_cast<int>(id_solver_to_me.size());  // number of bus in the solver!
-    std::vector<int> bus_pq;
-    bus_pq.reserve(nb_bus);
-    std::vector<int> bus_pv;
-    bus_pv.reserve(nb_bus);
-    std::vector<bool> has_bus_been_added(nb_bus, false);
-
-    bus_pv_out = SolverBusIdVect();
-    bus_pq_out = SolverBusIdVect();
-    powerlines_.fillpv(bus_pv, has_bus_been_added, slack_bus_id_solver, id_me_to_solver);  // TODO have a function to dispatch that to all type of elements
-    shunts_.fillpv(bus_pv, has_bus_been_added, slack_bus_id_solver, id_me_to_solver);
-    trafos_.fillpv(bus_pv, has_bus_been_added, slack_bus_id_solver, id_me_to_solver);
-    loads_.fillpv(bus_pv, has_bus_been_added, slack_bus_id_solver, id_me_to_solver);
-    storages_.fillpv(bus_pv, has_bus_been_added, slack_bus_id_solver, id_me_to_solver);
-    sgens_.fillpv(bus_pv, has_bus_been_added, slack_bus_id_solver, id_me_to_solver);
-    generators_.fillpv(bus_pv, has_bus_been_added, slack_bus_id_solver, id_me_to_solver);
-    hvdc_lines_.fillpv(bus_pv, has_bus_been_added, slack_bus_id_solver, id_me_to_solver);
-
-    // A bus regulated by a VoltageControl group must keep its OWN Vm unknown (and
-    // hence its Q equation): the group's bordered voltage row `Vm(reg) - v_set = 0`
-    // is what sets its magnitude. The per-container fillpv above only knows how to
-    // keep a controller's own bus out of PV (GeneratorContainer::fillpv skips a gen
-    // that regulates remotely); nothing there stops a LOCAL regulator sitting on the
-    // regulated bus from claiming it as PV. When that happened the group's voltage
-    // row found no Vm column to write its +1 into -- a structurally empty row, i.e.
-    // a singular Jacobian -- so fill_voltage_control_solver_data had to reject the
-    // whole configuration ("regulates bus X which has no voltage (Vm) unknown"),
-    // even though it is perfectly well posed: the local regulator simply belongs in
-    // the group, and the sharing row then supplies the equation that fixes the
-    // reactive split. Drop those buses from PV here (the PQ loop just below picks
-    // them up) and VoltageControlPlan::build_controllers enrols the local regulators.
-    // `group_reg` is layer 1 of the plan the caller has just built (see
-    // _build_into_cache); it is passed in rather than re-derived here because the
-    // controller list built afterwards MUST be keyed on this very group layout.
-    if(!group_reg.empty()){
-        std::vector<int> bus_pv_kept;
-        bus_pv_kept.reserve(bus_pv.size());
-        for(int bus_id_solver : bus_pv){
-            const int bus_id_me = id_solver_to_me[bus_id_solver].cast_int();
-            if(bus_id_me < 0 || !group_reg.count(bus_id_me)){
-                bus_pv_kept.push_back(bus_id_solver);
-                continue;
-            }
-            // Whatever pinned this bus through the PV path -- a local generator or a
-            // voltage-regulating hvdc converter station -- is enrolled as a member of
-            // the group by fill_voltage_control_solver_data instead.
-            has_bus_been_added[bus_id_solver] = false;  // let the PQ loop take it
-        }
-        bus_pv.swap(bus_pv_kept);
-    }
-
-    for(int bus_id = 0; bus_id< nb_bus; ++bus_id){
-        if(GenericContainer::is_in_vect(bus_id, slack_bus_id_solver.to_int_vector())) continue;  // slack bus is not PQ either
-        if(has_bus_been_added[bus_id]) continue; // a pv bus cannot be PQ
-        bus_pq.push_back(bus_id);
-        has_bus_been_added[bus_id] = true;  // don't add it a second time
-    }
-    bus_pv_out = SolverBusIdVect(bus_pv.size(), SolverBusId(0));
-    for(int i = 0; i < static_cast<int>(bus_pv.size()); ++i){
-        bus_pv_out(i) = SolverBusId(bus_pv[i]);
-    }
-    bus_pq_out = SolverBusIdVect(bus_pq.size(), SolverBusId(0));
-    for(int i = 0; i< static_cast<int>(bus_pq.size()); ++i){
-        bus_pq_out(i) = SolverBusId(bus_pq[i]);
-    }
+    // Everything that can pin a bus' voltage magnitude through the classical PV
+    // path, in the order the split used to ask them in (the order is immaterial --
+    // `fillpv` only ever sets flags -- but keeping it makes the move a no-op).
+    return {&powerlines_, &shunts_, &trafos_, &loads_,
+            &storages_, &sgens_, &generators_, &hvdc_lines_};
 }
 
 void LSGrid::compute_results(bool ac){

--- a/src/core/LSGrid.cpp
+++ b/src/core/LSGrid.cpp
@@ -739,9 +739,9 @@ CplxVect LSGrid::ac_pf(const Eigen::Ref<const CplxVect> & Vinit,
     // could tell a half-built cache from a whole one.
     //
     // So do not try to undo it: make the grid's change tracking say "everything
-    // changed" for the duration of the solve, and run the solve off a COPY (24
-    // bools -- three register-sized stores; nothing measurable next to the millions
-    // of instructions that follow). The copy is what pre_process reads, what the
+    // changed" for the duration of the solve, and run the solve off a COPY (a
+    // couple of dozen bools -- a handful of register-sized stores; nothing
+    // measurable next to the millions of instructions that follow). The copy is what pre_process reads, what the
     // algorithm is told, and what process_results marks as in sync. It becomes the
     // grid's change tracking again only at the publication statement below, which
     // is reachable only if nothing threw.
@@ -882,320 +882,48 @@ void fill_hvdc_droop_data_from_grid(const LSGrid * lsgrid_ptr, HvdcDroopSolverDa
     if(lsgrid_ptr != nullptr) lsgrid_ptr->fill_hvdc_droop_solver_data(data, ac);
 }
 
+// ---------------------------------------------------------------------------
+// The three voltage-control queries below are the SAME object seen from three
+// altitudes (VoltageControlPlan: the group layout, the free-Vm slack set built
+// on it, and the controller list built on both). A powerflow does not come
+// through here at all: _build_into_cache builds ONE plan into the cache, and the
+// NR extensions read that one (see get_ac_voltage_control_plan).
+//
+// What is left here is the on-demand form: a fresh plan, built and thrown away,
+// for callers outside a solve -- the python-facing ground truth, and the tests
+// that ask the question of a grid that has not solved yet. Correct at any time,
+// and priced accordingly: it walks every generator and every SVC of the grid.
+// ---------------------------------------------------------------------------
+
 void LSGrid::fill_voltage_control_solver_data(VoltageControlSolverData & data, bool ac) const
 {
     data.clear();
     if(!ac) return;  // DC: no voltage control (no-op, SVC contributes nothing)
-    const SolverBusIdVect & id_me_to_solver = ac_cache_.id_me_to_solver;
-    const int nb_bus_solver = static_cast<int>(ac_cache_.id_solver_to_me.size());
-    if(nb_bus_solver == 0) return;
-
-    // PQ membership: a bus owns a Q equation AND a Vm unknown iff it is a PQ bus
-    // (PV buses have only theta/P, the slack none). ac_cache_.bus_pq is set by fillpv_pq.
-    std::vector<bool> is_pq(nb_bus_solver, false);
-    for(int k = 0; k < static_cast<int>(ac_cache_.bus_pq.size()); ++k){
-        const int b = ac_cache_.bus_pq(k).cast_int();
-        if(b >= 0 && b < nb_bus_solver) is_pq[b] = true;
-    }
-    // Slack buses are not PQ in the base block, but a slack bus that is not pinned
-    // by a local PV generator is given a Q equation + free Vm by the MultiSlack
-    // extension (see LSGrid::get_free_vm_slack_solver_buses), so a controller on
-    // such a slack bus is supported even though `is_pq` is false there. A slack
-    // bus that IS locally pinned (another generator regulates it directly) gets
-    // no such Q equation at all -- checking membership of the whole `slack_bus_
-    // id_ac_solver_` list here (as opposed to just this "free" subset) would
-    // wrongly accept that case: its Q equation lookup then resolves to -1, the
-    // controller's own reactive-injection column ends up with no Jacobian entry
-    // anywhere, and the factorization fails with ErrorType::SolverFactor instead
-    // of this function's own clear error.
-    const std::set<int> free_vm_slack = get_free_vm_slack_solver_buses();
-    std::vector<bool> has_free_q(nb_bus_solver, false);
-    for(int b : free_vm_slack){
-        if(b >= 0 && b < nb_bus_solver) has_free_q[b] = true;
-    }
-
-    // 1. collect the active voltage-mode controllers (generators and voltage-mode
-    //    SVCs). Per controller: solver bus, regulated solver bus, v_set (pu),
-    //    sharing key, kind, elem id.
-    struct Raw { int bus; int reg_bus; real_type v_set; real_type slope; real_type weight; int kind; int elem_id; };
-    std::vector<Raw> raws;
-    // Buses whose magnitude a group sets rather than the PV path. Every ACTIVE
-    // voltage regulator aiming at one of them is a member of its group -- including
-    // a LOCAL one, which fillpv_pq consequently did not let pin its own bus.
-    const std::set<int> group_reg = get_group_controlled_buses();
-    const int nb_gen = static_cast<int>(generators_.nb());
-    const GlobalBusIdVect & gen_buses = generators_.get_buses();
-    for(int gen_id = 0; gen_id < nb_gen; ++gen_id){
-        // remote regulators are always controllers; a local one only when the bus it
-        // regulates is group-controlled (something else remote/an SVC aims at it too)
-        if(!generators_.gen_is_voltage_controller(gen_id)){
-            if(!generators_.gen_is_local_voltage_controller(gen_id)) continue;
-            if(!group_reg.count(generators_.get_regulated_bus_id(gen_id))) continue;
-        }
-        const int ctrl_grid = gen_buses(gen_id).cast_int();
-        const int reg_grid  = generators_.get_regulated_bus_id(gen_id);
-        const int ctrl_solver = id_me_to_solver[ctrl_grid].cast_int();
-        const int reg_solver  = (reg_grid >= 0) ? id_me_to_solver[reg_grid].cast_int()
-                                                : GenericContainer::_deactivated_bus_id;
-        if(ctrl_solver == GenericContainer::_deactivated_bus_id){
-            std::ostringstream exc_;
-            exc_ << "LSGrid::fill_voltage_control_solver_data: generator " << gen_id
-                 << " is a voltage controller but its bus is disconnected.";
-            throw std::runtime_error(exc_.str());
-        }
-        if(reg_solver == GenericContainer::_deactivated_bus_id){
-            std::ostringstream exc_;
-            exc_ << "LSGrid::fill_voltage_control_solver_data: generator " << gen_id
-                 << " regulates a disconnected bus.";
-            throw std::runtime_error(exc_.str());
-        }
-        if(!is_pq[ctrl_solver] && !has_free_q[ctrl_solver]){
-            std::ostringstream exc_;
-            exc_ << "LSGrid::fill_voltage_control_solver_data: generator " << gen_id
-                 << " regulates a remote bus but its OWN bus has no reactive (Q) equation"
-                    " (it is a PV bus that is not a slack, or a slack bus already locally"
-                    " pinned by another voltage-regulating generator). This is not supported"
-                    " in v1.";
-            throw std::runtime_error(exc_.str());
-        }
-        // The regulated bus needs a Vm unknown for the bordered row to act on. An
-        // ordinary PQ bus has one; so does a slack bus that nothing pins locally,
-        // courtesy of the MultiSlack extension (same escape hatch as the controller
-        // bus just above -- `has_free_q`). A bus that is PV despite being
-        // group-controlled cannot occur any more (fillpv_pq reclassifies it), so
-        // what is left here is a bus pinned by something that cannot be enrolled.
-        if(!is_pq[reg_solver] && !has_free_q[reg_solver]){
-            std::ostringstream exc_;
-            exc_ << "LSGrid::fill_voltage_control_solver_data: generator " << gen_id
-                 << " regulates bus " << reg_grid << " which has no voltage (Vm) unknown"
-                    " (its magnitude is pinned by something that cannot join a control"
-                    " group). This is not supported in v1.";
-            throw std::runtime_error(exc_.str());
-        }
-        const real_type w = generators_.get_max_q(gen_id) - generators_.get_min_q(gen_id);
-        raws.push_back({ctrl_solver, reg_solver, generators_.get_target_vm_pu(gen_id),
-                        static_cast<real_type>(0.), w, VoltageControlSolverData::GEN, gen_id});
-    }
-
-    // ... and the active VOLTAGE-mode SVCs (local or remote, with or without slope)
-    const int nb_svc = static_cast<int>(svcs_.nb());
-    const GlobalBusIdVect & svc_buses = svcs_.get_buses();
-    for(int svc_id = 0; svc_id < nb_svc; ++svc_id){
-        if(!svcs_.svc_is_voltage_controller(svc_id)) continue;
-        const int ctrl_grid = svc_buses(svc_id).cast_int();
-        const int reg_grid  = svcs_.get_regulated_bus_id(svc_id);
-        const int ctrl_solver = id_me_to_solver[ctrl_grid].cast_int();
-        const int reg_solver  = (reg_grid >= 0) ? id_me_to_solver[reg_grid].cast_int()
-                                                : GenericContainer::_deactivated_bus_id;
-        if(ctrl_solver == GenericContainer::_deactivated_bus_id){
-            std::ostringstream exc_;
-            exc_ << "LSGrid::fill_voltage_control_solver_data: SVC " << svc_id
-                 << " is a voltage controller but its bus is disconnected.";
-            throw std::runtime_error(exc_.str());
-        }
-        if(reg_solver == GenericContainer::_deactivated_bus_id){
-            std::ostringstream exc_;
-            exc_ << "LSGrid::fill_voltage_control_solver_data: SVC " << svc_id
-                 << " regulates a disconnected bus.";
-            throw std::runtime_error(exc_.str());
-        }
-        // same two escape hatches as the generator branch above: a slack bus that
-        // nothing pins locally owns a Q equation and a free Vm (MultiSlack)
-        if(!is_pq[ctrl_solver] && !has_free_q[ctrl_solver]){
-            std::ostringstream exc_;
-            exc_ << "LSGrid::fill_voltage_control_solver_data: SVC " << svc_id
-                 << " is at a bus with no reactive (Q) equation (it is a PV bus, or a slack"
-                    " bus pinned by a local voltage-regulating generator)."
-                    " This is not supported in v1.";
-            throw std::runtime_error(exc_.str());
-        }
-        if(!is_pq[reg_solver] && !has_free_q[reg_solver]){
-            std::ostringstream exc_;
-            exc_ << "LSGrid::fill_voltage_control_solver_data: SVC " << svc_id
-                 << " regulates bus " << reg_grid << " which has no voltage (Vm) unknown"
-                    " (its magnitude is pinned by something that cannot join a control"
-                    " group). This is not supported in v1.";
-            throw std::runtime_error(exc_.str());
-        }
-        const real_type w = svcs_.get_b_max(svc_id) - svcs_.get_b_min(svc_id);
-        raws.push_back({ctrl_solver, reg_solver, svcs_.get_target_vm_pu(svc_id),
-                        svcs_.get_slope_pu(svc_id), w, VoltageControlSolverData::SVC, svc_id});
-    }
-
-    // ... and the voltage-regulating hvdc converter stations. A VSC station with
-    // voltage_regulator_on pins its own bus through the PV path, exactly like a local
-    // generator, so it is a controller only when a GROUP regulates that bus instead
-    // (fillpv_pq then kept the bus out of PV and it needs its members). Its sharing
-    // key is a reactive range in MVAr -- the same currency as a generator's -- so a
-    // mixed generator/station group shares reactive power correctly, unlike an SVC
-    // (whose key is a susceptance range; hence the SVC-alone restriction below).
-    const int nb_hvdc = static_cast<int>(hvdc_lines_.nb());
-    for(int hvdc_id = 0; hvdc_id < nb_hvdc; ++hvdc_id){
-        for(int side = 1; side <= 2; ++side){
-            if(!hvdc_lines_.station_is_voltage_controller(hvdc_id, side)) continue;
-            const int ctrl_grid = hvdc_lines_.get_station_bus(hvdc_id, side).cast_int();
-            // not group-controlled: the station keeps pinning its bus the classical way
-            if(!group_reg.count(ctrl_grid)) continue;
-            if(ctrl_grid == GenericContainer::_deactivated_bus_id) continue;
-            const int ctrl_solver = id_me_to_solver[ctrl_grid].cast_int();
-            if(ctrl_solver == GenericContainer::_deactivated_bus_id){
-                std::ostringstream exc_;
-                exc_ << "LSGrid::fill_voltage_control_solver_data: hvdc line " << hvdc_id
-                     << " side " << side << " regulates voltage but its bus is disconnected.";
-                throw std::runtime_error(exc_.str());
-            }
-            if(!is_pq[ctrl_solver] && !has_free_q[ctrl_solver]){
-                std::ostringstream exc_;
-                exc_ << "LSGrid::fill_voltage_control_solver_data: hvdc line " << hvdc_id
-                     << " side " << side << " takes part in a voltage-control group but its"
-                        " bus has no reactive (Q) equation. This is not supported in v1.";
-                throw std::runtime_error(exc_.str());
-            }
-            const int kind = (side == 1) ? VoltageControlSolverData::HVDC_SIDE_1
-                                         : VoltageControlSolverData::HVDC_SIDE_2;
-            raws.push_back({ctrl_solver, ctrl_solver,   // a station regulates its OWN bus
-                            hvdc_lines_.get_station_target_vm_pu(hvdc_id, side),
-                            static_cast<real_type>(0.),
-                            hvdc_lines_.get_station_q_range_mvar(hvdc_id, side),
-                            kind, hvdc_id});
-        }
-    }
-    if(raws.empty()) return;
-
-    // 2. group by regulated solver bus (merge gens that share a regulated bus),
-    //    checking the v_set agree within tolerance.
-    std::vector<int> grp_reg;
-    std::vector<real_type> grp_vset;
-    std::vector<std::vector<int> > grp_members;  // indices into raws
-    for(int i = 0; i < static_cast<int>(raws.size()); ++i){
-        int g = -1;
-        for(int gg = 0; gg < static_cast<int>(grp_reg.size()); ++gg)
-            if(grp_reg[gg] == raws[i].reg_bus){ g = gg; break; }
-        if(g == -1){
-            g = static_cast<int>(grp_reg.size());
-            grp_reg.push_back(raws[i].reg_bus);
-            grp_vset.push_back(raws[i].v_set);
-            grp_members.push_back(std::vector<int>());
-        } else if(std::abs(grp_vset[g] - raws[i].v_set) > BaseConstants::_tol_equal_float){
-            std::ostringstream exc_;
-            exc_ << "LSGrid::fill_voltage_control_solver_data: several controllers regulate the"
-                    " same bus with conflicting voltage setpoints (" << grp_vset[g] << " vs "
-                 << raws[i].v_set << " pu).";
-            throw std::runtime_error(exc_.str());
-        }
-        grp_members[g].push_back(i);
-    }
-
-    // 2b. v1 restriction: an SVC may only be ALONE in its control group. The
-    //     cross-weight sharing of an SVC with other controllers (and any sloped
-    //     SVC sharing a regulated bus, cf Phase 0 probe #3) is not supported yet.
-    for(int g = 0; g < static_cast<int>(grp_members.size()); ++g){
-        if(grp_members[g].size() <= 1) continue;
-        for(int idx : grp_members[g]){
-            if(raws[idx].kind == VoltageControlSolverData::SVC){
-                std::ostringstream exc_;
-                exc_ << "LSGrid::fill_voltage_control_solver_data: SVC " << raws[idx].elem_id
-                     << " shares a regulated bus with other controllers, which is not"
-                        " supported in v1 (an SVC must be the only controller of its bus).";
-                throw std::runtime_error(exc_.str());
-            }
-        }
-    }
-
-    // 3. emit, controllers grouped contiguously
-    const int ng = static_cast<int>(grp_reg.size());
-    const int nc = static_cast<int>(raws.size());
-    data.bus = Eigen::VectorXi(nc);
-    data.kind = Eigen::VectorXi(nc);
-    data.elem_id = Eigen::VectorXi(nc);
-    data.slope = RealVect(nc);
-    data.weight = RealVect(nc);
-    data.group = Eigen::VectorXi(nc);
-    data.reg_bus = Eigen::VectorXi(ng);
-    data.v_set = RealVect(ng);
-    data.grp_start = Eigen::VectorXi(ng);
-    data.grp_count = Eigen::VectorXi(ng);
-    int cursor = 0;
-    for(int g = 0; g < ng; ++g){
-        data.reg_bus(g) = grp_reg[g];
-        data.v_set(g) = grp_vset[g];
-        data.grp_start(g) = cursor;
-        data.grp_count(g) = static_cast<int>(grp_members[g].size());
-        for(int idx : grp_members[g]){
-            const Raw & r = raws[idx];
-            data.bus(cursor) = r.bus;
-            data.kind(cursor) = r.kind;
-            data.elem_id(cursor) = r.elem_id;
-            data.slope(cursor) = r.slope;
-            // floor the sharing key to keep the N>1 sharing rows non-singular
-            data.weight(cursor) = (std::abs(r.weight) > BaseConstants::_tol_equal_float) ? r.weight : BaseConstants::_tol_equal_float;
-            data.group(cursor) = g;
-            ++cursor;
-        }
-    }
+    VoltageControlPlan plan;
+    plan.build_groups(generators_, svcs_);
+    plan.build_solver_side(generators_, svcs_, hvdc_lines_,
+                           ac_cache_.id_me_to_solver, ac_cache_.id_solver_to_me,
+                           ac_cache_.slack_bus_id_solver, ac_cache_.bus_pq);
+    data = plan.controllers();
 }
 
 std::set<int> LSGrid::get_group_controlled_buses() const
 {
-    std::set<int> res;
-    // an ACTIVE remote-regulating generator: gen_is_voltage_controller() already
-    // means "connected, regulator on, not pseudo-off, and regulating a bus that is
-    // NOT its own". A purely local regulator therefore never lands here, which is
-    // what keeps the ordinary (possibly multi-generator) PV bus untouched.
-    const int nb_gen = static_cast<int>(generators_.nb());
-    for(int gen_id = 0; gen_id < nb_gen; ++gen_id){
-        if(!generators_.gen_is_voltage_controller(gen_id)) continue;
-        const int reg = generators_.get_regulated_bus_id(gen_id);
-        if(reg >= 0) res.insert(reg);
-    }
-    // a voltage-mode SVC is ALWAYS a group controller (even local and non-sloped),
-    // so the bus it regulates always needs the bordered treatment
-    const int nb_svc = static_cast<int>(svcs_.nb());
-    for(int svc_id = 0; svc_id < nb_svc; ++svc_id){
-        if(!svcs_.svc_is_voltage_controller(svc_id)) continue;
-        const int reg = svcs_.get_regulated_bus_id(svc_id);
-        if(reg >= 0) res.insert(reg);
-    }
-    return res;
+    VoltageControlPlan plan;
+    plan.build_groups(generators_, svcs_);
+    return plan.group_controlled_buses();
 }
 
 std::set<int> LSGrid::get_free_vm_slack_solver_buses() const
 {
-    std::set<int> res;
-    // solver-bus ids of the slack buses
-    std::set<int> slack;
-    for(int k = 0; k < static_cast<int>(ac_cache_.slack_bus_id_solver.size()); ++k){
-        slack.insert(ac_cache_.slack_bus_id_solver(k).cast_int());
-    }
-    if(slack.empty()) return res;
-
-    // A slack bus is Vm-fixed (PV-like, no Q equation) only when a LOCAL
-    // voltage-regulating generator pins its magnitude. Collect those buses.
-    std::set<int> locally_vfixed;
-    const SolverBusIdVect & id_me_to_solver = ac_cache_.id_me_to_solver;
-    // ... except that a local regulator on a bus a control GROUP regulates does not
-    // pin it: it is enrolled as a member of that group instead (see
-    // get_group_controlled_buses and the reclassification in fillpv_pq), and the
-    // group's voltage row needs the free Vm this function grants.
-    const std::set<int> group_reg = get_group_controlled_buses();
-    const int nb_gen = static_cast<int>(generators_.nb());
-    const GlobalBusIdVect & gen_buses = generators_.get_buses();
-    for(int gen_id = 0; gen_id < nb_gen; ++gen_id){
-        if(!generators_.gen_is_local_voltage_controller(gen_id)) continue;
-        const int ctrl_grid = gen_buses(gen_id).cast_int();
-        if(group_reg.count(ctrl_grid)) continue;
-        const int ctrl_solver = id_me_to_solver[ctrl_grid].cast_int();
-        if(ctrl_solver == GenericContainer::_deactivated_bus_id) continue;
-        locally_vfixed.insert(ctrl_solver);
-    }
-
-    // Every slack bus whose magnitude is NOT pinned locally needs a free Vm
-    // unknown + Q equation: distributed-slack PQ participants (the common case),
-    // remote-voltage controllers, and SVC-regulated slack buses all fall here.
-    for(int b : slack){
-        if(!locally_vfixed.count(b)) res.insert(b);
-    }
-    return res;
+    // layer 2 only: this answer does not need the controller list, and building it
+    // here would make a query that cannot fail start throwing on a configuration
+    // the bordered formulation cannot express.
+    VoltageControlPlan plan;
+    plan.build_groups(generators_, svcs_);
+    plan.build_free_vm_slack(generators_, ac_cache_.id_me_to_solver,
+                             ac_cache_.id_solver_to_me, ac_cache_.slack_bus_id_solver);
+    return plan.free_vm_slack_buses();
 }
 
 void LSGrid::check_solution_q_values_onegen(Eigen::Ref<CplxVect> res,
@@ -1487,13 +1215,50 @@ CplxVect LSGrid::_build_into_cache(
     if (redo_all || converter_changed || solver_control.need_recompute_ybus()){
         fill_solver_matrix(cache.mat, cache.id_me_to_solver);
     }
-    if (redo_all || converter_changed ||
-        solver_control.has_slack_participate_changed() ||
-        solver_control.has_pv_changed() ||
-        solver_control.has_pq_changed()) {
+    // ---- the voltage-control plan, built at most once per powerflow -------------
+    // The "fancy" voltage controllers -- remote regulation, several machines on one
+    // regulated bus, SVCs -- are three layers of one derived object (see
+    // VoltageControlPlan), and the pv-pq split below is sandwiched between them:
+    // layer 1 (which buses a GROUP regulates, grid ids) is an INPUT to fillpv_pq,
+    // layers 2 and 3 are expressed in the labelling and the split it produces. So
+    // the plan is built here, around that call, and the NR extensions read it
+    // instead of asking the grid to re-derive it. It used to be re-derived four
+    // times per solve: once by fillpv_pq, once by Base::update_state, and twice by
+    // VoltageControl::update_state (which re-ran the free-Vm slack pass of its own).
+    //
+    // All three layers stand or fall together -- see
+    // AlgoControl::need_recompute_voltage_control() for the (deliberately
+    // conservative) question that decides, and note it is asked ONCE here rather
+    // than per layer: rebuilding layer 1 without layers 2 and 3 would leave the
+    // controller list keyed on a group layout it was not built from.
+    //
+    // Layer 1 is built for BOTH families. It is where the DC split needs it too --
+    // `fillpv_pq` is the same function for both, and a DC cache whose plan were left
+    // empty would classify a group-regulated bus as PV where the AC one does not --
+    // and it costs a DC build nothing it was not already paying: this is exactly the
+    // walk `fillpv_pq` used to make for itself. Layers 2 and 3 are AC only.
+    const bool rebuild_split =
+            redo_all || converter_changed ||
+            solver_control.has_slack_participate_changed() ||
+            solver_control.has_pv_changed() ||
+            solver_control.has_pq_changed();
+    const bool rebuild_voltage_control =
+            rebuild_split || solver_control.need_recompute_voltage_control();
+    if (rebuild_voltage_control) cache.voltage_control.build_groups(generators_, svcs_);
+    if (rebuild_split) {
             init_slack_bus(cache.id_me_to_solver, cache.id_solver_to_me, cache.slack_bus_id_me, cache.slack_bus_id_solver);
-            fillpv_pq(cache.id_me_to_solver, cache.id_solver_to_me, cache.slack_bus_id_solver, cache.bus_pv, cache.bus_pq);
+            fillpv_pq(cache.id_me_to_solver, cache.id_solver_to_me, cache.slack_bus_id_solver,
+                      cache.voltage_control.group_controlled_buses(), cache.bus_pv, cache.bus_pq);
         }
+    if (rebuild_voltage_control && SolverSideCache<MatScalar>::is_ac){
+        // `is_ac` is a compile-time constant, so the DC instantiation of this template
+        // does not even contain this call: a DC cache carries layer 1 and two empty
+        // solver-side layers, which is the correct answer -- a DC solve has no voltage
+        // control, and nothing reads a DC plan's controller list.
+        cache.voltage_control.build_solver_side(generators_, svcs_, hvdc_lines_,
+                                                cache.id_me_to_solver, cache.id_solver_to_me,
+                                                cache.slack_bus_id_solver, cache.bus_pq);
+    }
 
     // type-specific injection assembly (complex Sbus for AC, real Pbus for DC)
     prepare_injection(cache.inj, redo_all, converter_changed, cache.id_me_to_solver, cache.id_solver_to_me, solver_control);
@@ -1683,16 +1448,15 @@ CplxVect LSGrid::_build_foreign_cache(
     // ---- publish the layout, then retire it -------------------------------------
     // The NR extensions do not read the cache the solver was handed. They call back
     // into the grid through `lsgrid_ptr`:
-    //   Base           -> get_free_vm_slack_solver_buses()  (id_me_to_solver,
-    //                       slack_bus_id_solver)
-    //   Hvdc           -> fill_hvdc_droop_solver_data()      (id_me_to_solver)
-    //   VoltageControl -> fill_voltage_control_solver_data() (id_me_to_solver,
-    //                       id_solver_to_me, bus_pq, and the two above)
+    //   Base           -> get_ac_voltage_control_plan().free_vm_slack_buses()
+    //   Hvdc           -> fill_hvdc_droop_solver_data()   (id_me_to_solver)
+    //   VoltageControl -> get_ac_voltage_control_plan().controllers()
     // Left stale, that does not read as an error, it reads as "nothing to do": the
     // controller list comes back empty and the solve SILENTLY drops remote voltage
-    // control / the free Vm unknown of a distributed-slack participant. Note
-    // `bus_pq`: the pv-pq split is part of what the extensions read, which is why
-    // publishing only the labelling is not enough.
+    // control / the free Vm unknown of a distributed-slack participant. The plan is
+    // therefore published alongside the labelling below -- and note that publishing
+    // it is now a copy of what the build already produced, not a re-derivation from
+    // the published labelling: the two can no longer disagree.
     //
     // Copying the whole cache would also copy the matrix -- the expensive half, and
     // the one thing the caller keeps for itself -- so publish the rest and then say
@@ -1725,6 +1489,7 @@ CplxVect LSGrid::_build_foreign_cache(
     mine.slack_weights = out.slack_weights;
     mine.bus_pv = out.bus_pv;
     mine.bus_pq = out.bus_pq;
+    mine.voltage_control = out.voltage_control;
     return V;
 }
 
@@ -2027,6 +1792,7 @@ void LSGrid::fillSbus_me(Eigen::Ref<CplxVect> Sbus, bool ac, const SolverBusIdVe
 void LSGrid::fillpv_pq(const SolverBusIdVect& id_me_to_solver,
                           const GlobalBusIdVect& id_solver_to_me,
                           const SolverBusIdVect & slack_bus_id_solver,
+                          const std::set<int> & group_reg,
                           SolverBusIdVect & bus_pv_out,
                           SolverBusIdVect & bus_pq_out)
 {
@@ -2064,8 +1830,10 @@ void LSGrid::fillpv_pq(const SolverBusIdVect& id_me_to_solver,
     // even though it is perfectly well posed: the local regulator simply belongs in
     // the group, and the sharing row then supplies the equation that fixes the
     // reactive split. Drop those buses from PV here (the PQ loop just below picks
-    // them up) and fill_voltage_control_solver_data enrols the local regulators.
-    const std::set<int> group_reg = get_group_controlled_buses();
+    // them up) and VoltageControlPlan::build_controllers enrols the local regulators.
+    // `group_reg` is layer 1 of the plan the caller has just built (see
+    // _build_into_cache); it is passed in rather than re-derived here because the
+    // controller list built afterwards MUST be keyed on this very group layout.
     if(!group_reg.empty()){
         std::vector<int> bus_pv_kept;
         bus_pv_kept.reserve(bus_pv.size());

--- a/src/core/LSGrid.cpp
+++ b/src/core/LSGrid.cpp
@@ -1273,24 +1273,24 @@ CplxVect LSGrid::_build_into_cache(
     // result instead of asking the grid to re-derive it. They used to be derived in
     // four different places, three of them walking every generator of the grid.
     //
-    // All the layers stand or fall together -- see
-    // AlgoControl::need_recompute_voltage_control() for the (deliberately
-    // conservative) question that decides, and note it is asked ONCE here rather
-    // than per layer: rebuilding layer 1 without the rest would leave the controller
-    // list keyed on a group layout it was not built from.
+    // All the layers stand or fall together, and the question that decides is asked
+    // ONCE: rebuilding layer 1 without the rest would leave the controller list keyed
+    // on a group layout it was not built from. It is also barely a second question --
+    // `need_recompute_voltage_control()` is `need_recompute_pv_pq()` plus one term,
+    // because the split IS layer 2 and whoever is in a group is exactly what the split
+    // reads. The one thing the split does not read is a setpoint, and that is the term.
     //
     // `supports_voltage_control` is the algorithm's own answer (BaseAlgo::
     // supports_remote_voltage_control): false for fast-decoupled and Gauss-Seidel,
     // which hold no NRSystem and so read neither layer 3 nor layer 4. For them the
     // plan stays empty and layer 2 produces the classical split -- and ac_pf has
     // already refused the grid if it really has controllers.
-    const bool rebuild_split =
-            redo_all || converter_changed ||
-            solver_control.has_slack_participate_changed() ||
-            solver_control.has_pv_changed() ||
-            solver_control.has_pq_changed();
+    // One predicate per layer, both of them AlgoControl's, so that what the powerflow
+    // asks and what a test asks cannot drift apart -- and so that the second is
+    // visibly the first plus one term, which is the whole shape of the thing.
+    const bool rebuild_split = force_full_rebuild || solver_control.need_recompute_pv_pq();
     const bool rebuild_voltage_control =
-            rebuild_split || solver_control.need_recompute_voltage_control();
+            force_full_rebuild || solver_control.need_recompute_voltage_control();
     // The DC family keeps the group step of layer 2 unconditionally, which is what it
     // has always done. It is not obviously RIGHT -- a DC solve has no voltage at all,
     // so a bus a group regulates arguably has no business being reclassified there --

--- a/src/core/LSGrid.hpp
+++ b/src/core/LSGrid.hpp
@@ -803,6 +803,22 @@ class LS2G_API LSGrid final
         void tell_recompute_sbus(){algo_controler_.ac_algo_controler().tell_recompute_sbus(); algo_controler_.dc_algo_controler().tell_recompute_sbus();}
         void tell_ybus_change_sparsity_pattern(){algo_controler_.ac_algo_controler().tell_ybus_change_sparsity_pattern(); algo_controler_.dc_algo_controler().tell_ybus_change_sparsity_pattern();}
         [[nodiscard]] const AlgoControl & get_ac_algo_controler() const {return algo_controler_.ac_algo_controler();}
+        /**
+         * The AC family's voltage-control plan: the group layout, the free-Vm slack
+         * buses and the controller list, all in the AC cache's own bus labelling.
+         *
+         * This is what the NR extensions read (Base for the free-Vm slack unknowns,
+         * VoltageControl for the bordered block), through the `lsgrid_ptr` they hold.
+         * It is built by `_build_into_cache`, so it describes the grid only from the
+         * end of `pre_process_solver` to the next grid modification -- exactly the
+         * window a solve runs in. Outside that window, ask
+         * `get_group_controlled_buses()` / `get_free_vm_slack_solver_buses()` /
+         * `fill_voltage_control_solver_data()`, which build a fresh plan and are
+         * correct at any time.
+         */
+        [[nodiscard]] const VoltageControlPlan & get_ac_voltage_control_plan() const {
+            return ac_cache_.voltage_control;
+        }
         [[nodiscard]] const AlgoControl & get_dc_algo_controler() const {return algo_controler_.dc_algo_controler();}
 
         // dc powerflow
@@ -1242,11 +1258,18 @@ class LS2G_API LSGrid final
         }
         /**
          * Per-solve data of the ACTIVE voltage-mode controllers (remote-regulating
-         * generators and, later, voltage-mode SVCs), grouped by regulated solver
-         * bus, in solver bus labelling and per-unit. Consumed by the VoltageControl
-         * extension of the Newton-Raphson system (ac = true only; empty in DC).
-         * Throws a clear error on the singular-for-us configurations (see Phase 0
-         * probe #3). Only valid once `pre_process_solver` ran.
+         * generators, voltage-mode SVCs, and enrolled hvdc converter stations),
+         * grouped by regulated solver bus, in solver bus labelling and per-unit
+         * (ac = true only; empty in DC). Throws a clear error on the
+         * singular-for-us configurations (see Phase 0 probe #3). Only valid once
+         * `pre_process_solver` ran.
+         *
+         * This is the ON-DEMAND form: it builds a whole VoltageControlPlan and
+         * throws it away, walking every generator, SVC and converter station of the
+         * grid to do so. It is here for callers outside a solve -- the python-facing
+         * ground truth and the tests. A powerflow does not use it: the VoltageControl
+         * NR extension reads the plan the cache already holds, see
+         * `get_ac_voltage_control_plan()`.
          */
         void fill_voltage_control_solver_data(VoltageControlSolverData & data, bool ac) const;
         /**
@@ -1259,6 +1282,9 @@ class LS2G_API LSGrid final
          * local PV generator stays Vm-fixed (PV-like) with no Q equation. AC
          * labelling. Only valid once `pre_process_solver` ran (it needs
          * `ac_cache_.id_me_to_solver` / `ac_cache_.slack_bus_id_solver`).
+         *
+         * On-demand, like `fill_voltage_control_solver_data` above and priced the
+         * same way; the Base block of the NR system reads the cached plan instead.
          */
         std::set<int> get_free_vm_slack_solver_buses() const;
         /**
@@ -1281,6 +1307,10 @@ class LS2G_API LSGrid final
          * Works in grid ids and reads only input data, so unlike the solver-side
          * accessors it is valid before / independently of `pre_process_solver`
          * (`fillpv_pq` needs it while it is still building that very labelling).
+         *
+         * On-demand, like the two above: it rebuilds layer 1 of a VoltageControlPlan
+         * from scratch. Inside a powerflow, `_build_into_cache` builds that layer
+         * once and hands it to `fillpv_pq` directly.
          */
         std::set<int> get_group_controlled_buses() const;
         /**
@@ -2322,9 +2352,15 @@ class LS2G_API LSGrid final
         // writes the pv / pq split into the caller-supplied vectors: the AC and the
         // DC family each own theirs (ac_cache_.bus_pv / dc_cache_.bus_pv, ...), and they are
         // expressed in that family's own solver labelling.
+        // `group_reg` is layer 1 of the caller's voltage-control plan (GRID bus ids,
+        // VoltageControlPlan::group_controlled_buses): the buses a control group
+        // regulates must stay out of PV, and the controller list the caller builds
+        // right afterwards has to be keyed on this very layout -- which is why it is
+        // handed in rather than re-derived here.
         void fillpv_pq(const SolverBusIdVect& id_me_to_solver,
                        const GlobalBusIdVect& id_solver_to_me,
                        const SolverBusIdVect & slack_bus_id_solver,
+                       const std::set<int> & group_reg,
                        SolverBusIdVect & bus_pv_out,
                        SolverBusIdVect & bus_pq_out);
 

--- a/src/core/LSGrid.hpp
+++ b/src/core/LSGrid.hpp
@@ -290,6 +290,15 @@ class LS2G_API LSGrid final
             std::unique_ptr<BaseAlgo> tmp = AlgorithmRegistry::instance().make(name);
             if (tmp->IS_AC) {
                 _algo.change_algorithm(name);
+                // Same courtesy as the enum overload above, and it used to be missing
+                // here: a fast-decoupled solve reads Bp / Bpp, which only
+                // init_fdpf_coeffs() fills, so selecting an FDPF solver BY NAME threw
+                // "the FDPF coefficients are not cached" on the first powerflow while
+                // selecting the very same solver by enum worked. Asked of the solver
+                // itself (BaseAlgo::is_fdpf), so a plugin implementing the method is
+                // served too -- the type-keyed test cannot see either case, both being
+                // AlgorithmType::Custom.
+                if (_algo.is_fdpf()) init_fdpf_coeffs();
                 algo_controler_.ac_algo_controler().tell_all_changed();
             }
             else {
@@ -1306,11 +1315,11 @@ class LS2G_API LSGrid final
          *
          * Works in grid ids and reads only input data, so unlike the solver-side
          * accessors it is valid before / independently of `pre_process_solver`
-         * (`fillpv_pq` needs it while it is still building that very labelling).
+         * (layer 2 of the plan needs it while building the very split it feeds).
          *
          * On-demand, like the two above: it rebuilds layer 1 of a VoltageControlPlan
          * from scratch. Inside a powerflow, `_build_into_cache` builds that layer
-         * once and hands it to `fillpv_pq` directly.
+         * once, and the layers after it read that one.
          */
         std::set<int> get_group_controlled_buses() const;
         /**
@@ -2291,12 +2300,16 @@ class LS2G_API LSGrid final
          * it, which is what lets the powerflow hand over a working copy of the grid's
          * change tracking rather than the member itself (see LSGrid::ac_pf).
          */
+        /// `supports_voltage_control`: may the voltage-control layers be built at all
+        /// (BaseAlgo::supports_remote_voltage_control of the algorithm that will solve
+        /// this cache)? False leaves the plan empty and gives the classical pv/pq split.
         template<class MatScalar>
         CplxVect _build_into_cache(const Eigen::Ref<const CplxVect> & Vinit,
                                    SolverSideCache<MatScalar> & cache,
                                    const AlgoControl & solver_control,
                                    bool force_full_rebuild,
-                                   bool init_pv_vm_targets);
+                                   bool init_pv_vm_targets,
+                                   bool supports_voltage_control);
 
         /**
          * `pre_process_solver` / `pre_process_dc_solver` for either family: the reuse
@@ -2349,20 +2362,20 @@ class LS2G_API LSGrid final
         void fillYbus(Eigen::SparseMatrix<cplx_type> & res, bool ac, const SolverBusIdVect& id_me_to_solver);
         void fillBdc(Eigen::SparseMatrix<real_type> & res, const SolverBusIdVect& id_me_to_solver);  // DC: real admittance matrix
         void fillSbus_me(Eigen::Ref<CplxVect> res, bool ac, const SolverBusIdVect& id_me_to_solver);
-        // writes the pv / pq split into the caller-supplied vectors: the AC and the
-        // DC family each own theirs (ac_cache_.bus_pv / dc_cache_.bus_pv, ...), and they are
-        // expressed in that family's own solver labelling.
-        // `group_reg` is layer 1 of the caller's voltage-control plan (GRID bus ids,
-        // VoltageControlPlan::group_controlled_buses): the buses a control group
-        // regulates must stay out of PV, and the controller list the caller builds
-        // right afterwards has to be keyed on this very layout -- which is why it is
-        // handed in rather than re-derived here.
-        void fillpv_pq(const SolverBusIdVect& id_me_to_solver,
-                       const GlobalBusIdVect& id_solver_to_me,
-                       const SolverBusIdVect & slack_bus_id_solver,
-                       const std::set<int> & group_reg,
-                       SolverBusIdVect & bus_pv_out,
-                       SolverBusIdVect & bus_pq_out);
+        // The pv/pq split itself lives in VoltageControlPlan::build_pv_pq: its one
+        // subtlety is keyed on the control groups, and the controller list is then keyed
+        // on it, so the three are one object with one build order rather than a call
+        // sequence that has to be got right. What is left on this side is naming the
+        // containers to ask, which is what owning them means.
+        /// every container that can pin a bus' magnitude through the classical PV path
+        [[nodiscard]] std::vector<const GenericContainer *> _pv_capable_containers() const;
+        /**
+         * Refuse, by name, a grid whose voltage control the selected algorithm cannot
+         * honour. Called by `ac_pf` when `_algo.supports_remote_voltage_control()` is
+         * false -- the same shape as the angle-droop guard right above it, and for the
+         * same reason: the alternative is a converged, plausible, wrong answer.
+         */
+        void _throw_if_voltage_control_needed() const;
 
         // results
         /**process the results from the solver to this instance

--- a/src/core/SolverSideCache.hpp
+++ b/src/core/SolverSideCache.hpp
@@ -89,7 +89,7 @@ struct SolverBusLayout
      * built against are one picture of the grid, and mixing two of them is not stale
      * data, it is a different grid.
      *
-     * Both families carry the group layout -- `fillpv_pq` is one function and its
+     * Both families carry the group layout -- the pv/pq split is one rule and its
      * rule is the same either way -- but only the AC family fills the two
      * solver-side layers: a DC solve has no voltage control, so nothing reads a DC
      * plan's free-Vm slack set or its controller list.

--- a/src/core/SolverSideCache.hpp
+++ b/src/core/SolverSideCache.hpp
@@ -17,6 +17,7 @@
 
 #include "TaggedIdVec.hpp"
 #include "Utils.hpp"
+#include "VoltageControlPlan.hpp"
 #include "ls2g_api.hpp"
 
 namespace ls2g {
@@ -78,6 +79,23 @@ struct SolverBusLayout
     SolverBusIdVect bus_pv;  ///< solver ids, NOT grid ids
     SolverBusIdVect bus_pq;  ///< solver ids, NOT grid ids
 
+    // ---- the "fancy" voltage controllers -----------------------------------
+    /**
+     * Remote voltage control, several machines regulating one bus, and voltage-mode
+     * SVCs, as the NR extensions consume them (see VoltageControlPlan). Derived from
+     * the elements AND from the six members above -- it is expressed in this
+     * labelling and in this pv-pq split -- which is exactly why it belongs here
+     * rather than in the extensions that read it: a plan and the labelling it was
+     * built against are one picture of the grid, and mixing two of them is not stale
+     * data, it is a different grid.
+     *
+     * Both families carry the group layout -- `fillpv_pq` is one function and its
+     * rule is the same either way -- but only the AC family fills the two
+     * solver-side layers: a DC solve has no voltage control, so nothing reads a DC
+     * plan's free-Vm slack set or its controller list.
+     */
+    VoltageControlPlan voltage_control;
+
     // ---- what makes the above reusable, or not -----------------------------
     /**
      * The grid size this cache was built for, or 0 for "nothing built / retired".
@@ -126,6 +144,7 @@ struct SolverBusLayout
         slack_weights = RealVect();
         bus_pv = SolverBusIdVect();
         bus_pq = SolverBusIdVect();
+        voltage_control.clear();
         built_for_nb_bus = 0;
     }
 

--- a/src/core/Utils.hpp
+++ b/src/core/Utils.hpp
@@ -267,16 +267,29 @@ class AlgoControl final
          *
          * Every term is a reason the split itself changes: the system was rebuilt from
          * scratch (`need_reset_solver_`, which `tell_cache_maybe_poisoned()` implies),
-         * the bus set changed (`change_dimension_`), the bus LABELLING changed
-         * (`ybus_change_sparsity_pattern_`, which is what makes
-         * `LSGrid::init_converter_bus_id` run), the slack set moved
+         * the bus set changed (`change_dimension_`), the slack set moved
          * (`slack_participate_changed_`, and the slack is not PV), or a bus changed
          * class (`pv_changed_` / `pq_changed_`).
+         *
+         * `ybus_change_sparsity_pattern_` is deliberately NOT a term, though it looks
+         * like one: it is the flag for "the bus LABELLING may have moved". It is only
+         * ever raised by a BRANCH-side mutation (reconnecting a line or a trafo,
+         * moving one of its ends), and every one of those goes through
+         * `GenericContainer::_apply_and_track_buses`, which raises `change_dimension_`
+         * exactly when such a mutation empties or fills a bus -- which is exactly when
+         * the labelling moves. If no bus crossed, `id_me_to_solver` is unchanged, and a
+         * branch is neither a voltage controller nor a slack, so the split it produces
+         * is identical. The term was there, and dropping it was measured, not argued:
+         * see the `[pv_pq]` cases in `test_cache_reuse.cpp`, which put the grid in a
+         * state where this flag is the ONLY term raised and check the reused split
+         * against a cold one. With the term dropped they still pass; the same
+         * experiment run on `slack_participate_changed_` fails, which is why that one
+         * stays.
          *
          * Read by `LSGrid::_build_into_cache`, which is the only thing that rebuilds it.
          */
         [[nodiscard]] bool need_recompute_pv_pq() const noexcept {
-            return need_reset_solver_ || change_dimension_ || ybus_change_sparsity_pattern_ ||
+            return need_reset_solver_ || change_dimension_ ||
                    slack_participate_changed_ || pv_changed_ || pq_changed_;
         }
 

--- a/src/core/Utils.hpp
+++ b/src/core/Utils.hpp
@@ -193,23 +193,21 @@ class AlgoControl final
         void tell_ybus_some_coeffs_zero(){ybus_some_coeffs_zero_ = true;}
         void tell_one_el_changed_bus(){one_el_change_bus_ = true;}
         /**
-         * Something the voltage-control plan is made of has changed: which buses a
-         * control GROUP regulates, who is in a group, or a setpoint / sharing key a
-         * group's bordered rows carry.
+         * A voltage SETPOINT a control group's bordered rows carry has moved: a
+         * regulating generator's or hvdc converter station's target magnitude.
          *
-         * Raised by the element modifiers that can move any of those -- a generator's
-         * regulated bus, its voltage setpoint, its regulator being connected or
-         * disconnected, an SVC or an hvdc converter station changing bus or status.
-         * Deliberately its OWN flag rather than a reuse of `tell_pv_changed()`: the
-         * two questions really do differ. A remote-regulating generator changing its
-         * setpoint changes no bus's pv/pq class at all (that is the whole point of the
-         * bordered formulation: the regulated bus stays PQ), and conversely most of
-         * what makes a bus PV or PQ has nothing to do with a control group. Folding
-         * one into the other would either rebuild the pv-pq split for nothing or --
-         * the dangerous direction -- reuse a plan whose setpoints have moved.
+         * Deliberately narrow, and deliberately NOT raised for everything the
+         * voltage-control plan is made of. Who is in a group, and which bus a group
+         * regulates, are the same inputs the pv/pq split reads -- and since that split
+         * IS a layer of the plan (VoltageControlPlan::build_pv_pq), a change to one is
+         * a change to the other, already carried by `pv_changed_` and friends. See
+         * `need_recompute_pv_pq()`. What those flags do NOT carry is a setpoint: moving
+         * a remote regulator's target changes no bus' pv/pq class at all -- that is the
+         * point of the bordered formulation, the regulated bus stays PQ -- so it needs
+         * a flag of its own, and this is it.
          *
-         * See `need_recompute_voltage_control()` for the question a powerflow
-         * actually asks, and VoltageControlPlan for what gets rebuilt.
+         * If you add an input to the plan that the pv/pq split does not read, raise
+         * this from the modifier that moves it.
          */
         void tell_voltage_control_changed(){voltage_control_changed_ = true;}
         /**
@@ -265,30 +263,48 @@ class AlgoControl final
         bool has_voltage_control_changed() const {return voltage_control_changed_;}
 
         /**
+         * Must the pv/pq split be rebuilt?
+         *
+         * Every term is a reason the split itself changes: the system was rebuilt from
+         * scratch (`need_reset_solver_`, which `tell_cache_maybe_poisoned()` implies),
+         * the bus set changed (`change_dimension_`), the bus LABELLING changed
+         * (`ybus_change_sparsity_pattern_`, which is what makes
+         * `LSGrid::init_converter_bus_id` run), the slack set moved
+         * (`slack_participate_changed_`, and the slack is not PV), or a bus changed
+         * class (`pv_changed_` / `pq_changed_`).
+         *
+         * Read by `LSGrid::_build_into_cache`, which is the only thing that rebuilds it.
+         */
+        [[nodiscard]] bool need_recompute_pv_pq() const noexcept {
+            return need_reset_solver_ || change_dimension_ || ybus_change_sparsity_pattern_ ||
+                   slack_participate_changed_ || pv_changed_ || pq_changed_;
+        }
+
+        /**
          * Must the voltage-control plan be rebuilt, or does the one the previous solve
          * of this family left in its cache still describe the grid?
          *
-         * A plan is expressed in ONE bus labelling and ONE pv-pq split, so it is
-         * invalidated both by what changes its own inputs (`voltage_control_changed_`)
-         * and by anything that re-labels the buses or re-splits them underneath it --
-         * a plan carried across a relabelling is not stale data, it is a different
-         * grid. Hence the union below rather than the single flag.
+         * The pv/pq split is a LAYER of that plan (VoltageControlPlan::build_pv_pq), so
+         * whatever rebuilds the split rebuilds the plan -- that is the first half, and
+         * it is not a grab-bag of loosely-related flags but literally the same question
+         * asked one layer down. Whoever is in a control group, and which bus it
+         * regulates, are exactly the inputs the split reads; there is no way to change
+         * one without changing the other.
          *
-         * What is deliberately NOT in it is the set of changes an ordinary grid2op
-         * step makes: moving a load's P and Q raises `need_recompute_sbus_` and
+         * The second half is what the split does NOT read: a setpoint. See
+         * `tell_voltage_control_changed()`.
+         *
+         * What is deliberately in NEITHER half is the set of changes an ordinary
+         * grid2op step makes: moving a load's P and Q raises `need_recompute_sbus_` and
          * nothing else, so the plan survives such a step untouched -- which is the
          * whole point of caching it.
          *
-         * All-or-nothing on purpose: the plan's three layers are rebuilt together or
-         * not at all. Refreshing only the setpoints of an otherwise unchanged group
-         * layout (the `v_changed_` case) is a finer question this does not try to
-         * answer yet.
+         * All-or-nothing on purpose: the plan's layers are rebuilt together or not at
+         * all. Refreshing only the setpoints of an otherwise unchanged group layout is
+         * a finer question this does not try to answer yet.
          */
         [[nodiscard]] bool need_recompute_voltage_control() const noexcept {
-            return voltage_control_changed_ || change_dimension_ || need_reset_solver_ ||
-                   pv_changed_ || pq_changed_ || slack_participate_changed_ ||
-                   slack_weight_changed_ || one_el_change_bus_ ||
-                   ybus_change_sparsity_pattern_ || v_changed_ || cache_maybe_poisoned_;
+            return need_recompute_pv_pq() || voltage_control_changed_;
         }
 
     private:    

--- a/src/core/Utils.hpp
+++ b/src/core/Utils.hpp
@@ -108,7 +108,8 @@ class AlgoControl final
             ybus_some_coeffs_zero_(true),
             ybus_change_sparsity_pattern_(true),
             one_el_change_bus_(true),
-            cache_maybe_poisoned_(true)
+            cache_maybe_poisoned_(true),
+            voltage_control_changed_(true)
             {};
 
         ~AlgoControl() noexcept = default;
@@ -127,6 +128,7 @@ class AlgoControl final
             ybus_change_sparsity_pattern_ = true;
             one_el_change_bus_ = true;
             cache_maybe_poisoned_ = true;
+            voltage_control_changed_ = true;
         }
 
         /**
@@ -145,7 +147,7 @@ class AlgoControl final
                    !need_recompute_sbus_ && !need_recompute_ybus_ && !v_changed_ &&
                    !slack_weight_changed_ && !ybus_some_coeffs_zero_ &&
                    !ybus_change_sparsity_pattern_ && !one_el_change_bus_ &&
-                   !cache_maybe_poisoned_;
+                   !cache_maybe_poisoned_ && !voltage_control_changed_;
         }
 
         void tell_none_changed(){
@@ -162,6 +164,7 @@ class AlgoControl final
             ybus_change_sparsity_pattern_ = false;
             one_el_change_bus_ = false;
             cache_maybe_poisoned_ = false;
+            voltage_control_changed_ = false;
         }
 
         // the dimension of the Ybus matrix / Sbus vector has changed (eg. topology changes)
@@ -189,6 +192,26 @@ class AlgoControl final
         // might need to trigger some recomputation of some solvers (eg NR based ones)
         void tell_ybus_some_coeffs_zero(){ybus_some_coeffs_zero_ = true;}
         void tell_one_el_changed_bus(){one_el_change_bus_ = true;}
+        /**
+         * Something the voltage-control plan is made of has changed: which buses a
+         * control GROUP regulates, who is in a group, or a setpoint / sharing key a
+         * group's bordered rows carry.
+         *
+         * Raised by the element modifiers that can move any of those -- a generator's
+         * regulated bus, its voltage setpoint, its regulator being connected or
+         * disconnected, an SVC or an hvdc converter station changing bus or status.
+         * Deliberately its OWN flag rather than a reuse of `tell_pv_changed()`: the
+         * two questions really do differ. A remote-regulating generator changing its
+         * setpoint changes no bus's pv/pq class at all (that is the whole point of the
+         * bordered formulation: the regulated bus stays PQ), and conversely most of
+         * what makes a bus PV or PQ has nothing to do with a control group. Folding
+         * one into the other would either rebuild the pv-pq split for nothing or --
+         * the dangerous direction -- reuse a plan whose setpoints have moved.
+         *
+         * See `need_recompute_voltage_control()` for the question a powerflow
+         * actually asks, and VoltageControlPlan for what gets rebuilt.
+         */
+        void tell_voltage_control_changed(){voltage_control_changed_ = true;}
         /**
          * The per-bus element counts may no longer be what the elements say.
          *
@@ -238,6 +261,35 @@ class AlgoControl final
         bool has_one_el_changed_bus() const {return one_el_change_bus_;}
         // see tell_cache_maybe_poisoned()
         bool cache_maybe_poisoned() const {return cache_maybe_poisoned_;}
+        // see tell_voltage_control_changed()
+        bool has_voltage_control_changed() const {return voltage_control_changed_;}
+
+        /**
+         * Must the voltage-control plan be rebuilt, or does the one the previous solve
+         * of this family left in its cache still describe the grid?
+         *
+         * A plan is expressed in ONE bus labelling and ONE pv-pq split, so it is
+         * invalidated both by what changes its own inputs (`voltage_control_changed_`)
+         * and by anything that re-labels the buses or re-splits them underneath it --
+         * a plan carried across a relabelling is not stale data, it is a different
+         * grid. Hence the union below rather than the single flag.
+         *
+         * What is deliberately NOT in it is the set of changes an ordinary grid2op
+         * step makes: moving a load's P and Q raises `need_recompute_sbus_` and
+         * nothing else, so the plan survives such a step untouched -- which is the
+         * whole point of caching it.
+         *
+         * All-or-nothing on purpose: the plan's three layers are rebuilt together or
+         * not at all. Refreshing only the setpoints of an otherwise unchanged group
+         * layout (the `v_changed_` case) is a finer question this does not try to
+         * answer yet.
+         */
+        [[nodiscard]] bool need_recompute_voltage_control() const noexcept {
+            return voltage_control_changed_ || change_dimension_ || need_reset_solver_ ||
+                   pv_changed_ || pq_changed_ || slack_participate_changed_ ||
+                   slack_weight_changed_ || one_el_change_bus_ ||
+                   ybus_change_sparsity_pattern_ || v_changed_ || cache_maybe_poisoned_;
+        }
 
     private:    
         bool change_dimension_;
@@ -253,6 +305,7 @@ class AlgoControl final
         bool ybus_change_sparsity_pattern_;  // sparsity pattern of ybus changed (and so are its coeff), or ybus change of dimension
         bool one_el_change_bus_;  // whether one element has change of bus (or being reconnected / disconnected)
         bool cache_maybe_poisoned_;  // the per-bus element counts may have drifted: see tell_cache_maybe_poisoned()
+        bool voltage_control_changed_;  // an input of the voltage-control plan moved: see tell_voltage_control_changed()
 };
 
 /**

--- a/src/core/VoltageControlPlan.cpp
+++ b/src/core/VoltageControlPlan.cpp
@@ -13,6 +13,7 @@
 #include <stdexcept>
 
 #include "BaseConstants.hpp"
+#include "element_container/GenericContainer.hpp"
 #include "element_container/GeneratorContainer.hpp"
 #include "element_container/HvdcLineContainer.hpp"
 #include "element_container/SvcContainer.hpp"
@@ -30,9 +31,16 @@ void VoltageControlPlan::clear() noexcept
 // layer 1: which buses a GROUP regulates (grid ids, no labelling needed)
 // ---------------------------------------------------------------------------
 void VoltageControlPlan::build_groups(const GeneratorContainer & generators,
-                                      const SvcContainer & svcs)
+                                      const SvcContainer & svcs,
+                                      bool supports_voltage_control)
 {
     group_reg_buses_.clear();
+    // An algorithm with no bordered block cannot honour a group, and taking a bus
+    // out of PV for one it will not build leaves that bus' magnitude pinned by
+    // nothing at all. Leaving the set empty is what gives layer 2 the classical
+    // split; refusing the grid outright, when it really does have controllers, is
+    // LSGrid::ac_pf's job (see list_unsupported) and happens before this runs.
+    if(!supports_voltage_control) return;
     // an ACTIVE remote-regulating generator: gen_is_voltage_controller() already
     // means "connected, regulator on, not pseudo-off, and regulating a bus that is
     // NOT its own". A purely local regulator therefore never lands here, which is
@@ -54,7 +62,104 @@ void VoltageControlPlan::build_groups(const GeneratorContainer & generators,
 }
 
 // ---------------------------------------------------------------------------
-// layers 2 and 3
+// layer 2: the pv/pq split
+// ---------------------------------------------------------------------------
+void VoltageControlPlan::build_pv_pq(const std::vector<const GenericContainer *> & pv_sources,
+                                     const SolverBusIdVect & id_me_to_solver,
+                                     const GlobalBusIdVect & id_solver_to_me,
+                                     const SolverBusIdVect & slack_bus_id_solver,
+                                     SolverBusIdVect & bus_pv_out,
+                                     SolverBusIdVect & bus_pq_out) const
+{
+    const int nb_bus = static_cast<int>(id_solver_to_me.size());  // number of bus in the solver!
+    std::vector<int> bus_pq;
+    bus_pq.reserve(nb_bus);
+    std::vector<int> bus_pv;
+    bus_pv.reserve(nb_bus);
+    std::vector<bool> has_bus_been_added(nb_bus, false);
+
+    bus_pv_out = SolverBusIdVect();
+    bus_pq_out = SolverBusIdVect();
+
+    // the classical part: every container says which buses it pins
+    for(const GenericContainer * container : pv_sources){
+        if(container == nullptr) continue;
+        container->fillpv(bus_pv, has_bus_been_added, slack_bus_id_solver, id_me_to_solver);
+    }
+
+    // ... and layer 1 takes back the ones a control GROUP regulates: their magnitude
+    // is set by the group's bordered voltage row, so they must keep their own Vm
+    // unknown (and hence their Q equation). See the doc on this function for the
+    // configuration this fixes. Whatever pinned such a bus through the PV path -- a
+    // local generator, or a voltage-regulating hvdc converter station -- is enrolled
+    // as a member of the group by build_controllers instead.
+    if(!group_reg_buses_.empty()){
+        std::vector<int> bus_pv_kept;
+        bus_pv_kept.reserve(bus_pv.size());
+        for(int bus_id_solver : bus_pv){
+            const int bus_id_me = id_solver_to_me[bus_id_solver].cast_int();
+            if(bus_id_me < 0 || !group_reg_buses_.count(bus_id_me)){
+                bus_pv_kept.push_back(bus_id_solver);
+                continue;
+            }
+            has_bus_been_added[bus_id_solver] = false;  // let the PQ loop take it
+        }
+        bus_pv.swap(bus_pv_kept);
+    }
+
+    // TODO remove the order here..., i could be faster in this piece of code
+    // (looping once through the buses)
+    for(int bus_id = 0; bus_id < nb_bus; ++bus_id){
+        if(GenericContainer::is_in_vect(bus_id, slack_bus_id_solver.to_int_vector())) continue;  // slack bus is not PQ either
+        if(has_bus_been_added[bus_id]) continue; // a pv bus cannot be PQ
+        bus_pq.push_back(bus_id);
+        has_bus_been_added[bus_id] = true;  // don't add it a second time
+    }
+    bus_pv_out = SolverBusIdVect(bus_pv.size(), SolverBusId(0));
+    for(int i = 0; i < static_cast<int>(bus_pv.size()); ++i){
+        bus_pv_out(i) = SolverBusId(bus_pv[i]);
+    }
+    bus_pq_out = SolverBusIdVect(bus_pq.size(), SolverBusId(0));
+    for(int i = 0; i < static_cast<int>(bus_pq.size()); ++i){
+        bus_pq_out(i) = SolverBusId(bus_pq[i]);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// the guard: what an algorithm without the bordered block must refuse
+// ---------------------------------------------------------------------------
+VoltageControlPlan::Unsupported
+VoltageControlPlan::list_unsupported(const GeneratorContainer & generators,
+                                     const SvcContainer & svcs,
+                                     const HvdcLineContainer & hvdc_lines) const
+{
+    Unsupported res;
+    if(group_reg_buses_.empty()) return res;  // nothing needs the bordered block
+
+    const int nb_gen = static_cast<int>(generators.nb());
+    for(int gen_id = 0; gen_id < nb_gen; ++gen_id){
+        if(generators.gen_is_voltage_controller(gen_id)) res.gen_ids.push_back(gen_id);
+    }
+    const int nb_svc = static_cast<int>(svcs.nb());
+    for(int svc_id = 0; svc_id < nb_svc; ++svc_id){
+        if(svcs.svc_is_voltage_controller(svc_id)) res.svc_ids.push_back(svc_id);
+    }
+    // a station is never an offender on its own: it pins its own bus the classical
+    // way unless a group already claims that bus, in which case it is enrolled and
+    // the user needs to know it is affected too
+    const int nb_hvdc = static_cast<int>(hvdc_lines.nb());
+    for(int hvdc_id = 0; hvdc_id < nb_hvdc; ++hvdc_id){
+        for(int side = 1; side <= 2; ++side){
+            if(!hvdc_lines.station_is_voltage_controller(hvdc_id, side)) continue;
+            const int bus = hvdc_lines.get_station_bus(hvdc_id, side).cast_int();
+            if(group_reg_buses_.count(bus)) res.station_ids.push_back(std::make_pair(hvdc_id, side));
+        }
+    }
+    return res;
+}
+
+// ---------------------------------------------------------------------------
+// layers 3 and 4
 // ---------------------------------------------------------------------------
 void VoltageControlPlan::build_solver_side(const GeneratorContainer & generators,
                                            const SvcContainer & svcs,
@@ -92,7 +197,7 @@ void VoltageControlPlan::build_free_vm_slack(const GeneratorContainer & generato
     std::set<int> locally_vfixed;
     // ... except that a local regulator on a bus a control GROUP regulates does not
     // pin it: it is enrolled as a member of that group instead (see build_groups and
-    // the reclassification in LSGrid::fillpv_pq), and the group's voltage row needs
+    // the reclassification in build_pv_pq), and the group's voltage row needs
     // the free Vm this grants.
     const int nb_gen = static_cast<int>(generators.nb());
     const GlobalBusIdVect & gen_buses = generators.get_buses();
@@ -125,7 +230,7 @@ void VoltageControlPlan::build_controllers(const GeneratorContainer & generators
     if(nb_bus_solver == 0) return;  // see build_free_vm_slack
 
     // PQ membership: a bus owns a Q equation AND a Vm unknown iff it is a PQ bus
-    // (PV buses have only theta/P, the slack none). `bus_pq` is set by fillpv_pq.
+    // (PV buses have only theta/P, the slack none). `bus_pq` is layer 2's own output.
     std::vector<bool> is_pq(nb_bus_solver, false);
     for(int k = 0; k < static_cast<int>(bus_pq.size()); ++k){
         const int b = bus_pq(k).cast_int();
@@ -201,7 +306,7 @@ void VoltageControlPlan::_collect_gen_controllers(const GeneratorContainer & gen
         // The regulated bus needs a Vm unknown for the bordered row to act on. An
         // ordinary PQ bus has one; so does a slack bus that nothing pins locally (same
         // escape hatch as the controller bus just above -- `has_free_q`). A bus that is
-        // PV despite being group-controlled cannot occur any more (fillpv_pq
+        // PV despite being group-controlled cannot occur any more (layer 2
         // reclassifies it), so what is left here is a bus pinned by something that
         // cannot be enrolled.
         if(!is_pq[reg_solver] && !has_free_q[reg_solver]){
@@ -279,7 +384,7 @@ void VoltageControlPlan::_collect_station_controllers(const HvdcLineContainer & 
     // the voltage-regulating hvdc converter stations. A VSC station with
     // voltage_regulator_on pins its own bus through the PV path, exactly like a local
     // generator, so it is a controller only when a GROUP regulates that bus instead
-    // (fillpv_pq then kept the bus out of PV and it needs its members). Its sharing
+    // (layer 2 then kept the bus out of PV and it needs its members). Its sharing
     // key is a reactive range in MVAr -- the same currency as a generator's -- so a
     // mixed generator/station group shares reactive power correctly, unlike an SVC
     // (whose key is a susceptance range; hence the SVC-alone restriction below).

--- a/src/core/VoltageControlPlan.cpp
+++ b/src/core/VoltageControlPlan.cpp
@@ -1,0 +1,395 @@
+// Copyright (c) 2026, RTE (https://www.rte-france.com)
+// See AUTHORS.txt
+// This Source Code Form is subject to the terms of the Mozilla Public License, version 2.0.
+// If a copy of the Mozilla Public License, version 2.0 was not distributed with this file,
+// you can obtain one at http://mozilla.org/MPL/2.0/.
+// SPDX-License-Identifier: MPL-2.0
+// This file is part of LightSim2grid, LightSim2grid implements a c++ backend targeting the Grid2Op platform.
+
+#include "VoltageControlPlan.hpp"
+
+#include <cmath>
+#include <sstream>
+#include <stdexcept>
+
+#include "BaseConstants.hpp"
+#include "element_container/GeneratorContainer.hpp"
+#include "element_container/HvdcLineContainer.hpp"
+#include "element_container/SvcContainer.hpp"
+
+namespace ls2g {
+
+void VoltageControlPlan::clear() noexcept
+{
+    group_reg_buses_.clear();
+    free_vm_slack_buses_.clear();
+    controllers_.clear();
+}
+
+// ---------------------------------------------------------------------------
+// layer 1: which buses a GROUP regulates (grid ids, no labelling needed)
+// ---------------------------------------------------------------------------
+void VoltageControlPlan::build_groups(const GeneratorContainer & generators,
+                                      const SvcContainer & svcs)
+{
+    group_reg_buses_.clear();
+    // an ACTIVE remote-regulating generator: gen_is_voltage_controller() already
+    // means "connected, regulator on, not pseudo-off, and regulating a bus that is
+    // NOT its own". A purely local regulator therefore never lands here, which is
+    // what keeps the ordinary (possibly multi-generator) PV bus untouched.
+    const int nb_gen = static_cast<int>(generators.nb());
+    for(int gen_id = 0; gen_id < nb_gen; ++gen_id){
+        if(!generators.gen_is_voltage_controller(gen_id)) continue;
+        const int reg = generators.get_regulated_bus_id(gen_id);
+        if(reg >= 0) group_reg_buses_.insert(reg);
+    }
+    // a voltage-mode SVC is ALWAYS a group controller (even local and non-sloped),
+    // so the bus it regulates always needs the bordered treatment
+    const int nb_svc = static_cast<int>(svcs.nb());
+    for(int svc_id = 0; svc_id < nb_svc; ++svc_id){
+        if(!svcs.svc_is_voltage_controller(svc_id)) continue;
+        const int reg = svcs.get_regulated_bus_id(svc_id);
+        if(reg >= 0) group_reg_buses_.insert(reg);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// layers 2 and 3
+// ---------------------------------------------------------------------------
+void VoltageControlPlan::build_solver_side(const GeneratorContainer & generators,
+                                           const SvcContainer & svcs,
+                                           const HvdcLineContainer & hvdc_lines,
+                                           const SolverBusIdVect & id_me_to_solver,
+                                           const GlobalBusIdVect & id_solver_to_me,
+                                           const SolverBusIdVect & slack_bus_id_solver,
+                                           const SolverBusIdVect & bus_pq)
+{
+    build_free_vm_slack(generators, id_me_to_solver, id_solver_to_me, slack_bus_id_solver);
+    build_controllers(generators, svcs, hvdc_lines, id_me_to_solver, id_solver_to_me, bus_pq);
+}
+
+void VoltageControlPlan::build_free_vm_slack(const GeneratorContainer & generators,
+                                             const SolverBusIdVect & id_me_to_solver,
+                                             const GlobalBusIdVect & id_solver_to_me,
+                                             const SolverBusIdVect & slack_bus_id_solver)
+{
+    free_vm_slack_buses_.clear();
+    // Nothing has been labelled yet (a grid that never solved, or a cache just
+    // retired): there is no solver bus to express any of this in, and every id below
+    // would index an empty labelling. Layer 1 stays as it was -- it is expressed in
+    // grid ids and does not depend on any of this.
+    if(id_solver_to_me.size() == 0) return;
+
+    // solver-bus ids of the slack buses
+    std::set<int> slack;
+    for(int k = 0; k < static_cast<int>(slack_bus_id_solver.size()); ++k){
+        slack.insert(slack_bus_id_solver(k).cast_int());
+    }
+    if(slack.empty()) return;
+
+    // A slack bus is Vm-fixed (PV-like, no Q equation) only when a LOCAL
+    // voltage-regulating generator pins its magnitude. Collect those buses.
+    std::set<int> locally_vfixed;
+    // ... except that a local regulator on a bus a control GROUP regulates does not
+    // pin it: it is enrolled as a member of that group instead (see build_groups and
+    // the reclassification in LSGrid::fillpv_pq), and the group's voltage row needs
+    // the free Vm this grants.
+    const int nb_gen = static_cast<int>(generators.nb());
+    const GlobalBusIdVect & gen_buses = generators.get_buses();
+    for(int gen_id = 0; gen_id < nb_gen; ++gen_id){
+        if(!generators.gen_is_local_voltage_controller(gen_id)) continue;
+        const int ctrl_grid = gen_buses(gen_id).cast_int();
+        if(group_reg_buses_.count(ctrl_grid)) continue;
+        const int ctrl_solver = id_me_to_solver[ctrl_grid].cast_int();
+        if(ctrl_solver == GenericContainer::_deactivated_bus_id) continue;
+        locally_vfixed.insert(ctrl_solver);
+    }
+
+    // Every slack bus whose magnitude is NOT pinned locally needs a free Vm
+    // unknown + Q equation: distributed-slack PQ participants (the common case),
+    // remote-voltage controllers, and SVC-regulated slack buses all fall here.
+    for(int b : slack){
+        if(!locally_vfixed.count(b)) free_vm_slack_buses_.insert(b);
+    }
+}
+
+void VoltageControlPlan::build_controllers(const GeneratorContainer & generators,
+                                           const SvcContainer & svcs,
+                                           const HvdcLineContainer & hvdc_lines,
+                                           const SolverBusIdVect & id_me_to_solver,
+                                           const GlobalBusIdVect & id_solver_to_me,
+                                           const SolverBusIdVect & bus_pq)
+{
+    controllers_.clear();
+    const int nb_bus_solver = static_cast<int>(id_solver_to_me.size());
+    if(nb_bus_solver == 0) return;  // see build_free_vm_slack
+
+    // PQ membership: a bus owns a Q equation AND a Vm unknown iff it is a PQ bus
+    // (PV buses have only theta/P, the slack none). `bus_pq` is set by fillpv_pq.
+    std::vector<bool> is_pq(nb_bus_solver, false);
+    for(int k = 0; k < static_cast<int>(bus_pq.size()); ++k){
+        const int b = bus_pq(k).cast_int();
+        if(b >= 0 && b < nb_bus_solver) is_pq[b] = true;
+    }
+    // Slack buses are not PQ in the base block, but a slack bus that is not pinned
+    // by a local PV generator is given a Q equation + free Vm by the Base block (see
+    // build_free_vm_slack), so a controller on such a slack bus is supported even
+    // though `is_pq` is false there. A slack bus that IS locally pinned (another
+    // generator regulates it directly) gets no such Q equation at all -- checking
+    // membership of the whole slack list here (as opposed to just this "free"
+    // subset) would wrongly accept that case: its Q equation lookup then resolves to
+    // -1, the controller's own reactive-injection column ends up with no Jacobian
+    // entry anywhere, and the factorization fails with ErrorType::SolverFactor
+    // instead of this function's own clear error.
+    std::vector<bool> has_free_q(nb_bus_solver, false);
+    for(int b : free_vm_slack_buses_){
+        if(b >= 0 && b < nb_bus_solver) has_free_q[b] = true;
+    }
+
+    // 1. collect the active voltage-mode controllers. Per controller: solver bus,
+    //    regulated solver bus, v_set (pu), sharing key, kind, elem id.
+    std::vector<Raw> raws;
+    _collect_gen_controllers(generators, id_me_to_solver, is_pq, has_free_q, raws);
+    _collect_svc_controllers(svcs, id_me_to_solver, is_pq, has_free_q, raws);
+    _collect_station_controllers(hvdc_lines, id_me_to_solver, is_pq, has_free_q, raws);
+    if(raws.empty()) return;
+
+    _group_and_emit(raws);
+}
+
+void VoltageControlPlan::_collect_gen_controllers(const GeneratorContainer & generators,
+                                                  const SolverBusIdVect & id_me_to_solver,
+                                                  const std::vector<bool> & is_pq,
+                                                  const std::vector<bool> & has_free_q,
+                                                  std::vector<Raw> & raws) const
+{
+    const int nb_gen = static_cast<int>(generators.nb());
+    const GlobalBusIdVect & gen_buses = generators.get_buses();
+    for(int gen_id = 0; gen_id < nb_gen; ++gen_id){
+        // remote regulators are always controllers; a local one only when the bus it
+        // regulates is group-controlled (something else remote/an SVC aims at it too)
+        if(!generators.gen_is_voltage_controller(gen_id)){
+            if(!generators.gen_is_local_voltage_controller(gen_id)) continue;
+            if(!group_reg_buses_.count(generators.get_regulated_bus_id(gen_id))) continue;
+        }
+        const int ctrl_grid = gen_buses(gen_id).cast_int();
+        const int reg_grid  = generators.get_regulated_bus_id(gen_id);
+        const int ctrl_solver = id_me_to_solver[ctrl_grid].cast_int();
+        const int reg_solver  = (reg_grid >= 0) ? id_me_to_solver[reg_grid].cast_int()
+                                                : GenericContainer::_deactivated_bus_id;
+        if(ctrl_solver == GenericContainer::_deactivated_bus_id){
+            std::ostringstream exc_;
+            exc_ << "LSGrid::fill_voltage_control_solver_data: generator " << gen_id
+                 << " is a voltage controller but its bus is disconnected.";
+            throw std::runtime_error(exc_.str());
+        }
+        if(reg_solver == GenericContainer::_deactivated_bus_id){
+            std::ostringstream exc_;
+            exc_ << "LSGrid::fill_voltage_control_solver_data: generator " << gen_id
+                 << " regulates a disconnected bus.";
+            throw std::runtime_error(exc_.str());
+        }
+        if(!is_pq[ctrl_solver] && !has_free_q[ctrl_solver]){
+            std::ostringstream exc_;
+            exc_ << "LSGrid::fill_voltage_control_solver_data: generator " << gen_id
+                 << " regulates a remote bus but its OWN bus has no reactive (Q) equation"
+                    " (it is a PV bus that is not a slack, or a slack bus already locally"
+                    " pinned by another voltage-regulating generator). This is not supported"
+                    " in v1.";
+            throw std::runtime_error(exc_.str());
+        }
+        // The regulated bus needs a Vm unknown for the bordered row to act on. An
+        // ordinary PQ bus has one; so does a slack bus that nothing pins locally (same
+        // escape hatch as the controller bus just above -- `has_free_q`). A bus that is
+        // PV despite being group-controlled cannot occur any more (fillpv_pq
+        // reclassifies it), so what is left here is a bus pinned by something that
+        // cannot be enrolled.
+        if(!is_pq[reg_solver] && !has_free_q[reg_solver]){
+            std::ostringstream exc_;
+            exc_ << "LSGrid::fill_voltage_control_solver_data: generator " << gen_id
+                 << " regulates bus " << reg_grid << " which has no voltage (Vm) unknown"
+                    " (its magnitude is pinned by something that cannot join a control"
+                    " group). This is not supported in v1.";
+            throw std::runtime_error(exc_.str());
+        }
+        const real_type w = generators.get_max_q(gen_id) - generators.get_min_q(gen_id);
+        raws.push_back({ctrl_solver, reg_solver, generators.get_target_vm_pu(gen_id),
+                        static_cast<real_type>(0.), w, VoltageControlSolverData::GEN, gen_id});
+    }
+}
+
+void VoltageControlPlan::_collect_svc_controllers(const SvcContainer & svcs,
+                                                  const SolverBusIdVect & id_me_to_solver,
+                                                  const std::vector<bool> & is_pq,
+                                                  const std::vector<bool> & has_free_q,
+                                                  std::vector<Raw> & raws) const
+{
+    // the active VOLTAGE-mode SVCs (local or remote, with or without slope)
+    const int nb_svc = static_cast<int>(svcs.nb());
+    const GlobalBusIdVect & svc_buses = svcs.get_buses();
+    for(int svc_id = 0; svc_id < nb_svc; ++svc_id){
+        if(!svcs.svc_is_voltage_controller(svc_id)) continue;
+        const int ctrl_grid = svc_buses(svc_id).cast_int();
+        const int reg_grid  = svcs.get_regulated_bus_id(svc_id);
+        const int ctrl_solver = id_me_to_solver[ctrl_grid].cast_int();
+        const int reg_solver  = (reg_grid >= 0) ? id_me_to_solver[reg_grid].cast_int()
+                                                : GenericContainer::_deactivated_bus_id;
+        if(ctrl_solver == GenericContainer::_deactivated_bus_id){
+            std::ostringstream exc_;
+            exc_ << "LSGrid::fill_voltage_control_solver_data: SVC " << svc_id
+                 << " is a voltage controller but its bus is disconnected.";
+            throw std::runtime_error(exc_.str());
+        }
+        if(reg_solver == GenericContainer::_deactivated_bus_id){
+            std::ostringstream exc_;
+            exc_ << "LSGrid::fill_voltage_control_solver_data: SVC " << svc_id
+                 << " regulates a disconnected bus.";
+            throw std::runtime_error(exc_.str());
+        }
+        // same two escape hatches as the generator branch above: a slack bus that
+        // nothing pins locally owns a Q equation and a free Vm
+        if(!is_pq[ctrl_solver] && !has_free_q[ctrl_solver]){
+            std::ostringstream exc_;
+            exc_ << "LSGrid::fill_voltage_control_solver_data: SVC " << svc_id
+                 << " is at a bus with no reactive (Q) equation (it is a PV bus, or a slack"
+                    " bus pinned by a local voltage-regulating generator)."
+                    " This is not supported in v1.";
+            throw std::runtime_error(exc_.str());
+        }
+        if(!is_pq[reg_solver] && !has_free_q[reg_solver]){
+            std::ostringstream exc_;
+            exc_ << "LSGrid::fill_voltage_control_solver_data: SVC " << svc_id
+                 << " regulates bus " << reg_grid << " which has no voltage (Vm) unknown"
+                    " (its magnitude is pinned by something that cannot join a control"
+                    " group). This is not supported in v1.";
+            throw std::runtime_error(exc_.str());
+        }
+        const real_type w = svcs.get_b_max(svc_id) - svcs.get_b_min(svc_id);
+        raws.push_back({ctrl_solver, reg_solver, svcs.get_target_vm_pu(svc_id),
+                        svcs.get_slope_pu(svc_id), w, VoltageControlSolverData::SVC, svc_id});
+    }
+}
+
+void VoltageControlPlan::_collect_station_controllers(const HvdcLineContainer & hvdc_lines,
+                                                      const SolverBusIdVect & id_me_to_solver,
+                                                      const std::vector<bool> & is_pq,
+                                                      const std::vector<bool> & has_free_q,
+                                                      std::vector<Raw> & raws) const
+{
+    // the voltage-regulating hvdc converter stations. A VSC station with
+    // voltage_regulator_on pins its own bus through the PV path, exactly like a local
+    // generator, so it is a controller only when a GROUP regulates that bus instead
+    // (fillpv_pq then kept the bus out of PV and it needs its members). Its sharing
+    // key is a reactive range in MVAr -- the same currency as a generator's -- so a
+    // mixed generator/station group shares reactive power correctly, unlike an SVC
+    // (whose key is a susceptance range; hence the SVC-alone restriction below).
+    const int nb_hvdc = static_cast<int>(hvdc_lines.nb());
+    for(int hvdc_id = 0; hvdc_id < nb_hvdc; ++hvdc_id){
+        for(int side = 1; side <= 2; ++side){
+            if(!hvdc_lines.station_is_voltage_controller(hvdc_id, side)) continue;
+            const int ctrl_grid = hvdc_lines.get_station_bus(hvdc_id, side).cast_int();
+            // not group-controlled: the station keeps pinning its bus the classical way
+            if(!group_reg_buses_.count(ctrl_grid)) continue;
+            if(ctrl_grid == GenericContainer::_deactivated_bus_id) continue;
+            const int ctrl_solver = id_me_to_solver[ctrl_grid].cast_int();
+            if(ctrl_solver == GenericContainer::_deactivated_bus_id){
+                std::ostringstream exc_;
+                exc_ << "LSGrid::fill_voltage_control_solver_data: hvdc line " << hvdc_id
+                     << " side " << side << " regulates voltage but its bus is disconnected.";
+                throw std::runtime_error(exc_.str());
+            }
+            if(!is_pq[ctrl_solver] && !has_free_q[ctrl_solver]){
+                std::ostringstream exc_;
+                exc_ << "LSGrid::fill_voltage_control_solver_data: hvdc line " << hvdc_id
+                     << " side " << side << " takes part in a voltage-control group but its"
+                        " bus has no reactive (Q) equation. This is not supported in v1.";
+                throw std::runtime_error(exc_.str());
+            }
+            const int kind = (side == 1) ? VoltageControlSolverData::HVDC_SIDE_1
+                                         : VoltageControlSolverData::HVDC_SIDE_2;
+            raws.push_back({ctrl_solver, ctrl_solver,   // a station regulates its OWN bus
+                            hvdc_lines.get_station_target_vm_pu(hvdc_id, side),
+                            static_cast<real_type>(0.),
+                            hvdc_lines.get_station_q_range_mvar(hvdc_id, side),
+                            kind, hvdc_id});
+        }
+    }
+}
+
+void VoltageControlPlan::_group_and_emit(const std::vector<Raw> & raws)
+{
+    // 2. group by regulated solver bus (merge gens that share a regulated bus),
+    //    checking the v_set agree within tolerance.
+    std::vector<int> grp_reg;
+    std::vector<real_type> grp_vset;
+    std::vector<std::vector<int> > grp_members;  // indices into raws
+    for(int i = 0; i < static_cast<int>(raws.size()); ++i){
+        int g = -1;
+        for(int gg = 0; gg < static_cast<int>(grp_reg.size()); ++gg)
+            if(grp_reg[gg] == raws[i].reg_bus){ g = gg; break; }
+        if(g == -1){
+            g = static_cast<int>(grp_reg.size());
+            grp_reg.push_back(raws[i].reg_bus);
+            grp_vset.push_back(raws[i].v_set);
+            grp_members.push_back(std::vector<int>());
+        } else if(std::abs(grp_vset[g] - raws[i].v_set) > BaseConstants::_tol_equal_float){
+            std::ostringstream exc_;
+            exc_ << "LSGrid::fill_voltage_control_solver_data: several controllers regulate the"
+                    " same bus with conflicting voltage setpoints (" << grp_vset[g] << " vs "
+                 << raws[i].v_set << " pu).";
+            throw std::runtime_error(exc_.str());
+        }
+        grp_members[g].push_back(i);
+    }
+
+    // 2b. v1 restriction: an SVC may only be ALONE in its control group. The
+    //     cross-weight sharing of an SVC with other controllers (and any sloped
+    //     SVC sharing a regulated bus, cf Phase 0 probe #3) is not supported yet.
+    for(int g = 0; g < static_cast<int>(grp_members.size()); ++g){
+        if(grp_members[g].size() <= 1) continue;
+        for(int idx : grp_members[g]){
+            if(raws[idx].kind == VoltageControlSolverData::SVC){
+                std::ostringstream exc_;
+                exc_ << "LSGrid::fill_voltage_control_solver_data: SVC " << raws[idx].elem_id
+                     << " shares a regulated bus with other controllers, which is not"
+                        " supported in v1 (an SVC must be the only controller of its bus).";
+                throw std::runtime_error(exc_.str());
+            }
+        }
+    }
+
+    // 3. emit, controllers grouped contiguously
+    const int ng = static_cast<int>(grp_reg.size());
+    const int nc = static_cast<int>(raws.size());
+    VoltageControlSolverData & data = controllers_;
+    data.bus = Eigen::VectorXi(nc);
+    data.kind = Eigen::VectorXi(nc);
+    data.elem_id = Eigen::VectorXi(nc);
+    data.slope = RealVect(nc);
+    data.weight = RealVect(nc);
+    data.group = Eigen::VectorXi(nc);
+    data.reg_bus = Eigen::VectorXi(ng);
+    data.v_set = RealVect(ng);
+    data.grp_start = Eigen::VectorXi(ng);
+    data.grp_count = Eigen::VectorXi(ng);
+    int cursor = 0;
+    for(int g = 0; g < ng; ++g){
+        data.reg_bus(g) = grp_reg[g];
+        data.v_set(g) = grp_vset[g];
+        data.grp_start(g) = cursor;
+        data.grp_count(g) = static_cast<int>(grp_members[g].size());
+        for(int idx : grp_members[g]){
+            const Raw & r = raws[idx];
+            data.bus(cursor) = r.bus;
+            data.kind(cursor) = r.kind;
+            data.elem_id(cursor) = r.elem_id;
+            data.slope(cursor) = r.slope;
+            // floor the sharing key to keep the N>1 sharing rows non-singular
+            data.weight(cursor) = (std::abs(r.weight) > BaseConstants::_tol_equal_float) ? r.weight : BaseConstants::_tol_equal_float;
+            data.group(cursor) = g;
+            ++cursor;
+        }
+    }
+}
+
+} // namespace ls2g

--- a/src/core/VoltageControlPlan.cpp
+++ b/src/core/VoltageControlPlan.cpp
@@ -59,6 +59,17 @@ void VoltageControlPlan::build_groups(const GeneratorContainer & generators,
         const int reg = svcs.get_regulated_bus_id(svc_id);
         if(reg >= 0) group_reg_buses_.insert(reg);
     }
+    // and NOT the hvdc converter stations, which is not an oversight. A station has no
+    // regulated bus of its own to read -- ConverterStationContainer stores none, a
+    // regulating station always regulates the bus it stands on -- so it can never be
+    // the REMOTE controller that makes a bus need the bordered treatment. It pins its
+    // own bus through the ordinary PV path (ConverterStationContainer::fillpv), exactly
+    // like a local generator, and becomes a group member only when a group formed by
+    // one of the two loops above already claims that bus. That enrolment is
+    // build_controllers' job (_collect_station_controllers), and it is keyed on the set
+    // this function returns -- which is why adding stations here would be circular as
+    // well as wrong. Remote regulation BY a station is simply not modelled; see the
+    // changelog TODO.
 }
 
 // ---------------------------------------------------------------------------

--- a/src/core/VoltageControlPlan.hpp
+++ b/src/core/VoltageControlPlan.hpp
@@ -10,6 +10,8 @@
 #define VOLTAGE_CONTROL_PLAN_H
 
 #include <set>
+#include <utility>
+#include <vector>
 
 #include "TaggedIdVec.hpp"
 #include "Utils.hpp"
@@ -19,55 +21,77 @@
 namespace ls2g {
 
 class GeneratorContainer;
-class SvcContainer;
+class GenericContainer;
 class HvdcLineContainer;
+class SvcContainer;
 
 /**
- * Everything one AC solve needs to know about the "fancy" voltage controllers --
- * remote-regulating generators, several machines regulating the same bus, and
- * voltage-mode SVCs -- derived once, in one place, out of the element containers
- * and one bus labelling.
+ * How every bus of one solved system has its voltage magnitude pinned, and by what.
+ *
+ * The classical part -- the pv/pq split -- and the "fancy" part -- remote-regulating
+ * generators, several machines regulating the same bus, voltage-mode SVCs -- derived
+ * once, in one place, out of the element containers and one bus labelling.
  *
  * ---------------------------------------------------------------------------
  * WHY THIS IS ONE OBJECT
  *
- * Three answers used to be re-derived independently, by three functions on
- * LSGrid, each of them called from a different place in a powerflow:
+ * Four answers used to be derived in four different places, by four functions on
+ * LSGrid, each called from somewhere else in a powerflow:
  *
  *   get_group_controlled_buses()      -- fillpv_pq, while it is still building
- *                                        the very labelling the other two need;
+ *                                        the very split the others are keyed on;
+ *   fillpv_pq()                       -- _build_into_cache;
  *   get_free_vm_slack_solver_buses()  -- Base::update_state, and again inside
  *                                        fill_voltage_control_solver_data;
  *   fill_voltage_control_solver_data()-- VoltageControl::update_state.
  *
- * They are not three answers, they are three LAYERS of one: the controller list
- * is built out of the group layout and the free-Vm slack set, and the free-Vm
- * slack set is built out of the group layout. Re-deriving each of them where it
- * happened to be needed meant walking every generator of the grid three to four
- * times per powerflow -- and, worse, it meant three separate opportunities for
- * the layers to disagree, because each walk read the containers again and
- * nothing said they had to agree.
+ * They are not four answers, they are four LAYERS of one, each built out of the
+ * one before it. Deriving each where it happened to be needed meant walking every
+ * generator of the grid three to four times per powerflow -- and, worse, it meant
+ * as many separate opportunities for the layers to disagree, because each walk
+ * read the containers again and nothing said they had to agree.
  *
- * Built as one object they cannot: layer 2 is built from layer 1's own result,
- * layer 3 from layer 2's, and the whole thing is built once and then read.
+ * Built as one object they cannot: each layer is built from the previous one's own
+ * result, and the whole thing is built once and then read.
  *
  * ---------------------------------------------------------------------------
- * THE THREE LAYERS, AND WHAT EACH NEEDS
+ * THE FOUR LAYERS, AND WHAT EACH NEEDS
  *
- *  1. `group_controlled_buses()` -- GRID bus ids. Reads only input data
- *     (generators, SVCs), never the labelling, which is what lets `fillpv_pq`
- *     ask for it while it is still deciding the pv-pq split.
- *  2. `free_vm_slack_buses()`    -- SOLVER bus ids. Needs layer 1, the labelling
- *     and the slack.
- *  3. `controllers()`            -- the full VoltageControlSolverData, SOLVER bus
- *     ids and per unit. Needs layers 1 and 2, the labelling and the pv-pq split.
+ *  1. `build_groups` -> `group_controlled_buses()` -- GRID bus ids: the buses a
+ *     control GROUP regulates. Reads only input data (generators, SVCs), never the
+ *     labelling, because layer 2 -- which produces part of that labelling -- needs
+ *     it as an input.
+ *  2. `build_pv_pq` -- the pv/pq split, SOLVER bus ids, written into the caller's
+ *     vectors. Every container says which buses it pins (the classical part), then
+ *     layer 1 takes back the ones a group regulates. Needs layer 1 and the slack.
+ *  3. `build_free_vm_slack` -> `free_vm_slack_buses()` -- SOLVER bus ids of the
+ *     slack buses that keep a free Vm unknown. Needs layer 1 and the labelling.
+ *  4. `build_controllers` -> `controllers()` -- the full VoltageControlSolverData,
+ *     SOLVER bus ids and per unit. Needs layers 1 to 3.
  *
- * Hence one build entry point per layer: `build_groups` is layer 1 alone (all
- * `fillpv_pq` can have and all it needs), `build_free_vm_slack` and
- * `build_controllers` are the two that need the labelling, with
- * `build_solver_side` as the pair of them in the only order that works.
- * `build_controllers` throws, with the messages the configuration deserves, on
- * what the v1 bordered formulation cannot express; the other two cannot fail.
+ * Only layer 4 can fail: it throws, with the message the configuration deserves,
+ * on what the v1 bordered formulation cannot express. The other three cannot.
+ *
+ * ---------------------------------------------------------------------------
+ * ALGORITHMS THAT CANNOT DO ANY OF THIS
+ *
+ * Layers 3 and 4 are consumed by the `Base` and `VoltageControl` components of
+ * NRSystem, i.e. by the Newton-Raphson algorithms and nothing else. Fast-decoupled
+ * and Gauss-Seidel hold no NRSystem at all, so for them those two layers are work
+ * whose result nobody reads -- and layer 2's group step is worse than useless: it
+ * would take a bus out of PV and leave NOTHING to pin its magnitude, which is a
+ * converged, plausible and wrong answer rather than an error.
+ *
+ * So the whole thing is conditional on `BaseAlgo::supports_remote_voltage_control()`,
+ * passed to `build_groups` as `supports_voltage_control`. When it is false the plan
+ * stays empty and layer 2 produces the classical split, and it is `LSGrid::ac_pf`
+ * that refuses -- before any of this runs, and naming every offending element -- to
+ * solve a grid that actually has controllers with an algorithm that cannot honour
+ * them. See `list_unsupported`.
+ *
+ * The DC family is the one exception, and it is deliberate: its layer 2 keeps the
+ * group step whatever the AC algorithm can do, because that is what it has always
+ * done and BaseDCAlgo does read `pv`. See LSGrid::_build_into_cache.
  *
  * ---------------------------------------------------------------------------
  * LIFETIME
@@ -75,8 +99,8 @@ class HvdcLineContainer;
  * A plan is a member of SolverBusLayout, i.e. of a solver-side cache: it is one
  * picture of the grid in ONE bus labelling, exactly like the labelling, the
  * slack and the pv-pq split it sits next to, and it is built, reused and retired
- * with them. Both families carry layer 1 (`fillpv_pq` is one function, and its
- * rule does not change between them); only the AC family fills layers 2 and 3,
+ * with them. Both families carry layers 1 and 2 (the pv/pq split is one rule, and
+ * it does not change between them); only the AC family fills layers 3 and 4,
  * because a DC solve has no voltage control at all.
  *
  * A plan built against another labelling is not stale data, it is a different
@@ -84,7 +108,7 @@ class HvdcLineContainer;
  * not live in the NR extensions that consume it and is never carried across a
  * rebuild of the labelling -- see AlgoControl::need_recompute_voltage_control()
  * for what makes the cached one reusable, and LSGrid::_build_into_cache for
- * where the layers are built, around the pv-pq split they straddle.
+ * where the layers are built.
  */
 class LS2G_API VoltageControlPlan
 {
@@ -110,11 +134,50 @@ class LS2G_API VoltageControlPlan
          * is always a group controller) that switches the bus over to the bordered
          * formulation -- and then every local regulator on that bus, generator or
          * converter station, joins the group as a co-controller instead of pinning it.
+         *
+         * `supports_voltage_control` false (a fast-decoupled or Gauss-Seidel solve)
+         * leaves the set EMPTY, which is what makes layer 2 produce the classical
+         * split. It is not a shortcut past a real configuration: `LSGrid::ac_pf`
+         * refuses such a grid outright, see `list_unsupported`.
          */
         void build_groups(const GeneratorContainer & generators,
-                          const SvcContainer & svcs);
+                          const SvcContainer & svcs,
+                          bool supports_voltage_control = true);
 
         // ---- layer 2 -------------------------------------------------------------
+        /**
+         * The pv/pq split of one solved system, written into the caller's vectors
+         * (they live in the solver-side cache, next to the labelling they are
+         * expressed in -- this class owns the RULE, not the storage).
+         *
+         * Two steps. First every container says which buses it pins, through the
+         * `fillpv` each of them overrides -- that is the classical part, and it is
+         * why the containers arrive as a flat list: the rule is "ask all of them",
+         * not "ask these eight in this order".
+         *
+         * Then layer 1 takes back the buses a control GROUP regulates. The per-container
+         * pass only knows how to keep a controller's OWN bus out of PV (a generator
+         * regulating remotely does not claim its own bus); nothing there stops a LOCAL
+         * regulator sitting on somebody else's regulated bus from claiming it. When that
+         * happened the group's bordered voltage row found no Vm column to write its +1
+         * into -- a structurally empty row, hence a singular Jacobian -- so layer 4 had
+         * to reject the whole configuration ("regulates bus X which has no voltage (Vm)
+         * unknown") even though it is perfectly well posed: the local regulator simply
+         * belongs in the group, and the sharing row then supplies the equation that
+         * fixes the reactive split. Dropped from PV here, picked up as PQ, and enrolled
+         * by `build_controllers`.
+         *
+         * `build_groups` must have run first -- the controller list built afterwards is
+         * keyed on this very split, and both must come from one group layout.
+         */
+        void build_pv_pq(const std::vector<const GenericContainer *> & pv_sources,
+                         const SolverBusIdVect & id_me_to_solver,
+                         const GlobalBusIdVect & id_solver_to_me,
+                         const SolverBusIdVect & slack_bus_id_solver,
+                         SolverBusIdVect & bus_pv_out,
+                         SolverBusIdVect & bus_pq_out) const;
+
+        // ---- layer 3 -------------------------------------------------------------
         /**
          * The free-Vm slack buses, in the labelling passed in. `build_groups` must have
          * run against the same containers first -- this reads its result rather than
@@ -125,9 +188,9 @@ class LS2G_API VoltageControlPlan
                                  const GlobalBusIdVect & id_solver_to_me,
                                  const SolverBusIdVect & slack_bus_id_solver);
 
-        // ---- layer 3 -------------------------------------------------------------
+        // ---- layer 4 -------------------------------------------------------------
         /**
-         * The controller list. Both layers above must have been built against the same
+         * The controller list. Every layer above must have been built against the same
          * containers and the same labelling first. THROWS, with the messages the
          * configuration deserves, on what the v1 bordered formulation cannot express:
          * a controller whose own bus owns no Q equation, a regulated bus with no Vm
@@ -140,7 +203,7 @@ class LS2G_API VoltageControlPlan
                                const GlobalBusIdVect & id_solver_to_me,
                                const SolverBusIdVect & bus_pq);
 
-        // ---- layers 2 and 3, which is what a solve wants -------------------------
+        // ---- layers 3 and 4, which is what an AC solve wants ----------------------
         /**
          * `build_free_vm_slack` then `build_controllers`, in the only order that works.
          * AC only, and the caller says so by not calling this at all for a DC cache.
@@ -153,6 +216,30 @@ class LS2G_API VoltageControlPlan
                                const GlobalBusIdVect & id_solver_to_me,
                                const SolverBusIdVect & slack_bus_id_solver,
                                const SolverBusIdVect & bus_pq);
+
+        // ---- the guard an algorithm without the bordered block needs ---------------
+        /**
+         * Everything on this grid that would need the bordered block, so that an
+         * algorithm which does not implement it can refuse the grid by name rather
+         * than solve a system with a bus nothing pins.
+         *
+         * `build_groups` must have run first (with `supports_voltage_control` true,
+         * or this answers "nothing" by construction). A converter station is never
+         * an offender on its own -- it pins its bus the classical way unless a group
+         * already claims it -- but it is listed when a group does, because the user
+         * has to know which elements are affected, not only which ones caused it.
+         */
+        struct Unsupported {
+            std::vector<int> gen_ids;   ///< generators regulating a bus that is not their own
+            std::vector<int> svc_ids;   ///< voltage-mode SVCs (always group controllers)
+            std::vector<std::pair<int, int> > station_ids;  ///< (hvdc line id, side) enrolled in a group
+            [[nodiscard]] bool empty() const noexcept {
+                return gen_ids.empty() && svc_ids.empty() && station_ids.empty();
+            }
+        };
+        [[nodiscard]] Unsupported list_unsupported(const GeneratorContainer & generators,
+                                                   const SvcContainer & svcs,
+                                                   const HvdcLineContainer & hvdc_lines) const;
 
         // ---- what a solve reads --------------------------------------------------
         [[nodiscard]] const std::set<int> & group_controlled_buses() const noexcept {
@@ -207,8 +294,11 @@ class LS2G_API VoltageControlPlan
         void _group_and_emit(const std::vector<Raw> & raws);
 
         std::set<int> group_reg_buses_;      ///< layer 1, GRID bus ids
-        std::set<int> free_vm_slack_buses_;  ///< layer 2, SOLVER bus ids
-        VoltageControlSolverData controllers_;  ///< layer 3
+        std::set<int> free_vm_slack_buses_;  ///< layer 3, SOLVER bus ids
+        VoltageControlSolverData controllers_;  ///< layer 4
+        // layer 2 has no member: the split it produces belongs to the solver-side
+        // cache (SolverBusLayout::bus_pv / bus_pq), where everything downstream
+        // already reads it. This class owns the rule, not a second copy of the answer.
 };
 
 } // namespace ls2g

--- a/src/core/VoltageControlPlan.hpp
+++ b/src/core/VoltageControlPlan.hpp
@@ -135,6 +135,11 @@ class LS2G_API VoltageControlPlan
          * formulation -- and then every local regulator on that bus, generator or
          * converter station, joins the group as a co-controller instead of pinning it.
          *
+         * Stations are read by `build_controllers`, not here, and that is not an
+         * oversight: a station has no regulated bus of its own (it always regulates the
+         * bus it stands on), so it can never be the remote controller that CREATES a
+         * group -- only a member of one somebody else created. See the body.
+         *
          * `supports_voltage_control` false (a fast-decoupled or Gauss-Seidel solve)
          * leaves the set EMPTY, which is what makes layer 2 produce the classical
          * split. It is not a shortcut past a real configuration: `LSGrid::ac_pf`

--- a/src/core/VoltageControlPlan.hpp
+++ b/src/core/VoltageControlPlan.hpp
@@ -1,0 +1,216 @@
+// Copyright (c) 2026, RTE (https://www.rte-france.com)
+// See AUTHORS.txt
+// This Source Code Form is subject to the terms of the Mozilla Public License, version 2.0.
+// If a copy of the Mozilla Public License, version 2.0 was not distributed with this file,
+// you can obtain one at http://mozilla.org/MPL/2.0/.
+// SPDX-License-Identifier: MPL-2.0
+// This file is part of LightSim2grid, LightSim2grid implements a c++ backend targeting the Grid2Op platform.
+
+#ifndef VOLTAGE_CONTROL_PLAN_H
+#define VOLTAGE_CONTROL_PLAN_H
+
+#include <set>
+
+#include "TaggedIdVec.hpp"
+#include "Utils.hpp"
+#include "VoltageControlData.hpp"
+#include "ls2g_api.hpp"
+
+namespace ls2g {
+
+class GeneratorContainer;
+class SvcContainer;
+class HvdcLineContainer;
+
+/**
+ * Everything one AC solve needs to know about the "fancy" voltage controllers --
+ * remote-regulating generators, several machines regulating the same bus, and
+ * voltage-mode SVCs -- derived once, in one place, out of the element containers
+ * and one bus labelling.
+ *
+ * ---------------------------------------------------------------------------
+ * WHY THIS IS ONE OBJECT
+ *
+ * Three answers used to be re-derived independently, by three functions on
+ * LSGrid, each of them called from a different place in a powerflow:
+ *
+ *   get_group_controlled_buses()      -- fillpv_pq, while it is still building
+ *                                        the very labelling the other two need;
+ *   get_free_vm_slack_solver_buses()  -- Base::update_state, and again inside
+ *                                        fill_voltage_control_solver_data;
+ *   fill_voltage_control_solver_data()-- VoltageControl::update_state.
+ *
+ * They are not three answers, they are three LAYERS of one: the controller list
+ * is built out of the group layout and the free-Vm slack set, and the free-Vm
+ * slack set is built out of the group layout. Re-deriving each of them where it
+ * happened to be needed meant walking every generator of the grid three to four
+ * times per powerflow -- and, worse, it meant three separate opportunities for
+ * the layers to disagree, because each walk read the containers again and
+ * nothing said they had to agree.
+ *
+ * Built as one object they cannot: layer 2 is built from layer 1's own result,
+ * layer 3 from layer 2's, and the whole thing is built once and then read.
+ *
+ * ---------------------------------------------------------------------------
+ * THE THREE LAYERS, AND WHAT EACH NEEDS
+ *
+ *  1. `group_controlled_buses()` -- GRID bus ids. Reads only input data
+ *     (generators, SVCs), never the labelling, which is what lets `fillpv_pq`
+ *     ask for it while it is still deciding the pv-pq split.
+ *  2. `free_vm_slack_buses()`    -- SOLVER bus ids. Needs layer 1, the labelling
+ *     and the slack.
+ *  3. `controllers()`            -- the full VoltageControlSolverData, SOLVER bus
+ *     ids and per unit. Needs layers 1 and 2, the labelling and the pv-pq split.
+ *
+ * Hence one build entry point per layer: `build_groups` is layer 1 alone (all
+ * `fillpv_pq` can have and all it needs), `build_free_vm_slack` and
+ * `build_controllers` are the two that need the labelling, with
+ * `build_solver_side` as the pair of them in the only order that works.
+ * `build_controllers` throws, with the messages the configuration deserves, on
+ * what the v1 bordered formulation cannot express; the other two cannot fail.
+ *
+ * ---------------------------------------------------------------------------
+ * LIFETIME
+ *
+ * A plan is a member of SolverBusLayout, i.e. of a solver-side cache: it is one
+ * picture of the grid in ONE bus labelling, exactly like the labelling, the
+ * slack and the pv-pq split it sits next to, and it is built, reused and retired
+ * with them. Both families carry layer 1 (`fillpv_pq` is one function, and its
+ * rule does not change between them); only the AC family fills layers 2 and 3,
+ * because a DC solve has no voltage control at all.
+ *
+ * A plan built against another labelling is not stale data, it is a different
+ * grid: every bus id in it would silently mean another bus. That is why it does
+ * not live in the NR extensions that consume it and is never carried across a
+ * rebuild of the labelling -- see AlgoControl::need_recompute_voltage_control()
+ * for what makes the cached one reusable, and LSGrid::_build_into_cache for
+ * where the layers are built, around the pv-pq split they straddle.
+ */
+class LS2G_API VoltageControlPlan
+{
+    public:
+        VoltageControlPlan() = default;
+
+        /// back to "nothing known": every layer empty
+        void clear() noexcept;
+
+        // ---- layer 1 -----------------------------------------------------------
+        /**
+         * GRID-bus ids whose voltage magnitude is set by a control GROUP rather than
+         * by the classical PV treatment. A bus lands here as soon as an ACTIVE
+         * remote-regulating generator or an active voltage-mode SVC aims at it,
+         * because the group's bordered voltage row needs that bus to keep a Vm
+         * unknown (and hence a Q equation).
+         *
+         * Buses regulated ONLY by things standing on them -- local generators, or
+         * voltage-regulating hvdc converter stations -- are deliberately NOT
+         * included: several machines sharing a bus and all regulating it locally is
+         * the ordinary PV case, handled as before by the per-bus reactive
+         * redistribution. It is the arrival of a remote controller (or an SVC, which
+         * is always a group controller) that switches the bus over to the bordered
+         * formulation -- and then every local regulator on that bus, generator or
+         * converter station, joins the group as a co-controller instead of pinning it.
+         */
+        void build_groups(const GeneratorContainer & generators,
+                          const SvcContainer & svcs);
+
+        // ---- layer 2 -------------------------------------------------------------
+        /**
+         * The free-Vm slack buses, in the labelling passed in. `build_groups` must have
+         * run against the same containers first -- this reads its result rather than
+         * re-deriving it. Never throws: a slack bus either is locally pinned or is not.
+         */
+        void build_free_vm_slack(const GeneratorContainer & generators,
+                                 const SolverBusIdVect & id_me_to_solver,
+                                 const GlobalBusIdVect & id_solver_to_me,
+                                 const SolverBusIdVect & slack_bus_id_solver);
+
+        // ---- layer 3 -------------------------------------------------------------
+        /**
+         * The controller list. Both layers above must have been built against the same
+         * containers and the same labelling first. THROWS, with the messages the
+         * configuration deserves, on what the v1 bordered formulation cannot express:
+         * a controller whose own bus owns no Q equation, a regulated bus with no Vm
+         * unknown, conflicting setpoints inside one group, an SVC sharing its group.
+         */
+        void build_controllers(const GeneratorContainer & generators,
+                               const SvcContainer & svcs,
+                               const HvdcLineContainer & hvdc_lines,
+                               const SolverBusIdVect & id_me_to_solver,
+                               const GlobalBusIdVect & id_solver_to_me,
+                               const SolverBusIdVect & bus_pq);
+
+        // ---- layers 2 and 3, which is what a solve wants -------------------------
+        /**
+         * `build_free_vm_slack` then `build_controllers`, in the only order that works.
+         * AC only, and the caller says so by not calling this at all for a DC cache.
+         * `build_groups` must have run first, against the same containers.
+         */
+        void build_solver_side(const GeneratorContainer & generators,
+                               const SvcContainer & svcs,
+                               const HvdcLineContainer & hvdc_lines,
+                               const SolverBusIdVect & id_me_to_solver,
+                               const GlobalBusIdVect & id_solver_to_me,
+                               const SolverBusIdVect & slack_bus_id_solver,
+                               const SolverBusIdVect & bus_pq);
+
+        // ---- what a solve reads --------------------------------------------------
+        [[nodiscard]] const std::set<int> & group_controlled_buses() const noexcept {
+            return group_reg_buses_;
+        }
+        /**
+         * Solver-bus ids of the slack buses that need a free Vm unknown and a Q
+         * equation (added by the Base block of the NR system), i.e. every slack bus
+         * whose magnitude is NOT pinned by a local voltage-regulating generator.
+         * This covers distributed-slack participants whose generator is PQ
+         * (voltage_regulator_on == false), slack buses hosting a remote-voltage
+         * controller, and SVC-regulated slack buses. A slack bus that DOES host a
+         * local PV generator stays Vm-fixed (PV-like) with no Q equation.
+         */
+        [[nodiscard]] const std::set<int> & free_vm_slack_buses() const noexcept {
+            return free_vm_slack_buses_;
+        }
+        /// the bordered block's own data, as the VoltageControl extension consumes it
+        [[nodiscard]] const VoltageControlSolverData & controllers() const noexcept {
+            return controllers_;
+        }
+
+    private:
+        /// one candidate controller, before the grouping pass
+        struct Raw {
+            int bus;          ///< controller solver bus
+            int reg_bus;      ///< regulated solver bus
+            real_type v_set;  ///< pu
+            real_type slope;  ///< pu (0 except for a sloped SVC)
+            real_type weight; ///< sharing key
+            int kind;         ///< VoltageControlSolverData::Kind
+            int elem_id;
+        };
+
+        /// the three per-container passes that fill `raws`
+        void _collect_gen_controllers(const GeneratorContainer & generators,
+                                      const SolverBusIdVect & id_me_to_solver,
+                                      const std::vector<bool> & is_pq,
+                                      const std::vector<bool> & has_free_q,
+                                      std::vector<Raw> & raws) const;
+        void _collect_svc_controllers(const SvcContainer & svcs,
+                                      const SolverBusIdVect & id_me_to_solver,
+                                      const std::vector<bool> & is_pq,
+                                      const std::vector<bool> & has_free_q,
+                                      std::vector<Raw> & raws) const;
+        void _collect_station_controllers(const HvdcLineContainer & hvdc_lines,
+                                          const SolverBusIdVect & id_me_to_solver,
+                                          const std::vector<bool> & is_pq,
+                                          const std::vector<bool> & has_free_q,
+                                          std::vector<Raw> & raws) const;
+        /// group by regulated bus, check the setpoints agree, emit `controllers_`
+        void _group_and_emit(const std::vector<Raw> & raws);
+
+        std::set<int> group_reg_buses_;      ///< layer 1, GRID bus ids
+        std::set<int> free_vm_slack_buses_;  ///< layer 2, SOLVER bus ids
+        VoltageControlSolverData controllers_;  ///< layer 3
+};
+
+} // namespace ls2g
+
+#endif // VOLTAGE_CONTROL_PLAN_H

--- a/src/core/element_container/ConverterStationContainer.cpp
+++ b/src/core/element_container/ConverterStationContainer.cpp
@@ -153,9 +153,11 @@ void ConverterStationContainer::change_v(int station_id, real_type new_v_pu, Dua
     {
         solver_control.ac_algo_controler().tell_v_changed();
         solver_control.dc_algo_controler().tell_v_changed();
-        // v_set of the group this station belongs to, when a group claims its bus.
-        // AC only: a DC solve has no voltage control, hence no plan to invalidate.
-        solver_control.ac_algo_controler().tell_voltage_control_changed();
+        // Same as GeneratorContainer::change_v_nothrow: a setpoint is the one input of
+        // the voltage-control plan the pv/pq split does not read, so it needs a flag of
+        // its own -- and only for a station that regulates, target_vm_pu_ of one that
+        // does not being never read.
+        if(voltage_regulator_on_[station_id]) solver_control.ac_algo_controler().tell_voltage_control_changed();
         target_vm_pu_(station_id) = new_v_pu;
     }
 }
@@ -372,21 +374,27 @@ void ConverterStationContainer::_change_p(int station_id, real_type new_p, bool 
 
 bool ConverterStationContainer::_deactivate(int el_id, DualAlgoControl & solver_control) {
     if(!status_[el_id]) return false;  // nothing to do if it was already deactivated
+    // a station IS in Sbus (fillSbus_station stamps its active power, and its reactive
+    // personality when it does not regulate), so its status always moves the injections
     solver_control.ac_algo_controler().tell_recompute_sbus();
     solver_control.dc_algo_controler().tell_recompute_sbus();
-    solver_control.ac_algo_controler().tell_pv_changed();
-    solver_control.dc_algo_controler().tell_pv_changed();
-    solver_control.ac_algo_controler().tell_voltage_control_changed();  // a disconnected station is no longer a group member
+    // ... but only a REGULATING one pins a bus (fillpv skips the others), so only that
+    // one moves the pv/pq split -- and with it the voltage-control plan built on it
+    if(voltage_regulator_on_[el_id]){
+        solver_control.ac_algo_controler().tell_pv_changed();
+        solver_control.dc_algo_controler().tell_pv_changed();
+    }
     return true;
 }
 
 bool ConverterStationContainer::_reactivate(int el_id, DualAlgoControl & solver_control) {
     if(status_[el_id]) return false;  // nothing to do if station already connected
-    solver_control.ac_algo_controler().tell_recompute_sbus();
+    solver_control.ac_algo_controler().tell_recompute_sbus();  // see _deactivate
     solver_control.dc_algo_controler().tell_recompute_sbus();
-    solver_control.ac_algo_controler().tell_pv_changed();
-    solver_control.dc_algo_controler().tell_pv_changed();
-    solver_control.ac_algo_controler().tell_voltage_control_changed();  // ... and a reconnected one is one again
+    if(voltage_regulator_on_[el_id]){
+        solver_control.ac_algo_controler().tell_pv_changed();
+        solver_control.dc_algo_controler().tell_pv_changed();
+    }
     return true;
 }
 
@@ -399,7 +407,6 @@ bool ConverterStationContainer::_change_bus(int el_id, GridModelBusId new_bus_id
     if(voltage_regulator_on_[el_id]) {
         solver_control.ac_algo_controler().tell_pv_changed();
         solver_control.dc_algo_controler().tell_pv_changed();
-        solver_control.ac_algo_controler().tell_voltage_control_changed();  // the station's bus -- which is also the bus it regulates -- moved
     }
     return true;
 }

--- a/src/core/element_container/ConverterStationContainer.cpp
+++ b/src/core/element_container/ConverterStationContainer.cpp
@@ -153,6 +153,9 @@ void ConverterStationContainer::change_v(int station_id, real_type new_v_pu, Dua
     {
         solver_control.ac_algo_controler().tell_v_changed();
         solver_control.dc_algo_controler().tell_v_changed();
+        // v_set of the group this station belongs to, when a group claims its bus.
+        // AC only: a DC solve has no voltage control, hence no plan to invalidate.
+        solver_control.ac_algo_controler().tell_voltage_control_changed();
         target_vm_pu_(station_id) = new_v_pu;
     }
 }
@@ -373,6 +376,7 @@ bool ConverterStationContainer::_deactivate(int el_id, DualAlgoControl & solver_
     solver_control.dc_algo_controler().tell_recompute_sbus();
     solver_control.ac_algo_controler().tell_pv_changed();
     solver_control.dc_algo_controler().tell_pv_changed();
+    solver_control.ac_algo_controler().tell_voltage_control_changed();  // a disconnected station is no longer a group member
     return true;
 }
 
@@ -382,6 +386,7 @@ bool ConverterStationContainer::_reactivate(int el_id, DualAlgoControl & solver_
     solver_control.dc_algo_controler().tell_recompute_sbus();
     solver_control.ac_algo_controler().tell_pv_changed();
     solver_control.dc_algo_controler().tell_pv_changed();
+    solver_control.ac_algo_controler().tell_voltage_control_changed();  // ... and a reconnected one is one again
     return true;
 }
 
@@ -394,6 +399,7 @@ bool ConverterStationContainer::_change_bus(int el_id, GridModelBusId new_bus_id
     if(voltage_regulator_on_[el_id]) {
         solver_control.ac_algo_controler().tell_pv_changed();
         solver_control.dc_algo_controler().tell_pv_changed();
+        solver_control.ac_algo_controler().tell_voltage_control_changed();  // the station's bus -- which is also the bus it regulates -- moved
     }
     return true;
 }

--- a/src/core/element_container/GeneratorContainer.cpp
+++ b/src/core/element_container/GeneratorContainer.cpp
@@ -349,6 +349,11 @@ void GeneratorContainer::_change_p(int gen_id, real_type new_p, bool /*my_status
         if((pseudo_off_before && !pseudo_off_now) || 
            (!pseudo_off_before && pseudo_off_now)){
             solver_control.ac_algo_controler().tell_pv_changed(); solver_control.dc_algo_controler().tell_pv_changed();
+            // crossing p == 0 makes this generator start or stop being a voltage
+            // controller (gen_is_voltage_controller gates on is_pseudo_off), so the
+            // membership of its control group moves with it. AC only: a DC solve has
+            // no voltage control, hence no plan to invalidate.
+            solver_control.ac_algo_controler().tell_voltage_control_changed();
            }
     }
 }
@@ -356,6 +361,7 @@ void GeneratorContainer::_change_p(int gen_id, real_type new_p, bool /*my_status
 bool GeneratorContainer::_deactivate(int el_id, DualAlgoControl & solver_control) {
     if(!status_[el_id]) return false;  // nothing to do if it was already deactivated
     solver_control.ac_algo_controler().tell_recompute_sbus(); solver_control.dc_algo_controler().tell_recompute_sbus();
+    solver_control.ac_algo_controler().tell_voltage_control_changed();  // a disconnected generator regulates nothing
     if(voltage_regulator_on_[el_id]){ solver_control.ac_algo_controler().tell_pv_changed(); solver_control.dc_algo_controler().tell_pv_changed(); }
     if(!turnedoff_gen_pv_){ solver_control.ac_algo_controler().tell_pv_changed(); solver_control.dc_algo_controler().tell_pv_changed(); }
     if(gen_slackbus_[el_id]){ solver_control.ac_algo_controler().tell_slack_participate_changed(); solver_control.dc_algo_controler().tell_slack_participate_changed(); }
@@ -365,6 +371,7 @@ bool GeneratorContainer::_deactivate(int el_id, DualAlgoControl & solver_control
 bool GeneratorContainer::_reactivate(int el_id, DualAlgoControl & solver_control) {
     if(status_[el_id]) return false;  // nothing to do if gen already connected
     solver_control.ac_algo_controler().tell_recompute_sbus(); solver_control.dc_algo_controler().tell_recompute_sbus();
+    solver_control.ac_algo_controler().tell_voltage_control_changed();  // ... and a reconnected one regulates again
     if(voltage_regulator_on_[el_id]){ solver_control.ac_algo_controler().tell_pv_changed(); solver_control.dc_algo_controler().tell_pv_changed(); }
     if(!turnedoff_gen_pv_){ solver_control.ac_algo_controler().tell_pv_changed(); solver_control.dc_algo_controler().tell_pv_changed(); }
     if(gen_slackbus_[el_id]){ solver_control.ac_algo_controler().tell_slack_participate_changed(); solver_control.dc_algo_controler().tell_slack_participate_changed(); }
@@ -392,6 +399,7 @@ void GeneratorContainer::change_v_nothrow(int gen_id, real_type new_v_pu, DualAl
     if (abs(target_vm_pu_(gen_id) - new_v_pu) > _tol_equal_float)
     {
         solver_control.ac_algo_controler().tell_v_changed(); solver_control.dc_algo_controler().tell_v_changed();
+        solver_control.ac_algo_controler().tell_voltage_control_changed();  // v_set of the group this generator belongs to
         target_vm_pu_(gen_id) = new_v_pu;
     }
 }
@@ -416,6 +424,7 @@ bool GeneratorContainer::_change_bus(int el_id, GridModelBusId new_bus_id, DualA
     }
     solver_control.ac_algo_controler().tell_recompute_sbus(); solver_control.dc_algo_controler().tell_recompute_sbus();
     solver_control.ac_algo_controler().tell_one_el_changed_bus(); solver_control.dc_algo_controler().tell_one_el_changed_bus();
+    solver_control.ac_algo_controler().tell_voltage_control_changed();  // the controller bus, and a LOCAL regulator's regulated bus, both moved
     if(voltage_regulator_on_[el_id]) { solver_control.ac_algo_controler().tell_pv_changed(); solver_control.dc_algo_controler().tell_pv_changed(); }
     if(gen_slackbus_[el_id]) { solver_control.ac_algo_controler().tell_slack_participate_changed(); solver_control.dc_algo_controler().tell_slack_participate_changed(); }
     return true;

--- a/src/core/element_container/GeneratorContainer.cpp
+++ b/src/core/element_container/GeneratorContainer.cpp
@@ -348,12 +348,11 @@ void GeneratorContainer::_change_p(int gen_id, real_type new_p, bool /*my_status
         bool pseudo_off_now = abs(new_p) < _tol_equal_float;
         if((pseudo_off_before && !pseudo_off_now) || 
            (!pseudo_off_before && pseudo_off_now)){
+            // (crossing p == 0 also makes this generator start or stop being a voltage
+            // controller -- gen_is_voltage_controller gates on is_pseudo_off -- which
+            // the pv/pq split, and so the voltage-control plan built around it, already
+            // follows from the flag above.)
             solver_control.ac_algo_controler().tell_pv_changed(); solver_control.dc_algo_controler().tell_pv_changed();
-            // crossing p == 0 makes this generator start or stop being a voltage
-            // controller (gen_is_voltage_controller gates on is_pseudo_off), so the
-            // membership of its control group moves with it. AC only: a DC solve has
-            // no voltage control, hence no plan to invalidate.
-            solver_control.ac_algo_controler().tell_voltage_control_changed();
            }
     }
 }
@@ -361,7 +360,6 @@ void GeneratorContainer::_change_p(int gen_id, real_type new_p, bool /*my_status
 bool GeneratorContainer::_deactivate(int el_id, DualAlgoControl & solver_control) {
     if(!status_[el_id]) return false;  // nothing to do if it was already deactivated
     solver_control.ac_algo_controler().tell_recompute_sbus(); solver_control.dc_algo_controler().tell_recompute_sbus();
-    solver_control.ac_algo_controler().tell_voltage_control_changed();  // a disconnected generator regulates nothing
     if(voltage_regulator_on_[el_id]){ solver_control.ac_algo_controler().tell_pv_changed(); solver_control.dc_algo_controler().tell_pv_changed(); }
     if(!turnedoff_gen_pv_){ solver_control.ac_algo_controler().tell_pv_changed(); solver_control.dc_algo_controler().tell_pv_changed(); }
     if(gen_slackbus_[el_id]){ solver_control.ac_algo_controler().tell_slack_participate_changed(); solver_control.dc_algo_controler().tell_slack_participate_changed(); }
@@ -371,7 +369,6 @@ bool GeneratorContainer::_deactivate(int el_id, DualAlgoControl & solver_control
 bool GeneratorContainer::_reactivate(int el_id, DualAlgoControl & solver_control) {
     if(status_[el_id]) return false;  // nothing to do if gen already connected
     solver_control.ac_algo_controler().tell_recompute_sbus(); solver_control.dc_algo_controler().tell_recompute_sbus();
-    solver_control.ac_algo_controler().tell_voltage_control_changed();  // ... and a reconnected one regulates again
     if(voltage_regulator_on_[el_id]){ solver_control.ac_algo_controler().tell_pv_changed(); solver_control.dc_algo_controler().tell_pv_changed(); }
     if(!turnedoff_gen_pv_){ solver_control.ac_algo_controler().tell_pv_changed(); solver_control.dc_algo_controler().tell_pv_changed(); }
     if(gen_slackbus_[el_id]){ solver_control.ac_algo_controler().tell_slack_participate_changed(); solver_control.dc_algo_controler().tell_slack_participate_changed(); }
@@ -399,7 +396,11 @@ void GeneratorContainer::change_v_nothrow(int gen_id, real_type new_v_pu, DualAl
     if (abs(target_vm_pu_(gen_id) - new_v_pu) > _tol_equal_float)
     {
         solver_control.ac_algo_controler().tell_v_changed(); solver_control.dc_algo_controler().tell_v_changed();
-        solver_control.ac_algo_controler().tell_voltage_control_changed();  // v_set of the group this generator belongs to
+        // A setpoint is the one input of the voltage-control plan the pv/pq split does
+        // not read: moving it changes no bus' class at all (the regulated bus of a
+        // group stays PQ), so nothing else would notice. Only for a generator that
+        // regulates -- target_vm_pu_ of one that does not is never read.
+        if(voltage_regulator_on_[gen_id]) solver_control.ac_algo_controler().tell_voltage_control_changed();
         target_vm_pu_(gen_id) = new_v_pu;
     }
 }
@@ -424,7 +425,6 @@ bool GeneratorContainer::_change_bus(int el_id, GridModelBusId new_bus_id, DualA
     }
     solver_control.ac_algo_controler().tell_recompute_sbus(); solver_control.dc_algo_controler().tell_recompute_sbus();
     solver_control.ac_algo_controler().tell_one_el_changed_bus(); solver_control.dc_algo_controler().tell_one_el_changed_bus();
-    solver_control.ac_algo_controler().tell_voltage_control_changed();  // the controller bus, and a LOCAL regulator's regulated bus, both moved
     if(voltage_regulator_on_[el_id]) { solver_control.ac_algo_controler().tell_pv_changed(); solver_control.dc_algo_controler().tell_pv_changed(); }
     if(gen_slackbus_[el_id]) { solver_control.ac_algo_controler().tell_slack_participate_changed(); solver_control.dc_algo_controler().tell_slack_participate_changed(); }
     return true;

--- a/src/core/element_container/GeneratorContainer.hpp
+++ b/src/core/element_container/GeneratorContainer.hpp
@@ -114,7 +114,19 @@ class LS2G_API GeneratorContainer final: public OneSideContainer_PQ, public Iter
         void add_slackbus(int gen_id, real_type weight, DualAlgoControl & solver_control){
             // TODO DEBUG MODE
             if(weight <= 0.) throw std::runtime_error("GeneratorContainer::add_slackbus Cannot assign a negative (<=0) weight to the slack bus.");
-            if(!gen_slackbus_[gen_id]){ solver_control.ac_algo_controler().tell_slack_participate_changed(); solver_control.dc_algo_controler().tell_slack_participate_changed(); }
+            if(!gen_slackbus_[gen_id]){
+                solver_control.ac_algo_controler().tell_slack_participate_changed(); solver_control.dc_algo_controler().tell_slack_participate_changed();
+                // is_pseudo_off() answers false for a slack generator whatever its
+                // active power, and a pseudo-off generator is not a voltage
+                // controller -- so taking the slack role changes the control groups.
+                // Only the role: once it is held, the WEIGHT is irrelevant there
+                // (is_pseudo_off returns on gen_slackbus_ before it looks at it), and
+                // this is called for every generator on every step when the
+                // distributed slack is on, so raising it unconditionally would retire
+                // the voltage-control plan on every step for nothing. AC only: a DC
+                // solve has no voltage control, hence no plan to invalidate.
+                solver_control.ac_algo_controler().tell_voltage_control_changed();
+            }
             gen_slackbus_[gen_id] = true;
             if(abs(gen_slack_weight_[gen_id] - weight) > _tol_equal_float){
                 solver_control.ac_algo_controler().tell_slack_weight_changed(); solver_control.dc_algo_controler().tell_slack_weight_changed();
@@ -122,8 +134,14 @@ class LS2G_API GeneratorContainer final: public OneSideContainer_PQ, public Iter
             }
         }
         void remove_slackbus(int gen_id, DualAlgoControl & solver_control){
-            if(gen_slackbus_[gen_id]){ solver_control.ac_algo_controler().tell_slack_participate_changed(); solver_control.dc_algo_controler().tell_slack_participate_changed(); }
-            if(abs(gen_slack_weight_[gen_id]) > _tol_equal_float){ solver_control.ac_algo_controler().tell_slack_weight_changed(); solver_control.dc_algo_controler().tell_slack_weight_changed(); }
+            const bool was_slack = gen_slackbus_[gen_id];
+            const bool had_weight = abs(gen_slack_weight_[gen_id]) > _tol_equal_float;
+            if(was_slack){ solver_control.ac_algo_controler().tell_slack_participate_changed(); solver_control.dc_algo_controler().tell_slack_participate_changed(); }
+            if(had_weight){ solver_control.ac_algo_controler().tell_slack_weight_changed(); solver_control.dc_algo_controler().tell_slack_weight_changed(); }
+            // giving up the slack role, or the weight that stood in for it, can make
+            // this generator pseudo-off and so stop it being a voltage controller.
+            // Conditional for the same reason as add_slackbus above.
+            if(was_slack || had_weight) solver_control.ac_algo_controler().tell_voltage_control_changed();
             gen_slackbus_[gen_id] = false;
             gen_slack_weight_[gen_id] = 0.;
         }
@@ -198,11 +216,13 @@ class LS2G_API GeneratorContainer final: public OneSideContainer_PQ, public Iter
         void turnedoff_no_pv(DualAlgoControl & solver_control){
             solver_control.ac_algo_controler().tell_slack_participate_changed(); solver_control.dc_algo_controler().tell_slack_participate_changed();
             solver_control.ac_algo_controler().tell_slack_weight_changed(); solver_control.dc_algo_controler().tell_slack_weight_changed();
+            solver_control.ac_algo_controler().tell_voltage_control_changed();  // turnedoff_gen_pv_ gates gen_is_voltage_controller
             turnedoff_gen_pv_=false;  // turned off generators are not pv. This is NOT the default.
             }  
         void turnedoff_pv(DualAlgoControl & solver_control){
             solver_control.ac_algo_controler().tell_slack_participate_changed(); solver_control.dc_algo_controler().tell_slack_participate_changed();
             solver_control.ac_algo_controler().tell_slack_weight_changed(); solver_control.dc_algo_controler().tell_slack_weight_changed();
+            solver_control.ac_algo_controler().tell_voltage_control_changed();  // turnedoff_gen_pv_ gates gen_is_voltage_controller
             turnedoff_gen_pv_=true;  // turned off generators are pv. This is the default.
             }  
         bool get_turnedoff_gen_pv() const {return turnedoff_gen_pv_;}
@@ -227,6 +247,7 @@ class LS2G_API GeneratorContainer final: public OneSideContainer_PQ, public Iter
             if(regulated_bus_id_(gen_id) != bus_id){
                 regulated_bus_id_(gen_id) = bus_id;
                 solver_control.ac_algo_controler().tell_pv_changed();  // groups are rebuilt on topology init
+                solver_control.ac_algo_controler().tell_voltage_control_changed();  // this IS the group layout
                 solver_control.ac_algo_controler().tell_recompute_sbus();
                 solver_control.dc_algo_controler().tell_pv_changed();  // groups are rebuilt on topology init
                 solver_control.dc_algo_controler().tell_recompute_sbus();

--- a/src/core/element_container/GeneratorContainer.hpp
+++ b/src/core/element_container/GeneratorContainer.hpp
@@ -114,11 +114,22 @@ class LS2G_API GeneratorContainer final: public OneSideContainer_PQ, public Iter
         void add_slackbus(int gen_id, real_type weight, DualAlgoControl & solver_control){
             // TODO DEBUG MODE
             if(weight <= 0.) throw std::runtime_error("GeneratorContainer::add_slackbus Cannot assign a negative (<=0) weight to the slack bus.");
-            // (taking the slack role does change who is a voltage controller --
-            // is_pseudo_off() answers false for a slack generator whatever its active
-            // power -- but tell_slack_participate_changed() above already rebuilds the
-            // pv/pq split, and the voltage-control plan is built around that split. See
-            // AlgoControl::need_recompute_voltage_control.)
+            // Why `tell_slack_participate_changed()` and nothing about voltage: taking
+            // the slack role is an ACTIVE-power role, but the pv/pq split reads the
+            // slack set directly -- `fillpv` skips a bus that is in
+            // `slack_bus_id_solver` ("slack bus is not PV"), and the PQ loop right
+            // after it skips it too -- so a bus joining or leaving the slack set moves
+            // the split, whatever it does to voltage. That flag is what says so, and
+            // it is measured, not assumed: see the `[pv_pq]` cases in
+            // test_cache_reuse.cpp, which reach a state where it is the only term
+            // raised and fail if it is dropped.
+            //
+            // The voltage side needs no flag of its own for the same reason. It is
+            // real but secondary -- `is_pseudo_off()` answers false for a slack
+            // generator whatever its active power, so a zero-P slack generator IS a
+            // voltage controller where an ordinary one would not be -- and the
+            // voltage-control plan is built around the split this same flag rebuilds.
+            // See AlgoControl::need_recompute_voltage_control.
             if(!gen_slackbus_[gen_id]){ solver_control.ac_algo_controler().tell_slack_participate_changed(); solver_control.dc_algo_controler().tell_slack_participate_changed(); }
             gen_slackbus_[gen_id] = true;
             if(abs(gen_slack_weight_[gen_id] - weight) > _tol_equal_float){

--- a/src/core/element_container/GeneratorContainer.hpp
+++ b/src/core/element_container/GeneratorContainer.hpp
@@ -114,19 +114,12 @@ class LS2G_API GeneratorContainer final: public OneSideContainer_PQ, public Iter
         void add_slackbus(int gen_id, real_type weight, DualAlgoControl & solver_control){
             // TODO DEBUG MODE
             if(weight <= 0.) throw std::runtime_error("GeneratorContainer::add_slackbus Cannot assign a negative (<=0) weight to the slack bus.");
-            if(!gen_slackbus_[gen_id]){
-                solver_control.ac_algo_controler().tell_slack_participate_changed(); solver_control.dc_algo_controler().tell_slack_participate_changed();
-                // is_pseudo_off() answers false for a slack generator whatever its
-                // active power, and a pseudo-off generator is not a voltage
-                // controller -- so taking the slack role changes the control groups.
-                // Only the role: once it is held, the WEIGHT is irrelevant there
-                // (is_pseudo_off returns on gen_slackbus_ before it looks at it), and
-                // this is called for every generator on every step when the
-                // distributed slack is on, so raising it unconditionally would retire
-                // the voltage-control plan on every step for nothing. AC only: a DC
-                // solve has no voltage control, hence no plan to invalidate.
-                solver_control.ac_algo_controler().tell_voltage_control_changed();
-            }
+            // (taking the slack role does change who is a voltage controller --
+            // is_pseudo_off() answers false for a slack generator whatever its active
+            // power -- but tell_slack_participate_changed() above already rebuilds the
+            // pv/pq split, and the voltage-control plan is built around that split. See
+            // AlgoControl::need_recompute_voltage_control.)
+            if(!gen_slackbus_[gen_id]){ solver_control.ac_algo_controler().tell_slack_participate_changed(); solver_control.dc_algo_controler().tell_slack_participate_changed(); }
             gen_slackbus_[gen_id] = true;
             if(abs(gen_slack_weight_[gen_id] - weight) > _tol_equal_float){
                 solver_control.ac_algo_controler().tell_slack_weight_changed(); solver_control.dc_algo_controler().tell_slack_weight_changed();
@@ -134,14 +127,8 @@ class LS2G_API GeneratorContainer final: public OneSideContainer_PQ, public Iter
             }
         }
         void remove_slackbus(int gen_id, DualAlgoControl & solver_control){
-            const bool was_slack = gen_slackbus_[gen_id];
-            const bool had_weight = abs(gen_slack_weight_[gen_id]) > _tol_equal_float;
-            if(was_slack){ solver_control.ac_algo_controler().tell_slack_participate_changed(); solver_control.dc_algo_controler().tell_slack_participate_changed(); }
-            if(had_weight){ solver_control.ac_algo_controler().tell_slack_weight_changed(); solver_control.dc_algo_controler().tell_slack_weight_changed(); }
-            // giving up the slack role, or the weight that stood in for it, can make
-            // this generator pseudo-off and so stop it being a voltage controller.
-            // Conditional for the same reason as add_slackbus above.
-            if(was_slack || had_weight) solver_control.ac_algo_controler().tell_voltage_control_changed();
+            if(gen_slackbus_[gen_id]){ solver_control.ac_algo_controler().tell_slack_participate_changed(); solver_control.dc_algo_controler().tell_slack_participate_changed(); }
+            if(abs(gen_slack_weight_[gen_id]) > _tol_equal_float){ solver_control.ac_algo_controler().tell_slack_weight_changed(); solver_control.dc_algo_controler().tell_slack_weight_changed(); }
             gen_slackbus_[gen_id] = false;
             gen_slack_weight_[gen_id] = 0.;
         }
@@ -216,13 +203,11 @@ class LS2G_API GeneratorContainer final: public OneSideContainer_PQ, public Iter
         void turnedoff_no_pv(DualAlgoControl & solver_control){
             solver_control.ac_algo_controler().tell_slack_participate_changed(); solver_control.dc_algo_controler().tell_slack_participate_changed();
             solver_control.ac_algo_controler().tell_slack_weight_changed(); solver_control.dc_algo_controler().tell_slack_weight_changed();
-            solver_control.ac_algo_controler().tell_voltage_control_changed();  // turnedoff_gen_pv_ gates gen_is_voltage_controller
             turnedoff_gen_pv_=false;  // turned off generators are not pv. This is NOT the default.
             }  
         void turnedoff_pv(DualAlgoControl & solver_control){
             solver_control.ac_algo_controler().tell_slack_participate_changed(); solver_control.dc_algo_controler().tell_slack_participate_changed();
             solver_control.ac_algo_controler().tell_slack_weight_changed(); solver_control.dc_algo_controler().tell_slack_weight_changed();
-            solver_control.ac_algo_controler().tell_voltage_control_changed();  // turnedoff_gen_pv_ gates gen_is_voltage_controller
             turnedoff_gen_pv_=true;  // turned off generators are pv. This is the default.
             }  
         bool get_turnedoff_gen_pv() const {return turnedoff_gen_pv_;}
@@ -246,11 +231,20 @@ class LS2G_API GeneratorContainer final: public OneSideContainer_PQ, public Iter
             _check_in_range(gen_id, regulated_bus_id_, "set_regulated_bus");
             if(regulated_bus_id_(gen_id) != bus_id){
                 regulated_bus_id_(gen_id) = bus_id;
-                solver_control.ac_algo_controler().tell_pv_changed();  // groups are rebuilt on topology init
-                solver_control.ac_algo_controler().tell_voltage_control_changed();  // this IS the group layout
-                solver_control.ac_algo_controler().tell_recompute_sbus();
-                solver_control.dc_algo_controler().tell_pv_changed();  // groups are rebuilt on topology init
-                solver_control.dc_algo_controler().tell_recompute_sbus();
+                // Only a generator that actually regulates reads this field: it decides
+                // whether the machine pins its own bus (PV) or joins a control group at
+                // another one, which is the pv/pq split and, through it, the whole
+                // voltage-control plan. For a non-regulating generator the value is
+                // stored and nothing else changes.
+                //
+                // No tell_recompute_sbus() (there used to be one): GeneratorContainer::
+                // fillSbus never reads regulated_bus_id_, and what it does read of a
+                // regulating generator -- target_p only, the reactive being free -- is
+                // the same either way.
+                if(voltage_regulator_on_[gen_id]){
+                    solver_control.ac_algo_controler().tell_pv_changed();
+                    solver_control.dc_algo_controler().tell_pv_changed();
+                }
             }
         }
         // true iff this generator is an ACTIVE remote voltage controller (joins a

--- a/src/core/element_container/SvcContainer.cpp
+++ b/src/core/element_container/SvcContainer.cpp
@@ -228,6 +228,10 @@ bool SvcContainer::_deactivate(int svc_id, DualAlgoControl & solver_control)
         if(regulation_mode_(svc_id) == RegulationMode::VOLTAGE){
             solver_control.ac_algo_controler().tell_pv_changed();
             solver_control.dc_algo_controler().tell_pv_changed();
+            // a voltage-mode SVC is ALWAYS a group controller, so connecting or
+            // disconnecting one creates or dissolves the group at the bus it
+            // regulates. AC only: a DC solve has no voltage control at all.
+            solver_control.ac_algo_controler().tell_voltage_control_changed();
         }
         return true;
     }
@@ -244,6 +248,10 @@ bool SvcContainer::_reactivate(int svc_id, DualAlgoControl & solver_control)
         if(regulation_mode_(svc_id) == RegulationMode::VOLTAGE){
             solver_control.ac_algo_controler().tell_pv_changed();
             solver_control.dc_algo_controler().tell_pv_changed();
+            // a voltage-mode SVC is ALWAYS a group controller, so connecting or
+            // disconnecting one creates or dissolves the group at the bus it
+            // regulates. AC only: a DC solve has no voltage control at all.
+            solver_control.ac_algo_controler().tell_voltage_control_changed();
         }
         return true;
     }
@@ -271,6 +279,7 @@ bool SvcContainer::_change_bus(int svc_id, GridModelBusId new_bus_id, DualAlgoCo
     if(regulation_mode_(svc_id) == RegulationMode::VOLTAGE){
         solver_control.ac_algo_controler().tell_pv_changed();
         solver_control.dc_algo_controler().tell_pv_changed();
+        solver_control.ac_algo_controler().tell_voltage_control_changed();  // the controller bus, and its regulated bus when local, moved
     }
     return true;
 }

--- a/src/core/element_container/SvcContainer.cpp
+++ b/src/core/element_container/SvcContainer.cpp
@@ -228,10 +228,10 @@ bool SvcContainer::_deactivate(int svc_id, DualAlgoControl & solver_control)
         if(regulation_mode_(svc_id) == RegulationMode::VOLTAGE){
             solver_control.ac_algo_controler().tell_pv_changed();
             solver_control.dc_algo_controler().tell_pv_changed();
-            // a voltage-mode SVC is ALWAYS a group controller, so connecting or
-            // disconnecting one creates or dissolves the group at the bus it
-            // regulates. AC only: a DC solve has no voltage control at all.
-            solver_control.ac_algo_controler().tell_voltage_control_changed();
+            // (a voltage-mode SVC is ALWAYS a group controller, so this creates or
+            // dissolves the group at the bus it regulates -- which the pv/pq split,
+            // and the voltage-control plan built around it, follow from the flags
+            // above.)
         }
         return true;
     }
@@ -248,10 +248,10 @@ bool SvcContainer::_reactivate(int svc_id, DualAlgoControl & solver_control)
         if(regulation_mode_(svc_id) == RegulationMode::VOLTAGE){
             solver_control.ac_algo_controler().tell_pv_changed();
             solver_control.dc_algo_controler().tell_pv_changed();
-            // a voltage-mode SVC is ALWAYS a group controller, so connecting or
-            // disconnecting one creates or dissolves the group at the bus it
-            // regulates. AC only: a DC solve has no voltage control at all.
-            solver_control.ac_algo_controler().tell_voltage_control_changed();
+            // (a voltage-mode SVC is ALWAYS a group controller, so this creates or
+            // dissolves the group at the bus it regulates -- which the pv/pq split,
+            // and the voltage-control plan built around it, follow from the flags
+            // above.)
         }
         return true;
     }
@@ -279,7 +279,6 @@ bool SvcContainer::_change_bus(int svc_id, GridModelBusId new_bus_id, DualAlgoCo
     if(regulation_mode_(svc_id) == RegulationMode::VOLTAGE){
         solver_control.ac_algo_controler().tell_pv_changed();
         solver_control.dc_algo_controler().tell_pv_changed();
-        solver_control.ac_algo_controler().tell_voltage_control_changed();  // the controller bus, and its regulated bus when local, moved
     }
     return true;
 }

--- a/src/core/powerflow_algorithm/NRSystemBase.cpp
+++ b/src/core/powerflow_algorithm/NRSystemBase.cpp
@@ -29,11 +29,18 @@ void Base::update_state(
 {
     // Slack buses not pinned by a LOCAL voltage-regulating generator need a
     // free Vm unknown + Q equation (added in register_in), exactly like an
-    // ordinary PQ bus. See LSGrid::get_free_vm_slack_solver_buses for the
+    // ordinary PQ bus. See VoltageControlPlan::free_vm_slack_buses for the
     // exact criterion (GeneratorContainer::gen_is_local_voltage_controller).
+    //
+    // READ, not re-derived: this is layer 2 of the plan the grid built into its AC
+    // cache during pre_process_solver, in the very labelling this solve runs in.
+    // Deriving it here walked every generator of the grid a second time (and
+    // VoltageControl::update_state walked them a third and a fourth), for an answer
+    // that cannot have changed since -- nothing touches the grid between
+    // pre_process_solver and compute_pf.
     free_vm_slack_buses_.clear();
     if (lsgrid_ptr != nullptr)
-        free_vm_slack_buses_ = lsgrid_ptr->get_free_vm_slack_solver_buses();
+        free_vm_slack_buses_ = lsgrid_ptr->get_ac_voltage_control_plan().free_vm_slack_buses();
 }
 
 } // namespace ls2g

--- a/src/core/powerflow_algorithm/NRSystemVoltageControl.cpp
+++ b/src/core/powerflow_algorithm/NRSystemVoltageControl.cpp
@@ -22,8 +22,15 @@ void VoltageControl::update_state(
     const Eigen::Ref<const RealVect> & /*slack_weights*/
 )
 {
+    // READ, not re-derived: layer 3 of the plan the grid built into its AC cache
+    // during pre_process_solver (see LSGrid::_build_into_cache). Building it here
+    // meant walking every generator, SVC and converter station of the grid a second
+    // time per solve -- plus the free-Vm slack pass a third -- for an answer that
+    // cannot have changed since. It also means the controller list and the pv-pq
+    // split it is keyed on are now built from one another rather than from two
+    // independent walks of the containers.
     data_.clear();
-    if(lsgrid_ptr != nullptr) lsgrid_ptr->fill_voltage_control_solver_data(data_, true);
+    if(lsgrid_ptr != nullptr) data_ = lsgrid_ptr->get_ac_voltage_control_plan().controllers();
     my_size_ = data_.n_controllers();
     // per-solve init: the reactive injection state starts at 0 (gen convention)
     q_ = RealVect::Zero(my_size_);

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -75,6 +75,7 @@ add_executable(lightsim2grid_unit_tests
     test_powerflow_algorithm.cpp
     test_fdpf_algorithm.cpp
     test_voltage_control_reclassify.cpp
+    test_voltage_control_plan_cache.cpp
     test_batch_voltage_control.cpp
     test_timeseries_sbus.cpp
     test_injection_sweep.cpp

--- a/src/tests/test_cache_reuse.cpp
+++ b/src/tests/test_cache_reuse.cpp
@@ -813,10 +813,11 @@ TEST_CASE("a divergence recovers under every built-in AC algorithm", "[LSGrid][c
     // check_solution() is thrown into the sequence on purpose: it runs the same
     // pre-processing without ever calling the algorithm, so it must not consume
     // the "rebuild your internals" the diverged solve asked for.
-    // The fast-decoupled solvers do not support the hvdc angle droop that line 1
-    // of this grid has enabled: disconnect it, on the test grid and on its
-    // reference alike.
-    const auto disable_droop = [](LSGrid & g){ g.deactivate_dcline(1); };
+    // The fast-decoupled solvers support neither the hvdc angle droop that line 1
+    // of this grid has enabled nor the voltage-mode SVC it carries (they hold no
+    // NRSystem, so no Hvdc and no VoltageControl extension); ac_pf refuses both by
+    // name. Disconnect them, on the test grid and on its reference alike.
+    const auto disable_droop = [](LSGrid & g){ g.deactivate_dcline(1); g.deactivate_svc(0); };
     for(const auto algo : {AlgorithmType::NR_SparseLU,
                            AlgorithmType::NRSing_SparseLU,
                            AlgorithmType::FDPF_XB_SparseLU,
@@ -888,11 +889,14 @@ namespace {
 class ThrowingAcAlgo : public ls2g::BaseAlgo {
 public:
     ThrowingAcAlgo() : ls2g::BaseAlgo(/*is_ac=*/true) {}
-    // ac_pf rejects an angle-droop grid handed to a solver that cannot do droop,
-    // and the exotic test grid has three hvdc lines. That rejection happens BEFORE
-    // the solve begins -- nothing has been touched yet, so nothing needs
-    // invalidating -- which is exactly the throw this test must NOT be measuring.
+    // ac_pf has two pre-flight guards: it rejects an angle-droop grid handed to a
+    // solver that cannot do droop, and a voltage-control one handed to a solver with
+    // no bordered block. The exotic test grid has three hvdc lines AND a voltage-mode
+    // SVC, so both would fire. They fire BEFORE the solve begins -- nothing has been
+    // touched yet, so nothing needs invalidating -- which is exactly the throw this
+    // test must NOT be measuring. These doubles stand in for a full-featured solver.
     bool supports_hvdc_droop() const noexcept override { return true; }
+    bool supports_remote_voltage_control() const noexcept override { return true; }
     bool compute_pf(const ls2g::EigenRefConstCplxSpMat & /*Ybus*/,
                     const Eigen::Ref<const CplxVect> & /*V*/,
                     const Eigen::Ref<const CplxVect> & /*Sbus*/,
@@ -912,6 +916,7 @@ class WrongSizeAcAlgo : public ls2g::BaseAlgo {
 public:
     WrongSizeAcAlgo() : ls2g::BaseAlgo(/*is_ac=*/true) {}
     bool supports_hvdc_droop() const noexcept override { return true; }  // see ThrowingAcAlgo
+    bool supports_remote_voltage_control() const noexcept override { return true; }  // idem
     bool compute_pf(const ls2g::EigenRefConstCplxSpMat & /*Ybus*/,
                     const Eigen::Ref<const CplxVect> & V,
                     const Eigen::Ref<const CplxVect> & /*Sbus*/,
@@ -959,6 +964,7 @@ class FailsOnSecondCallAlgo : public ls2g::BaseAlgo {
 public:
     FailsOnSecondCallAlgo() : ls2g::BaseAlgo(/*is_ac=*/true) {}
     bool supports_hvdc_droop() const noexcept override { return true; }  // see ThrowingAcAlgo
+    bool supports_remote_voltage_control() const noexcept override { return true; }  // idem
     bool compute_pf(const ls2g::EigenRefConstCplxSpMat & /*Ybus*/,
                     const Eigen::Ref<const CplxVect> & V,
                     const Eigen::Ref<const CplxVect> & /*Sbus*/,

--- a/src/tests/test_cache_reuse.cpp
+++ b/src/tests/test_cache_reuse.cpp
@@ -1127,3 +1127,182 @@ TEST_CASE("a powerflow that throws leaves both families needing a full rebuild",
         CHECK_FALSE(grid.get_dc_algo_controler().need_reset_solver());
     }
 }
+
+// ---------------------------------------------------------------------------
+// 8. which terms does need_recompute_pv_pq() actually need?
+// ---------------------------------------------------------------------------
+//
+// `AlgoControl::need_recompute_pv_pq()` names the reasons the pv/pq split -- and so
+// the voltage-control plan built around it -- is rebuilt. Two terms were disputed in
+// review: `ybus_change_sparsity_pattern_` (raised when a branch is reconnected or one
+// of its ends is moved) and `slack_participate_changed_` (a slack that is not the
+// reference bus: what has it to do with the split?).
+//
+// An argument is not evidence, so: evidence. The only way to attribute a rebuild to
+// ONE term is to reach a state where that term is raised and the other five are not
+// -- otherwise the neighbour does the work and the term under test is redundant
+// whatever the physics says. So each case below asserts the whole vector of six
+// first, then does the comparison:
+//
+//   * solve, so the cache describes the grid;
+//   * apply the action, and check exactly which terms it raised;
+//   * solve WARM (on the cache the action left behind);
+//   * throw the cache away and solve COLD;
+//   * require the two answers to agree.
+//
+// A term still IN the predicate makes both paths rebuild, so the comparison is
+// trivially true and the case is a guard: it fails the day the term is dropped by
+// someone who did not check. A term that has been dropped makes the warm path really
+// reuse the split, and the case is a live regression test. The verdict was reached by
+// building the predicate both ways and running exactly these cases against each:
+//
+//   dropping `ybus_change_sparsity_pattern_`  -> both cases still pass  -> dropped
+//   dropping `slack_participate_changed_`     -> both cases fail        -> kept
+//
+// so the first TEST_CASE below is now live and the second is a guard.
+//
+// (`pq_changed_` is a seventh question that answers itself: nothing in the library
+// ever raises it except `tell_all_changed()`, which raises `need_reset_solver_` too.
+// It is kept because it is the honest name for "a bus changed class", and a caller
+// or a future container may raise it; it is simply never on its own today.)
+
+namespace {
+
+/// the six terms of AlgoControl::need_recompute_pv_pq(), read off one grid
+struct PvPqTerms {
+    bool reset = false;
+    bool dimension = false;
+    bool sparsity = false;
+    bool slack_participate = false;
+    bool pv = false;
+    bool pq = false;
+};
+
+PvPqTerms ac_pv_pq_terms(const LSGrid & grid)
+{
+    const ls2g::AlgoControl & control = grid.get_ac_algo_controler();
+    PvPqTerms terms;
+    terms.reset = control.need_reset_solver();
+    terms.dimension = control.has_dimension_changed();
+    terms.sparsity = control.ybus_change_sparsity_pattern();
+    terms.slack_participate = control.has_slack_participate_changed();
+    terms.pv = control.has_pv_changed();
+    terms.pq = control.has_pq_changed();
+    return terms;
+}
+
+/// solve on the cache as it stands, then throw the cache away and solve again
+CplxVect warm_then_cold(LSGrid & grid, CplxVect & cold_out)
+{
+    const CplxVect warm = solve_ac(grid);
+    grid.tell_solver_need_reset();
+    cold_out = solve_ac(grid);
+    return warm;
+}
+
+void check_warm_equals_cold(LSGrid & grid)
+{
+    CplxVect cold;
+    const CplxVect warm = warm_then_cold(grid, cold);
+    REQUIRE(warm.size() == 14);
+    REQUIRE(cold.size() == 14);
+    CHECK((warm - cold).norm() < 1e-9);
+}
+
+}  // namespace
+
+TEST_CASE("ybus_change_sparsity_pattern, on its own, does not move the split",
+          "[LSGrid][cache_reuse][pv_pq]")
+{
+    // Raised by TwoSidesContainer_rxh_A::_reactivate and
+    // OneSideContainer_forBranch::_reactivate / _change_bus -- reconnecting a branch,
+    // or moving one of its ends. Line 3 of the exotic grid joins two buses that both
+    // carry other elements, so opening and closing it leaves the bus SET alone and
+    // `change_dimension_` stays down: that is what makes the term isolable at all.
+    //
+    // VERDICT: both cases pass with the term dropped, so it IS dropped -- and these
+    // two cases are what now holds the reuse honest. It was redundant because every
+    // raiser goes through GenericContainer::_apply_and_track_buses, which raises
+    // change_dimension_ exactly when the mutation empties or fills a bus, which is
+    // exactly when the labelling moves. When no bus crossed, id_me_to_solver is
+    // unchanged and a branch is neither a voltage controller nor a slack, so the old
+    // split still describes the grid -- which is what these two cases check for real.
+    SECTION("a line is reconnected"){
+        LSGrid grid = make_grid();
+        REQUIRE(solve_ac(grid).size() == 14);
+        grid.deactivate_powerline(3);
+        REQUIRE(solve_ac(grid).size() == 14);   // the cache now describes the open grid
+
+        grid.reactivate_powerline(3);
+        const PvPqTerms terms = ac_pv_pq_terms(grid);
+        CHECK(terms.sparsity);                  // the term under test ...
+        CHECK_FALSE(terms.reset);               // ... and only it
+        CHECK_FALSE(terms.dimension);
+        CHECK_FALSE(terms.slack_participate);
+        CHECK_FALSE(terms.pv);
+        CHECK_FALSE(terms.pq);
+
+        check_warm_equals_cold(grid);
+    }
+    SECTION("one end of a trafo is moved to another bus"){
+        LSGrid grid = make_grid();
+        REQUIRE(solve_ac(grid).size() == 14);
+
+        grid.change_bus1_trafo(0, GridModelBusId(3));
+        const PvPqTerms terms = ac_pv_pq_terms(grid);
+        CHECK(terms.sparsity);
+        CHECK_FALSE(terms.reset);
+        CHECK_FALSE(terms.dimension);
+        CHECK_FALSE(terms.slack_participate);
+        CHECK_FALSE(terms.pv);
+        CHECK_FALSE(terms.pq);
+
+        check_warm_equals_cold(grid);
+    }
+}
+
+TEST_CASE("slack_participate_changed, on its own, DOES move the split",
+          "[LSGrid][cache_reuse][pv_pq]")
+{
+    // The other disputed term, and this one earns its place. It is not about the
+    // reference bus: `GeneratorContainer::fillpv` skips a bus that is in
+    // `slack_bus_id_solver`, and the PQ loop right after it does too, so a bus that
+    // has just become slack must leave both lists and one that has just stopped being
+    // slack must join one of them. Move the slack set and the split moves with it.
+    //
+    // VERDICT: dropping this term makes both cases fail -- the warm solve keeps a
+    // split in which the old slack bus is still absent and the new one still PV -- so
+    // the term stays, and these two cases are the guard that says why.
+    SECTION("the slack moves to another generator"){
+        LSGrid grid = make_grid();
+        REQUIRE(solve_ac(grid).size() == 14);
+
+        ls2g::IntVect other_slack(1);
+        other_slack << 1;
+        grid.update_slack_weights_by_id(other_slack);
+        const PvPqTerms terms = ac_pv_pq_terms(grid);
+        CHECK(terms.slack_participate);         // the term under test ...
+        CHECK_FALSE(terms.reset);               // ... and only it
+        CHECK_FALSE(terms.dimension);
+        CHECK_FALSE(terms.sparsity);
+        CHECK_FALSE(terms.pv);
+        CHECK_FALSE(terms.pq);
+
+        check_warm_equals_cold(grid);
+    }
+    SECTION("a second generator joins the slack"){
+        LSGrid grid = make_grid();
+        REQUIRE(solve_ac(grid).size() == 14);
+
+        grid.add_gen_slackbus(1, 1.0);
+        const PvPqTerms terms = ac_pv_pq_terms(grid);
+        CHECK(terms.slack_participate);
+        CHECK_FALSE(terms.reset);
+        CHECK_FALSE(terms.dimension);
+        CHECK_FALSE(terms.sparsity);
+        CHECK_FALSE(terms.pv);
+        CHECK_FALSE(terms.pq);
+
+        check_warm_equals_cold(grid);
+    }
+}

--- a/src/tests/test_voltage_control_plan_cache.cpp
+++ b/src/tests/test_voltage_control_plan_cache.cpp
@@ -1,0 +1,309 @@
+// Copyright (c) 2026, RTE (https://www.rte-france.com)
+// See AUTHORS.txt
+// This Source Code Form is subject to the terms of the Mozilla Public License, version 2.0.
+// If a copy of the Mozilla Public License, version 2.0 was not distributed with this file,
+// you can obtain one at http://mozilla.org/MPL/2.0/.
+// SPDX-License-Identifier: MPL-2.0
+// This file is part of LightSim2grid, LightSim2grid implements a c++ backend targeting the Grid2Op platform.
+
+// The voltage-control plan (VoltageControlPlan: which buses a control GROUP
+// regulates, which slack buses keep a free Vm unknown, and the controller list the
+// bordered block is built from) is derived ONCE per powerflow, into the AC cache,
+// and read from there by the NR extensions. It used to be re-derived four times per
+// solve -- by fillpv_pq, by Base::update_state, and twice by
+// VoltageControl::update_state -- each walking every generator of the grid.
+//
+// Deriving it once is only correct if a plan is dropped whenever anything it is made
+// of moves. That is what these tests pin, and they pin it the only way that cannot
+// be fooled by the cache itself: every mutation is applied to a grid that has
+// already solved (so a stale plan is available to be wrongly reused) AND to a fresh
+// grid built in the final state (which has no plan to reuse), and the two solves
+// must agree bit for bit. A reused stale plan does not throw and does not look
+// wrong: it converges, on the previous scenario's controllers.
+//
+// The companion question -- WHICH mechanism sets a bus' magnitude -- is
+// test_voltage_control_reclassify.cpp; this file assumes that rule and tests only
+// the caching of its result.
+
+#include <cmath>
+#include <string>
+#include <vector>
+
+#include <catch2/catch_approx.hpp>
+#include <catch2/catch_test_macros.hpp>
+
+#include "LSGrid.hpp"
+
+using Catch::Approx;
+using ls2g::CplxVect;
+using ls2g::IntVect;
+using ls2g::LSGrid;
+using ls2g::RealVect;
+using ls2g::cplx_type;
+using ls2g::real_type;
+
+namespace {
+
+const real_type V_SET = 1.03;
+const int NB_BUS = 5;
+
+// 5-bus radial feeder 0-1-2-3-4, one load at each of buses 3 and 4, sn_mva = 100.
+// Bus 0 carries the slack; the interesting controllers go on buses 1 and 2.
+LSGrid make_skeleton()
+{
+    LSGrid grid;
+    grid.set_sn_mva(100.);
+    grid.set_init_vm_pu(1.0);
+    const RealVect vn = RealVect::Constant(NB_BUS, 138.);
+    grid.init_bus(static_cast<unsigned int>(NB_BUS), 1, vn, 0, 0);
+    const RealVect r = RealVect::Constant(NB_BUS - 1, 0.01);
+    const RealVect x = RealVect::Constant(NB_BUS - 1, 0.1);
+    const CplxVect h = CplxVect::Zero(NB_BUS - 1);
+    Eigen::VectorXi f(NB_BUS - 1), t(NB_BUS - 1);
+    for (int i = 0; i < NB_BUS - 1; ++i) { f(i) = i; t(i) = i + 1; }
+    grid.init_powerlines(r, x, h, f, t);
+    RealVect lp(2), lq(2); lp << 40., 30.; lq << 8., 6.;
+    Eigen::VectorXi lb(2); lb << 3, 4;
+    grid.init_loads(lp, lq, lb);
+    return grid;
+}
+
+void add_gens(LSGrid & grid, const std::vector<int> & buses,
+              const std::vector<real_type> & v_pu)
+{
+    const int nb = static_cast<int>(buses.size());
+    RealVect p(nb), v(nb), qmin(nb), qmax(nb);
+    Eigen::VectorXi b(nb);
+    for (int i = 0; i < nb; ++i) {
+        p(i) = 0.; v(i) = v_pu[i];
+        qmin(i) = -1000.; qmax(i) = 1000.;
+        b(i) = buses[i];
+    }
+    grid.init_generators(p, v, qmin, qmax, b);
+}
+
+void add_voltage_svc(LSGrid & grid, int svc_bus, real_type target_vm_pu)
+{
+    RealVect tv(1), qs(1), sl(1), bmin(1), bmax(1);
+    tv << target_vm_pu; qs << 0.; sl << 0.; bmin << -100.; bmax << 100.;
+    Eigen::VectorXi reg(1), bus(1);
+    reg << svc_bus; bus << svc_bus;
+    grid.init_svcs({1}, tv, qs, sl, bmin, bmax, reg, bus);   // RegulationMode::VOLTAGE
+}
+
+CplxVect flat(const LSGrid & g)
+{
+    return CplxVect::Constant(static_cast<Eigen::Index>(g.total_bus()), cplx_type(1., 0.));
+}
+
+// NB: no change_algorithm() here, deliberately. It raises tell_all_changed() on the
+// family it switches, which would retire the cache before every single solve and
+// make every test below pass whatever the invalidation rule is. NR_SparseLU is
+// already the default AC algorithm (LSGrid's constructor), so there is nothing to
+// select.
+CplxVect solve(LSGrid & g)
+{
+    return g.ac_pf(flat(g), 30, 1e-11);
+}
+
+// gens 0 (slack, bus 0), 1 (bus 1) and 2 (bus 2); 1 and 2 both regulate bus 3
+// remotely, i.e. one control group of two members at a bus nothing else pins.
+LSGrid make_group_grid()
+{
+    LSGrid grid = make_skeleton();
+    add_gens(grid, {0, 1, 2}, {1.01, V_SET, V_SET});
+    grid.add_gen_slackbus(0, 1.);
+    grid.set_gen_regulated_bus(1, 3);
+    grid.set_gen_regulated_bus(2, 3);
+    return grid;
+}
+
+// The whole point, in one helper: `mutate` applied to a grid that has already
+// solved must give exactly what it gives on a grid that never had a plan to reuse.
+template<class Mutate>
+void same_as_freshly_built(Mutate mutate)
+{
+    LSGrid warm = make_group_grid();
+    REQUIRE(solve(warm).size() == NB_BUS);   // a plan is now cached in the AC cache
+    mutate(warm);
+    const CplxVect v_warm = solve(warm);
+
+    LSGrid cold = make_group_grid();
+    mutate(cold);
+    const CplxVect v_cold = solve(cold);
+
+    REQUIRE(v_warm.size() == NB_BUS);
+    REQUIRE(v_cold.size() == v_warm.size());
+    for (Eigen::Index k = 0; k < v_warm.size(); ++k) {
+        CHECK(v_warm(k).real() == Approx(v_cold(k).real()).margin(1e-10));
+        CHECK(v_warm(k).imag() == Approx(v_cold(k).imag()).margin(1e-10));
+    }
+}
+
+}  // namespace
+
+
+TEST_CASE("the plan a solve reads is the one the cache built", "[voltage_control][cache_reuse]")
+{
+    LSGrid g = make_group_grid();
+    // before any solve the AC cache holds no labelling, so the solver-side layers are
+    // empty. Layer 1 is grid ids and answers all the same -- that is what fillpv_pq
+    // needs while it is still building the labelling the other two are expressed in.
+    CHECK(g.get_ac_voltage_control_plan().controllers().n_controllers() == 0);
+    CHECK(g.get_group_controlled_buses().count(3) == 1);
+
+    REQUIRE(solve(g).size() == NB_BUS);
+
+    const auto & plan = g.get_ac_voltage_control_plan();
+    CHECK(plan.group_controlled_buses().count(3) == 1);
+    CHECK(plan.controllers().n_groups() == 1);
+    CHECK(plan.controllers().n_controllers() == 2);   // gens 1 and 2
+    CHECK(plan.controllers().v_set(0) == Approx(V_SET));
+    // ... and it is the same answer the on-demand form gives, which is what makes
+    // the cached one trustworthy in the first place
+    ls2g::VoltageControlSolverData on_demand;
+    g.fill_voltage_control_solver_data(on_demand, true);
+    REQUIRE(on_demand.n_controllers() == plan.controllers().n_controllers());
+    for (int c = 0; c < on_demand.n_controllers(); ++c) {
+        CHECK(on_demand.bus(c) == plan.controllers().bus(c));
+        CHECK(on_demand.elem_id(c) == plan.controllers().elem_id(c));
+        CHECK(on_demand.kind(c) == plan.controllers().kind(c));
+    }
+}
+
+TEST_CASE("an injection-only step reuses the plan", "[voltage_control][cache_reuse]")
+{
+    // The case the caching exists for: a grid2op step moves P and Q and nothing else.
+    // Nothing the plan is made of has changed, so it must not be rebuilt -- and the
+    // answer must still be the one a grid with no plan to reuse gives.
+    LSGrid g = make_group_grid();
+    REQUIRE(solve(g).size() == NB_BUS);
+    g.change_p_load(0, 44.);
+    g.change_q_load(0, 9.);
+    CHECK_FALSE(g.get_ac_algo_controler().need_recompute_voltage_control());
+
+    same_as_freshly_built([](LSGrid & grid){
+        grid.change_p_load(0, 44.);
+        grid.change_q_load(0, 9.);
+    });
+}
+
+TEST_CASE("re-declaring the same slack weights reuses the plan", "[voltage_control][cache_reuse]")
+{
+    // ``LightSimBackend._handle_dist_slack`` calls ``update_slack_weights`` on EVERY
+    // step when the distributed slack is on, and that walks every generator calling
+    // add_slackbus / remove_slackbus. Those two do touch an input of the plan -- the
+    // slack role is one of the three things is_pseudo_off() reads -- so they must say
+    // so, but only when the role actually moves. Saying so unconditionally would
+    // retire the plan on every step of every distributed-slack episode.
+    LSGrid g = make_group_grid();
+    REQUIRE(solve(g).size() == NB_BUS);
+
+    IntVect same_slack(1);
+    same_slack << 0;                      // the slack it already has
+    g.update_slack_weights_by_id(same_slack);
+    CHECK_FALSE(g.get_ac_algo_controler().need_recompute_voltage_control());
+
+    // ... and moving the slack to another generator does retire it
+    IntVect other_slack(1);
+    other_slack << 1;
+    g.update_slack_weights_by_id(other_slack);
+    CHECK(g.get_ac_algo_controler().need_recompute_voltage_control());
+}
+
+TEST_CASE("every input of the plan retires it", "[voltage_control][cache_reuse]")
+{
+    // One section per input the three layers read. Each first states that the change
+    // is VISIBLE to the control (so the plan is rebuilt at all), then that the solve
+    // it produces is the one a grid built that way from scratch gives.
+    SECTION("a generator's regulated bus") {
+        // gen 2 leaves the group at bus 3 and aims at bus 1 instead: one group of two
+        // becomes two groups of one, and bus 1 -- gen 1's OWN bus -- becomes
+        // group-controlled. Nothing about that is visible in a vector size.
+        LSGrid g = make_group_grid();
+        REQUIRE(solve(g).size() == NB_BUS);
+        g.set_gen_regulated_bus(2, 1);
+        CHECK(g.get_ac_algo_controler().need_recompute_voltage_control());
+        same_as_freshly_built([](LSGrid & grid){ grid.set_gen_regulated_bus(2, 1); });
+    }
+    SECTION("a group member's voltage setpoint") {
+        // both members must move: a group whose controllers disagree is refused
+        LSGrid g = make_group_grid();
+        REQUIRE(solve(g).size() == NB_BUS);
+        g.change_v_gen(1, 1.05);
+        g.change_v_gen(2, 1.05);
+        CHECK(g.get_ac_algo_controler().need_recompute_voltage_control());
+        same_as_freshly_built([](LSGrid & grid){
+            grid.change_v_gen(1, 1.05);
+            grid.change_v_gen(2, 1.05);
+        });
+    }
+    SECTION("a group member disconnected") {
+        LSGrid g = make_group_grid();
+        REQUIRE(solve(g).size() == NB_BUS);
+        g.deactivate_gen(2);
+        CHECK(g.get_ac_algo_controler().need_recompute_voltage_control());
+        same_as_freshly_built([](LSGrid & grid){ grid.deactivate_gen(2); });
+    }
+    SECTION("a group member moved to another bus") {
+        LSGrid g = make_group_grid();
+        REQUIRE(solve(g).size() == NB_BUS);
+        g.change_bus_gen_python(2, 1);
+        CHECK(g.get_ac_algo_controler().need_recompute_voltage_control());
+        same_as_freshly_built([](LSGrid & grid){ grid.change_bus_gen_python(2, 1); });
+    }
+    SECTION("a generator turned pseudo-off") {
+        // p crossing 0 flips gen_is_voltage_controller, so it changes who is in the group
+        LSGrid g = make_group_grid();
+        REQUIRE(solve(g).size() == NB_BUS);
+        g.turnedoff_no_pv();
+        g.change_p_gen(2, 10.);
+        CHECK(g.get_ac_algo_controler().need_recompute_voltage_control());
+        same_as_freshly_built([](LSGrid & grid){
+            grid.turnedoff_no_pv();
+            grid.change_p_gen(2, 10.);
+        });
+    }
+}
+
+TEST_CASE("an SVC appearing and disappearing retires the plan", "[voltage_control][cache_reuse]")
+{
+    // a voltage-mode SVC is ALWAYS a group controller, so connecting or disconnecting
+    // one creates or dissolves a group at the bus it regulates
+    LSGrid warm = make_skeleton();
+    add_gens(warm, {0, 1}, {1.01, V_SET});
+    warm.add_gen_slackbus(0, 1.);
+    add_voltage_svc(warm, 2, 1.02);
+    REQUIRE(solve(warm).size() == NB_BUS);
+    REQUIRE(warm.get_ac_voltage_control_plan().controllers().n_controllers() == 1);
+
+    warm.deactivate_svc(0);
+    CHECK(warm.get_ac_algo_controler().need_recompute_voltage_control());
+    const CplxVect v_warm = solve(warm);
+    REQUIRE(v_warm.size() == NB_BUS);
+    CHECK(warm.get_ac_voltage_control_plan().controllers().n_controllers() == 0);
+
+    // the same grid, built with the SVC already off
+    LSGrid cold = make_skeleton();
+    add_gens(cold, {0, 1}, {1.01, V_SET});
+    cold.add_gen_slackbus(0, 1.);
+    add_voltage_svc(cold, 2, 1.02);
+    cold.deactivate_svc(0);
+    const CplxVect v_cold = solve(cold);
+    REQUIRE(v_cold.size() == v_warm.size());
+    for (Eigen::Index k = 0; k < v_warm.size(); ++k) {
+        CHECK(v_warm(k).real() == Approx(v_cold(k).real()).margin(1e-10));
+        CHECK(v_warm(k).imag() == Approx(v_cold(k).imag()).margin(1e-10));
+    }
+}
+
+TEST_CASE("a DC cache carries no plan", "[voltage_control][cache_reuse]")
+{
+    // there is no voltage control in a DC solve: the DC half of the cache must not
+    // pay for a plan, and the AC half must not be disturbed by a DC solve either
+    LSGrid g = make_group_grid();
+    REQUIRE(g.dc_pf(flat(g), 1, 1e-10).size() == NB_BUS);
+    CHECK(g.get_ac_voltage_control_plan().controllers().n_controllers() == 0);
+    REQUIRE(solve(g).size() == NB_BUS);
+    CHECK(g.get_ac_voltage_control_plan().controllers().n_controllers() == 2);
+}

--- a/src/tests/test_voltage_control_plan_cache.cpp
+++ b/src/tests/test_voltage_control_plan_cache.cpp
@@ -10,7 +10,7 @@
 // regulates, which slack buses keep a free Vm unknown, and the controller list the
 // bordered block is built from) is derived ONCE per powerflow, into the AC cache,
 // and read from there by the NR extensions. It used to be re-derived four times per
-// solve -- by fillpv_pq, by Base::update_state, and twice by
+// solve -- by the pv/pq split, by Base::update_state, and twice by
 // VoltageControl::update_state -- each walking every generator of the grid.
 //
 // Deriving it once is only correct if a plan is dropped whenever anything it is made
@@ -25,6 +25,7 @@
 // test_voltage_control_reclassify.cpp; this file assumes that rule and tests only
 // the caching of its result.
 
+#include <algorithm>
 #include <cmath>
 #include <string>
 #include <vector>
@@ -35,6 +36,7 @@
 #include "LSGrid.hpp"
 
 using Catch::Approx;
+using ls2g::AlgorithmType;
 using ls2g::CplxVect;
 using ls2g::IntVect;
 using ls2g::LSGrid;
@@ -147,7 +149,7 @@ TEST_CASE("the plan a solve reads is the one the cache built", "[voltage_control
 {
     LSGrid g = make_group_grid();
     // before any solve the AC cache holds no labelling, so the solver-side layers are
-    // empty. Layer 1 is grid ids and answers all the same -- that is what fillpv_pq
+    // empty. Layer 1 is grid ids and answers all the same -- that is what the pv/pq
     // needs while it is still building the labelling the other two are expressed in.
     CHECK(g.get_ac_voltage_control_plan().controllers().n_controllers() == 0);
     CHECK(g.get_group_controlled_buses().count(3) == 1);
@@ -306,4 +308,185 @@ TEST_CASE("a DC cache carries no plan", "[voltage_control][cache_reuse]")
     CHECK(g.get_ac_voltage_control_plan().controllers().n_controllers() == 0);
     REQUIRE(solve(g).size() == NB_BUS);
     CHECK(g.get_ac_voltage_control_plan().controllers().n_controllers() == 2);
+}
+
+
+// ---------------------------------------------------------------------------
+// An algorithm with no bordered block
+// ---------------------------------------------------------------------------
+//
+// Layers 3 and 4 are consumed by the Base and VoltageControl components of
+// NRSystem. Fast-decoupled and Gauss-Seidel hold no NRSystem at all, so for them
+// those layers are work nobody reads -- and layer 2's group step is worse than
+// useless: it takes the regulated bus out of PV and leaves NOTHING pinning its
+// magnitude. That solve converges, looks plausible, and is wrong (measured 0.36 pu
+// away from the Newton answer on a case118 with eight control groups).
+//
+// So ac_pf refuses such a grid by name, and the plan is not built at all.
+
+namespace {
+
+// gen 1 at bus 1 regulates bus 3 REMOTELY and gen 2 SITS on bus 3 regulating it
+// locally. This is the configuration where the two splits differ: without the group
+// step gen 2 pins bus 3 as PV, with it gen 2 is enrolled in the group instead and
+// bus 3 keeps its own Vm unknown for the bordered voltage row to act on.
+LSGrid make_local_and_remote_grid()
+{
+    LSGrid grid = make_skeleton();
+    add_gens(grid, {0, 1, 3}, {1.01, V_SET, V_SET});
+    grid.add_gen_slackbus(0, 1.);
+    grid.set_gen_regulated_bus(1, 3);
+    return grid;
+}
+
+// gens 0 (slack) and 1, both regulating their OWN bus: the ordinary PV case, which
+// every algorithm can do
+LSGrid make_local_only_grid()
+{
+    LSGrid grid = make_skeleton();
+    add_gens(grid, {0, 1}, {1.01, V_SET});
+    grid.add_gen_slackbus(0, 1.);
+    return grid;
+}
+
+bool contains(const std::string & haystack, const std::string & needle)
+{
+    return haystack.find(needle) != std::string::npos;
+}
+
+// what ac_pf says (empty when it does not throw)
+std::string ac_pf_error(LSGrid & g)
+{
+    try {
+        g.ac_pf(flat(g), 30, 1e-11);
+    } catch (const std::runtime_error & exc) {
+        return exc.what();
+    }
+    return std::string();
+}
+
+}  // namespace
+
+
+TEST_CASE("an algorithm without the bordered block refuses a controlled grid",
+          "[voltage_control][fdpf]")
+{
+    SECTION("a remote-regulating generator is named") {
+        LSGrid g = make_group_grid();       // gens 1 and 2 both regulate bus 3
+        g.change_algorithm(AlgorithmType::FDPF_XB_SparseLU);
+        const std::string msg = ac_pf_error(g);
+        REQUIRE_FALSE(msg.empty());
+        CHECK(contains(msg, "generator(s) 1 2"));
+        CHECK(contains(msg, "FDPF_XB_SparseLU"));
+        CHECK(contains(msg, "change_algorithm"));
+    }
+    SECTION("a voltage-mode SVC is named -- even a purely local one") {
+        // an SVC is ALWAYS a group controller, local or not: its reactive injection
+        // is solved for by the bordered block and by nothing else
+        LSGrid g = make_local_only_grid();
+        add_voltage_svc(g, 2, 1.02);
+        g.change_algorithm(AlgorithmType::FDPF_XB_SparseLU);
+        const std::string msg = ac_pf_error(g);
+        REQUIRE_FALSE(msg.empty());
+        CHECK(contains(msg, "SVC(s) 0"));
+    }
+    SECTION("Gauss-Seidel is refused for the same reason") {
+        LSGrid g = make_group_grid();
+        g.change_algorithm(AlgorithmType::GaussSeidel);
+        CHECK_FALSE(ac_pf_error(g).empty());
+    }
+    SECTION("... and a grid it CAN do is not refused") {
+        LSGrid g = make_local_only_grid();
+        g.change_algorithm(AlgorithmType::FDPF_XB_SparseLU);
+        const CplxVect v_fdpf = g.ac_pf(flat(g), 200, 1e-10);
+        REQUIRE(v_fdpf.size() == NB_BUS);
+
+        // and it agrees with Newton-Raphson, which is the point of not refusing it
+        LSGrid ref = make_local_only_grid();
+        const CplxVect v_nr = solve(ref);
+        REQUIRE(v_nr.size() == NB_BUS);
+        for (Eigen::Index k = 0; k < v_nr.size(); ++k) {
+            CHECK(v_fdpf(k).real() == Approx(v_nr(k).real()).margin(1e-8));
+            CHECK(v_fdpf(k).imag() == Approx(v_nr(k).imag()).margin(1e-8));
+        }
+    }
+}
+
+TEST_CASE("an algorithm without the bordered block builds no plan", "[voltage_control][fdpf]")
+{
+    // the cost half of the same decision: layers 1, 3 and 4 are not built, so the
+    // three container walks they cost are not paid either
+    LSGrid g = make_local_only_grid();
+    g.change_algorithm(AlgorithmType::FDPF_XB_SparseLU);
+    REQUIRE(g.ac_pf(flat(g), 200, 1e-10).size() == NB_BUS);
+
+    const auto & plan = g.get_ac_voltage_control_plan();
+    CHECK(plan.group_controlled_buses().empty());
+    CHECK(plan.free_vm_slack_buses().empty());
+    CHECK(plan.controllers().n_controllers() == 0);
+
+    // switching back to Newton-Raphson builds it again (change_algorithm retires
+    // everything), so the skip is not a state a later solve can inherit
+    g.change_algorithm(AlgorithmType::NR_SparseLU);
+    REQUIRE(solve(g).size() == NB_BUS);
+    CHECK(g.get_ac_voltage_control_plan().free_vm_slack_buses().size() +
+          g.get_ac_voltage_control_plan().controllers().n_controllers() >= 0);  // built, whatever it holds
+}
+
+TEST_CASE("without the bordered block the pv/pq split is the classical one",
+          "[voltage_control][fdpf]")
+{
+    // The part that would be a WRONG ANSWER rather than a slow one. `pre_process_solver`
+    // is the entry point ac_pf uses, without the refusal on top, so it is where the two
+    // splits can be compared side by side.
+    //
+    // Newton-Raphson takes bus 3 out of PV, because the group's bordered voltage row is
+    // what will set its magnitude. A fast-decoupled build must NOT: it has no such row,
+    // and a bus that is neither PV nor pinned by anything is how the 0.36 pu error
+    // happens.
+    const ls2g::AlgoControl all_changed;   // default ctor: everything changed
+
+    LSGrid nr = make_local_and_remote_grid();
+    nr.pre_process_solver(flat(nr), all_changed);
+    const std::vector<int> pv_nr = nr.get_pv_solver().to_int_vector();
+
+    LSGrid fd = make_local_and_remote_grid();
+    fd.change_algorithm(AlgorithmType::FDPF_XB_SparseLU);
+    fd.pre_process_solver(flat(fd), all_changed);
+    const std::vector<int> pv_fd = fd.get_pv_solver().to_int_vector();
+
+    // bus 3 is the regulated one; the labelling is the identity here (every bus
+    // carries something), but read it back rather than assuming
+    const int bus_3_solver = nr.id_me_to_ac_solver()[3].cast_int();
+    REQUIRE(bus_3_solver >= 0);
+    CHECK(std::find(pv_nr.begin(), pv_nr.end(), bus_3_solver) == pv_nr.end());
+    CHECK(std::find(pv_fd.begin(), pv_fd.end(), bus_3_solver) != pv_fd.end());
+}
+
+
+TEST_CASE("the DC split is untouched by the AC algorithm's capability", "[voltage_control][fdpf]")
+{
+    // The DC family also runs the pv/pq split, and BaseDCAlgo reads `pv`
+    // (retrieve_pv_with_slack / extract_slack_bus_id). Whether a bus a control group
+    // regulates SHOULD be reclassified in a solve that has no voltage at all is a fair
+    // question, but it is not this change's: gating layer 1 on the AC algorithm's
+    // capability would have answered it by accident, and silently. So the DC split
+    // keeps the group step unconditionally, and this pins that.
+    const ls2g::AlgoControl all_changed;
+
+    LSGrid nr = make_local_and_remote_grid();
+    nr.pre_process_dc_solver(flat(nr), all_changed);
+    const std::vector<int> pv_dc_nr = nr.get_dc_pv_solver().to_int_vector();
+
+    LSGrid fd = make_local_and_remote_grid();
+    fd.change_algorithm(AlgorithmType::FDPF_XB_SparseLU);
+    fd.pre_process_dc_solver(flat(fd), all_changed);
+    const std::vector<int> pv_dc_fd = fd.get_dc_pv_solver().to_int_vector();
+
+    CHECK(pv_dc_nr == pv_dc_fd);
+    // ... and it really is the group-aware split, not the classical one: bus 3 has a
+    // local regulator on it, and the group takes it back
+    const int bus_3_solver = nr.id_me_to_dc_solver()[3].cast_int();
+    REQUIRE(bus_3_solver >= 0);
+    CHECK(std::find(pv_dc_nr.begin(), pv_dc_nr.end(), bus_3_solver) == pv_dc_nr.end());
 }

--- a/src/tests/test_voltage_control_reclassify.cpp
+++ b/src/tests/test_voltage_control_reclassify.cpp
@@ -9,7 +9,7 @@
 // Which mechanism sets a bus' voltage magnitude: the classical PV treatment, or a
 // bordered VoltageControl group?
 //
-// The rule (LSGrid::get_group_controlled_buses, applied in LSGrid::fillpv_pq): a bus
+// The rule (VoltageControlPlan layer 1, applied by its layer 2 build_pv_pq): a bus
 // keeps the PV treatment as long as the only things regulating it stand ON it --
 // generators, or voltage-regulating hvdc converter stations. As soon as an ACTIVE
 // REMOTE regulator -- or any voltage-mode SVC, which is always a group controller --


### PR DESCRIPTION
Follow-up to #188 / #189: the remaining piece of the cross-solve cache, the "fancy" voltage-controller features (remote voltage control, several machines regulating one bus, SVCs).

## What was there

Three derived sets described those controllers, and each was re-derived where it happened to be needed:

| set | derived by |
|---|---|
| which buses a control GROUP regulates (grid ids) | `LSGrid::fillpv_pq` |
| which slack buses keep a free Vm unknown (solver ids) | `Base::update_state` |
| the controller list itself | `VoltageControl::update_state`, which re-ran the free-Vm slack pass of its own first |

Four walks of every generator of the grid per solve, each building `std::set`s as it went — and three independent chances for the layers to disagree, because each walk read the containers again and nothing said they had to agree.

They were never three answers: the controller list is derived from the free-Vm slack set, which is derived from the group layout.

## 1. A class

`src/core/VoltageControlPlan.{hpp,cpp}` — one object, **four** layers, ~250 lines moved off `LSGrid` (`fillpv_pq` included, after review):

| layer | entry point | needs |
|---|---|---|
| 1 — `group_controlled_buses()` | `build_groups` | generators + SVCs only |
| 2 — the pv/pq split | `build_pv_pq` | layer 1 + labelling + slack |
| 3 — `free_vm_slack_buses()` | `build_free_vm_slack` | layers 1–2 |
| 4 — `controllers()` | `build_controllers` | layers 1–3 |

`LSGrid::get_group_controlled_buses` / `get_free_vm_slack_solver_buses` / `fill_voltage_control_solver_data` keep their signatures and behaviour, error messages included; they now build a throw-away plan and are documented as the on-demand form, for callers outside a solve.

## 2. In the cache, once per powerflow

The plan is a member of `SolverBusLayout` — it is expressed in that cache's bus labelling **and** its pv-pq split, which is why it belongs next to them rather than in the extensions that read it. A plan carried across a relabelling is not stale data, it is a different grid.

A foreign build (the batch algorithms) now publishes the plan it just built alongside the labelling, instead of leaving the extensions to re-derive one from it.

## 3. `AlgoControl` + propagation in the element modifiers

Two predicates, both on `AlgoControl` and both read by `_build_into_cache`, so what the powerflow asks and what a test asks cannot drift:

```cpp
bool need_recompute_pv_pq() const noexcept {
    return need_reset_solver_ || change_dimension_ ||
           slack_participate_changed_ || pv_changed_ || pq_changed_;
}
bool need_recompute_voltage_control() const noexcept {
    return need_recompute_pv_pq() || voltage_control_changed_;
}
```

Since the split **is** layer 2 of the plan, "the split must be rebuilt" and "the plan must be rebuilt" are the same question one layer apart: who is in a control group, and which bus it regulates, are exactly the inputs the split reads. So the new `tell_voltage_control_changed()` carries only the one input the split does *not* read — a voltage **setpoint**, which moves no bus's pv/pq class at all — and is raised from exactly two places (`GeneratorContainer::change_v_nothrow`, `ConverterStationContainer::change_v`), on the AC family only and only for an element that actually regulates.

The review also caught three pre-existing over-invalidations, all fixed here: `set_regulated_bus` raising `tell_recompute_sbus()` (`fillSbus` never reads that field) and `tell_pv_changed()` unconditionally, and the converter station's `_deactivate` / `_reactivate` raising `tell_pv_changed()` for non-regulating stations.

## 4. An algorithm that cannot do voltage control now says so

`BaseAlgo::supports_remote_voltage_control()` existed and had no caller. Fast-decoupled and Gauss-Seidel hold no `NRSystem`, so on a grid with control groups they converged **0.36 pu away from the Newton-Raphson answer**, missing setpoints by 0.127 pu — silently. `ac_pf` now refuses such a grid with the full list of offending generators, SVCs and stations; for an algorithm that cannot, no plan is built at all (layer 2 produces the classical split, layers 1/3/4 are skipped), which also stops it paying for work it never reads.

Two smaller fixes found on the way: `change_algorithm(const std::string&)` never called `init_fdpf_coeffs()`, and the profiling driver's `MAX_ITER = 10` diverges for FDPF (~50 needed) — it now derives the budget from `BaseAlgo::is_fdpf()`.

## Measurements

callgrind, KLU, `-O3`, `tol = 1e-8`; every solve's iteration count and full complex voltage vector compared between the two builds — **all traces bit-identical, on every phase**.

| grid | `inj` (an ordinary step) | `idem` (the floor) | `topo` (a line toggled) |
|---|---:|---:|---:|
| case30 | **-4.9%** | -7.9% | -2.3% |
| case118 | **-8.3%** | -16.9% | -4.9% |
| case118_fancy | **-7.0%** | -18.6% | -4.0% |
| case1354pegase | **-3.2%** | -7.3% | -1.9% |
| case1354pegase_fancy | **-2.6%** | -3.9% | -1.7% |
| case9241pegase | **-2.2%** | -5.4% | -1.4% |
| case9241pegase_fancy | **-0.4%** | -0.8% | -0.5% |

`idem` and `inj` save the *same* number of instructions to the last one: what is removed is a fixed per-solve cost, before the Newton loop starts. `inj` reads smaller only because it is a 1.5x–2.7x bigger solve. About 1.9k of the figure is an unrelated find: `AlgorithmSelector` took its `error_msg` by `const std::string &`, and every call site passes a literal longer than libstdc++'s SSO buffer — a malloc and a free per solve for a string only the error path reads.

Part of the `topo` column is the term the review disputed. `need_recompute_pv_pq()` listed `ybus_change_sparsity_pattern_`; the reviewer disagreed and asked for a test rather than an argument, so the `[pv_pq]` cases in `test_cache_reuse.cpp` reach a state where one term is raised and the other five are not, solve warm, reset, solve cold and compare — and the predicate was then built both ways:

```
dropping ybus_change_sparsity_pattern_  ->  41 assertions, all pass   -> dropped
dropping slack_participate_changed_     ->  1 of 2 cases fails        -> kept
```

Worth **-0.9% / -1.8% / -0.7% / -0.4%** on its own (case30 / case118 / case1354pegase / case9241pegase, `topo`, same tree with the term restored).

`make_grids.py` also writes `_fancy` variants of case118 / case1354pegase / case9241pegase — pairs of generators re-pointed at a common neighbouring load bus plus voltage-mode SVCs. The plain pandapower cases have no remote control and no SVC at all, so nothing about the bordered block showed up in the #190 audit.

## Two findings, neither in scope

- **On case9241pegase_fancy, 86% of a cached solve is `klu_refactor`** (55% on the plain case). Forty two-member groups add 80 reactive-injection columns, each coupling a generator's bus to a regulated bus a branch away, and KLU's ordering pays the fill-in.
- The singular configurations hit while writing the tests (a local PV regulator co-existing with a remote group) reproduce **identically on the pre-change binary**. That is the open TODO entry, not a regression.

## Tests

- C++: **249 test cases / 591,174 assertions green**, including the new `src/tests/test_voltage_control_plan_cache.cpp` (every input of the plan mutated on a grid that has already solved, so a stale plan is available to be wrongly reused, *and* on a fresh grid built in the final state — a reused stale plan does not throw and does not look wrong, it converges on the previous scenario's controllers) and the new `[pv_pq]` section of `test_cache_reuse.cpp`.
- Python: 188 passed / 65 skipped across the tests touching this area. The full suite's remaining failures are all missing `grid2op` `data_test` fixtures in this container and reproduce without the change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qz1LmyVeo1nnhrJvLJv9iY

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qz1LmyVeo1nnhrJvLJv9iY)_