### PR TITLE
Recover a stranded singleton voltage controller instead of diverging

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1009,9 +1009,6 @@ TODO: a "combine mode" axis for ``ScenarioSweepCPP`` choosing between the curren
   the check is free. What remains on the powerflow path is the ``allow_*_cache_reuse`` switch plus
   a debug-only assertion, so a future third claimant is caught by the C++ suite (run under ASan,
   UBSan and valgrind in CI) at no cost in release wheels.
-
-[1.0.0] 2026-08-28
---------------------
 - [FIXED] ``ContingencyAnalysis`` / ``SecurityAnalysis``'s ``handle_disconnected_grid`` mode no
   longer reports a DIVERGENCE for a contingency that strands a lone (single-controller) remote
   voltage regulator's own bus while leaving the bus it regulates connected -- e.g. a generator
@@ -1042,6 +1039,9 @@ TODO: a "combine mode" axis for ``ScenarioSweepCPP`` choosing between the curren
   *regulated* bus itself (rather than a controller's bus) also stays a DIVERGENCE: unlike this
   case, that one has no well-defined fallback under the "same sparsity every contingency" masking
   design, and even a rebuilt single-shot topology has no support for it either (it raises).
+
+[1.0.0] 2026-08-28
+--------------------
 - [BREAKING] **solver cache reuse is now automatic and on by default**, per solver family.
   A powerflow reuses what the previous one of the same family built -- the compact bus labelling,
   ``Ybus`` / ``Sbus``, the PV / PQ split, the slack weights -- and only re-stamps what the grid

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1012,6 +1012,26 @@ TODO: a "combine mode" axis for ``ScenarioSweepCPP`` choosing between the curren
 
 [1.0.0] 2026-08-28
 --------------------
+- [FIXED] ``ContingencyAnalysis`` / ``SecurityAnalysis``'s ``handle_disconnected_grid`` mode no
+  longer reports a DIVERGENCE for a contingency that stands a lone (single-controller) remote
+  voltage regulator's own bus while leaving the bus it regulates connected -- e.g. a generator
+  reaching its regulated bus only through a transformer that trips. Bus masking is a value-only
+  edit that must not touch the Jacobian's sparsity pattern, so the ``VoltageControl`` extension's
+  bordered voltage row used to survive untouched and keep demanding ``Vm(regulated) == v_set``
+  while the controller's own reactive-injection unknown lost its only coupling once its bus's P/Q
+  rows were masked to identity -- a structurally singular system. For a group with exactly one
+  controller, that row is now repurposed (when the mask strands the controller's own bus) into a
+  plain ``Q_c == 0`` pin instead, using a Jacobian slot that is now reserved unconditionally for
+  every such controller (previously only for a sloped SVC) so no re-factorization is needed. The
+  regulated bus then falls back to its own ordinary PQ equations, matching what a rebuilt
+  (single-shot) topology already does once the disconnected controller drops out of its group.
+  A group shared by more than one controller (``cnt > 1``) is untouched by this fix: stranding one
+  of several controllers regulating the same bus stays exactly as before (see
+  ``src/tests/test_batch_voltage_control.cpp`` for what that already does -- it happens not to
+  diverge, since the surviving sharing-row coupling keeps the system non-singular). Stranding the
+  *regulated* bus itself (rather than a controller's bus) also stays a DIVERGENCE: unlike this
+  case, that one has no well-defined fallback under the "same sparsity every contingency" masking
+  design, and even a rebuilt single-shot topology has no support for it either (it raises).
 - [BREAKING] **solver cache reuse is now automatic and on by default**, per solver family.
   A powerflow reuses what the previous one of the same family built -- the compact bus labelling,
   ``Ybus`` / ``Sbus``, the PV / PQ split, the slack weights -- and only re-stamps what the grid

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1013,7 +1013,7 @@ TODO: a "combine mode" axis for ``ScenarioSweepCPP`` choosing between the curren
 [1.0.0] 2026-08-28
 --------------------
 - [FIXED] ``ContingencyAnalysis`` / ``SecurityAnalysis``'s ``handle_disconnected_grid`` mode no
-  longer reports a DIVERGENCE for a contingency that stands a lone (single-controller) remote
+  longer reports a DIVERGENCE for a contingency that strands a lone (single-controller) remote
   voltage regulator's own bus while leaving the bus it regulates connected -- e.g. a generator
   reaching its regulated bus only through a transformer that trips. Bus masking is a value-only
   edit that must not touch the Jacobian's sparsity pattern, so the ``VoltageControl`` extension's
@@ -1021,10 +1021,20 @@ TODO: a "combine mode" axis for ``ScenarioSweepCPP`` choosing between the curren
   while the controller's own reactive-injection unknown lost its only coupling once its bus's P/Q
   rows were masked to identity -- a structurally singular system. For a group with exactly one
   controller, that row is now repurposed (when the mask strands the controller's own bus) into a
-  plain ``Q_c == 0`` pin instead, using a Jacobian slot that is now reserved unconditionally for
-  every such controller (previously only for a sloped SVC) so no re-factorization is needed. The
-  regulated bus then falls back to its own ordinary PQ equations, matching what a rebuilt
-  (single-shot) topology already does once the disconnected controller drops out of its group.
+  plain ``Q_c == 0`` pin instead, using one extra Jacobian slot per such controller, so no
+  re-factorization is needed. The regulated bus then falls back to its own ordinary PQ equations,
+  matching what a rebuilt (single-shot) topology already does once the disconnected controller
+  drops out of its group.
+  That extra slot is reserved ONLY when it can ever be used: ``NRAlgo`` /
+  ``AlgorithmSelector`` gained ``set_may_mask_voltage_control(bool)``, and ``BaseBatchSweep``
+  calls it (on ``_algo`` and on every freshly-spawned per-thread algo) exactly when
+  ``handle_disconnected_grid`` is actually enabled for this run, before the first
+  ``build_J_sparsity()`` it affects. Plain ``ac_pf``, ``TimeSeriesCPP``, and a
+  ``ContingencyAnalysis`` / ``ScenarioSweep`` that never turns ``handle_disconnected_grid`` on are
+  therefore bit-for-bit as cheap as before this fix -- no reserved slot, no extra ``fill_J`` work --
+  regardless of how many remote-regulating generators or SVCs the grid has. A sloped SVC keeps
+  reserving its coupling slot unconditionally as before (needed for the slope itself, independent
+  of masking).
   A group shared by more than one controller (``cnt > 1``) is untouched by this fix: stranding one
   of several controllers regulating the same bus stays exactly as before (see
   ``src/tests/test_batch_voltage_control.cpp`` for what that already does -- it happens not to

--- a/src/core/AlgorithmSelector.hpp
+++ b/src/core/AlgorithmSelector.hpp
@@ -263,6 +263,9 @@ class LS2G_API AlgorithmSelector final
         void set_masked_buses(const std::vector<int>& solver_bus_ids) {
             get_prt_solver("set_masked_buses", false)->set_masked_buses(solver_bus_ids);
         }
+        void set_may_mask_voltage_control(bool val) {
+            get_prt_solver("set_may_mask_voltage_control", false)->set_may_mask_voltage_control(val);
+        }
 
         Eigen::SparseMatrix<real_type> get_J_python() const {
             Eigen::SparseMatrix<real_type> res = get_J();

--- a/src/core/batch_algorithm/BaseBatchSweep.cpp
+++ b/src/core/batch_algorithm/BaseBatchSweep.cpp
@@ -274,6 +274,10 @@ void BaseBatchSweep<YbusPolicy, SbusPolicy, INIT>::_compute_threaded(
     auto init_thread = [&](int t){
         algos[t] = make_thread_algo();
         algos[t]->set_lazy_v(use_dc_lazy_v);
+        // freshly spawned -- no rebuild-invalidation needed (its very first
+        // build_J_sparsity() already sees this), unlike _algo in
+        // _maybe_prepare_masks() which may already have sparsity built.
+        if(mask_mode) algos[t]->set_may_mask_voltage_control(true);
         controls[t] = _algo_controler;
         ybus_copies[t] = ac_cache_.mat;
     };

--- a/src/core/batch_algorithm/BaseBatchSweep.hpp
+++ b/src/core/batch_algorithm/BaseBatchSweep.hpp
@@ -1098,6 +1098,18 @@ class LS2G_API BaseBatchSweep: public BaseBatchSolverSynch
         template<class Y = YbusPolicy, typename std::enable_if<Y::supports_contingency, int>::type = 0>
         void _maybe_prepare_masks(){
             if(!_handle_disconnected_grid) return;
+            if(!_voltage_control_may_mask_wired_){
+                // first compute() with masking on for this object (or the first ever):
+                // _algo's VoltageControl extension needs its stranded-controller
+                // Jacobian slot, which must exist in the sparsity BEFORE the next
+                // build_J_sparsity() -- force one. A no-op the next time (this stays
+                // true until the object is destroyed; turning handle_disconnected_grid
+                // back off does not need a matching rebuild, it just leaves the slot
+                // reserved and unused).
+                _algo.set_may_mask_voltage_control(true);
+                _algo_controler.tell_pv_changed();
+                _voltage_control_may_mask_wired_ = true;
+            }
             if(!_algo.supports_bus_masking()){
                 std::ostringstream exc_;
                 exc_ << algo_name() << ": the `handle_disconnected_grid` mode requires a "
@@ -1344,6 +1356,12 @@ class LS2G_API BaseBatchSweep: public BaseBatchSolverSynch
         // state (SFINAE-gated methods above restrict who can reach it); empty /
         // false on every instantiation but ContingencyAnalysis.
         bool _handle_disconnected_grid = false;
+        // whether _algo (the single-threaded / member algo -- each per-thread one is
+        // freshly spawned and told directly, see _compute_threaded) has already been
+        // told may_mask_voltage_control(true): sparsity only needs a forced rebuild
+        // (tell_pv_changed()) the first time a compute() actually turns masking on,
+        // see _maybe_prepare_masks().
+        bool _voltage_control_may_mask_wired_ = false;
         std::vector<std::vector<int> > _li_masked;
         std::vector<char> _skip_mask;
         bool _compute_limit_violations_ = false;

--- a/src/core/powerflow_algorithm/BaseAlgo.hpp
+++ b/src/core/powerflow_algorithm/BaseAlgo.hpp
@@ -459,6 +459,17 @@ class LS2G_API BaseAlgo : public BaseConstants
         virtual bool supports_bus_masking() const { return false; }
         virtual void set_masked_buses(const std::vector<int> & /*solver_bus_ids*/) {}
 
+        // Tells the algorithm whether a stranded-controller Jacobian slot (see
+        // VoltageControl::declare_feature_entries in NRSystem.hpp) is worth reserving
+        // for THIS run: only ContingencyAnalysis/ScenarioSweep's handle_disconnected_grid
+        // mode ever calls set_masked_buses, so every other caller (plain ac_pf,
+        // TimeSeries, an un-masked batch) should not pay for it at all. Must be called
+        // BEFORE the first build_J_sparsity() this affects; a caller that flips it after
+        // sparsity was already built for a different value must also force a rebuild
+        // (e.g. via the solver control's tell_pv_changed()) -- see BaseBatchSweep::
+        // _maybe_prepare_masks(). Default is a no-op so other algorithms are unaffected.
+        virtual void set_may_mask_voltage_control(bool /*val*/) {}
+
         virtual AlgoConfig get_config() const { return AlgoConfig{}; }
         virtual void set_config(const AlgoConfig&) {}
         

--- a/src/core/powerflow_algorithm/NRAlgo.hpp
+++ b/src/core/powerflow_algorithm/NRAlgo.hpp
@@ -169,6 +169,9 @@ public:
     void set_masked_buses(const std::vector<int> & solver_bus_ids) override {
         _system.set_masked_buses(solver_bus_ids);
     }
+    void set_may_mask_voltage_control(bool val) override {
+        _system.set_may_mask_voltage_control(val);
+    }
     
     // ----- scaling policy ------------------------------------------------------
     ScalingPolicyType get_scaling_policy_type()  const { return scaling_policy_->type(); }

--- a/src/core/powerflow_algorithm/NRSystem.hpp
+++ b/src/core/powerflow_algorithm/NRSystem.hpp
@@ -700,6 +700,13 @@ class LS2G_API VoltageControl
             masked_buses_ = masked_buses;
         }
 
+        // Gates the extra (v_row, q_col) slot declare_feature_entries reserves for a
+        // lone (cnt==1) GEN controller (see there): only worth it when THIS run might
+        // ever call set_masked_buses with a non-empty list. Caller-set, once, before
+        // the first declare_feature_entries() it should affect -- see NRSystem::
+        // set_may_mask_voltage_control / BaseAlgo::set_may_mask_voltage_control.
+        void set_may_mask_voltage_control(bool val) { may_mask_ = val; }
+
         // claims, per group: N q-unknown columns, 1 voltage row, N-1 sharing rows;
         // caches the controller q rows and the regulated-bus vm columns (the ledger
         // is fully populated by Base / MultiSlack before this runs)
@@ -745,11 +752,14 @@ class LS2G_API VoltageControl
                     const int j = first + off;
                     if (q_rows_[j] >= 0 && q_cols_[j] >= 0) h_qrow_[j] = sink.add(q_rows_[j], q_cols_[j]);
                     // slope coupling Vm(reg) <- s.Q_c, declared for every SVC (slope-independent
-                    // pattern) and for a lone (cnt == 1) controller of any kind: reserved with
-                    // value 0 in the normal case so set_masked_buses can repurpose it into a
-                    // "pin Q_c to 0" coefficient (see fill_feature_values) without ever touching
-                    // J's sparsity pattern.
-                    if ((data_.kind(j) == VoltageControlSolverData::SVC || cnt == 1) &&
+                    // pattern, needed regardless of masking) and, ONLY when this run might ever
+                    // mask a bus (may_mask_, see set_may_mask_voltage_control), for a lone
+                    // (cnt == 1) controller of any kind: reserved with value 0 in the normal case
+                    // so set_masked_buses can repurpose it into a "pin Q_c to 0" coefficient (see
+                    // fill_feature_values) without ever touching J's sparsity pattern. Gating this
+                    // on may_mask_ keeps every other caller -- plain ac_pf, TimeSeries, an
+                    // un-masked batch -- exactly as cheap as before this feature existed.
+                    if ((data_.kind(j) == VoltageControlSolverData::SVC || (cnt == 1 && may_mask_)) &&
                         v_row >= 0 && q_cols_[j] >= 0)
                         h_slope_[j] = sink.add(v_row, q_cols_[j]);
                 }
@@ -895,6 +905,12 @@ class LS2G_API VoltageControl
             }
         }
 
+        // Caller-set run config, NOT reset by clear() (see set_may_mask_voltage_control):
+        // whether a lone controller's Jacobian slot is worth reserving in
+        // declare_feature_entries. The batch code that owns this decision
+        // (BaseBatchSweep::_maybe_prepare_masks) re-asserts it before every
+        // compute(), so it never actually goes stale across a clear_jacobian().
+        bool                           may_mask_ = false;
         int                            my_size_;     // number of controllers
         VoltageControlSolverData       data_;        // per-solve controller data (refreshed every update_state)
         RealVect                       q_;           // running reactive injection per controller (pu, gen convention)
@@ -1009,6 +1025,18 @@ public:
         // (_find_extension returns nullptr when VoltageControl is not in Rest...).
         VoltageControl* vc = _find_extension<VoltageControl>();
         if (vc != nullptr) vc->set_masked_buses(masked_buses_);
+    }
+
+    // Whether the stranded-controller Jacobian slot (see VoltageControl::
+    // declare_feature_entries) is worth reserving at all: only set_masked_buses()
+    // above is ever able to use it, and only ContingencyAnalysis / ScenarioSweep's
+    // handle_disconnected_grid mode ever calls that. Must be called before the
+    // first build_J_sparsity() this should affect (see BaseAlgo::
+    // set_may_mask_voltage_control's doc for the caller-side invalidation this
+    // implies if it is ever flipped after sparsity was already built).
+    void set_may_mask_voltage_control(bool val) {
+        VoltageControl* vc = _find_extension<VoltageControl>();
+        if (vc != nullptr) vc->set_may_mask_voltage_control(val);
     }
 
     // ----- NR iteration primitives -----------------------------------------------

--- a/src/core/powerflow_algorithm/NRSystem.hpp
+++ b/src/core/powerflow_algorithm/NRSystem.hpp
@@ -675,6 +675,31 @@ class LS2G_API VoltageControl
             const Eigen::Ref<const IntVect>  & /*pq*/
         ) {}
 
+        // ContingencyAnalysis "handle_disconnected_grid" mode (see NRSystem::
+        // set_masked_buses, which forwards here): scope is a SINGLETON group
+        // (cnt == 1) whose sole controller sits on a bus this contingency masks.
+        // That controller's own equipment is isolated from the live component --
+        // there is nobody left to hold the regulated bus at v_set -- so its
+        // voltage row is repurposed (fill_feature_values / fill_custom_rows) from
+        // the voltage constraint into a plain "Q_c = 0" pin, freeing the
+        // regulated bus back to its own ordinary PQ equations. That reproduces
+        // what a rebuilt (single-shot) topology does once the disconnected
+        // controller drops out of the group. A multi-controller (cnt > 1) group
+        // with a stranded member is NOT covered: the row/column structure stays
+        // singular for it, exactly as before this method existed.
+        //
+        // Only STORES the list here: `data_` may still hold the previous contingency's
+        // (or, on a freshly spawned per-thread algo, no) content at this point -- the
+        // multi-threaded path calls this before that thread's first update_state() ever
+        // runs. group_stranded_ is (re)computed from data_ + masked_buses_ inside
+        // update_state() itself, which always runs right after this, once per
+        // compute_pf() call, so it is guaranteed to see data_ freshly rebuilt for the
+        // very contingency this masked_buses_ belongs to.
+        void set_masked_buses(const std::vector<int>& masked_buses)
+        {
+            masked_buses_ = masked_buses;
+        }
+
         // claims, per group: N q-unknown columns, 1 voltage row, N-1 sharing rows;
         // caches the controller q rows and the regulated-bus vm columns (the ledger
         // is fully populated by Base / MultiSlack before this runs)
@@ -719,8 +744,13 @@ class LS2G_API VoltageControl
                 for (int off = 0; off < cnt; ++off) {
                     const int j = first + off;
                     if (q_rows_[j] >= 0 && q_cols_[j] >= 0) h_qrow_[j] = sink.add(q_rows_[j], q_cols_[j]);
-                    // slope coupling Vm(reg) <- s.Q_c, declared for every SVC (slope-independent pattern)
-                    if (data_.kind(j) == VoltageControlSolverData::SVC && v_row >= 0 && q_cols_[j] >= 0)
+                    // slope coupling Vm(reg) <- s.Q_c, declared for every SVC (slope-independent
+                    // pattern) and for a lone (cnt == 1) controller of any kind: reserved with
+                    // value 0 in the normal case so set_masked_buses can repurpose it into a
+                    // "pin Q_c to 0" coefficient (see fill_feature_values) without ever touching
+                    // J's sparsity pattern.
+                    if ((data_.kind(j) == VoltageControlSolverData::SVC || cnt == 1) &&
+                        v_row >= 0 && q_cols_[j] >= 0)
                         h_slope_[j] = sink.add(v_row, q_cols_[j]);
                 }
                 if (v_row >= 0 && vm_cols_[g] >= 0) h_vm_[g] = sink.add(v_row, vm_cols_[g]);
@@ -739,15 +769,19 @@ class LS2G_API VoltageControl
         void fill_feature_values(FeatureWriter& writer, const Eigen::Ref<const RealVect>& /*Va*/) const
         {
             const int ng = data_.n_groups();
+            const bool have_stranded = !group_stranded_.empty();
             for (int g = 0; g < ng; ++g) {
                 const int first = data_.grp_start(g);
                 const int cnt   = data_.grp_count(g);
+                const bool stranded = have_stranded && group_stranded_[g];
                 for (int off = 0; off < cnt; ++off) {
                     const int j = first + off;
                     if (h_qrow_[j]  >= 0) writer.add(h_qrow_[j],  static_cast<real_type>(-1.));
-                    if (h_slope_[j] >= 0) writer.add(h_slope_[j], data_.slope(j));
+                    if (h_slope_[j] >= 0) writer.add(h_slope_[j], stranded ? static_cast<real_type>(1.) : data_.slope(j));
                 }
-                if (h_vm_[g] >= 0) writer.add(h_vm_[g], static_cast<real_type>(1.));
+                // stranded (singleton, masked controller): drop the Vm(reg) coupling -- the row
+                // is now "Q_c = 0" (see fill_custom_rows), not the voltage constraint.
+                if (h_vm_[g] >= 0) writer.add(h_vm_[g], stranded ? static_cast<real_type>(0.) : static_cast<real_type>(1.));
                 const real_type w_first = data_.weight(first);
                 for (int k = 0; k < cnt - 1; ++k) {
                     if (h_shareA_[g][k] >= 0) writer.add(h_shareA_[g][k], w_first);
@@ -771,9 +805,18 @@ class LS2G_API VoltageControl
                               const Eigen::Ref<const RealVect>& dx) const
         {
             const int ng = data_.n_groups();
+            const bool have_stranded = !group_stranded_.empty();
             for (int g = 0; g < ng; ++g) {
                 const int first = data_.grp_start(g);
                 const int cnt   = data_.grp_count(g);
+                if (have_stranded && group_stranded_[g]) {
+                    // stranded singleton controller: pin Q_c = 0 instead of the voltage
+                    // constraint (see set_masked_buses); cnt == 1 here, so there are no
+                    // sharing rows to fill for this group.
+                    const real_type Qt_first = q_(first) + dx(q_cols_[first]);
+                    res(v_rows_[g]) -= Qt_first;
+                    continue;
+                }
                 // voltage constraint  Vm(reg) + sum s_c.Q_c - v_set
                 real_type vm_trial = Vm(data_.reg_bus(g));
                 if (vm_cols_[g] >= 0) vm_trial += dx(vm_cols_[g]);
@@ -814,6 +857,8 @@ class LS2G_API VoltageControl
             h_vm_.clear();
             h_shareA_.clear();
             h_shareB_.clear();
+            masked_buses_.clear();
+            group_stranded_.clear();
         }
 
         // converged reactive injection per controller (pu, registration order)
@@ -833,6 +878,23 @@ class LS2G_API VoltageControl
         }
 
     private:
+        // (re)derive group_stranded_ from the just-refreshed data_ and the stored
+        // masked_buses_ (see set_masked_buses above for why this can't run there
+        // directly). Called from update_state(), once per compute_pf() call, right
+        // after data_ is rebuilt -- cheap: ng and masked_buses_ are both tiny.
+        void _recompute_group_stranded()
+        {
+            const int ng = data_.n_groups();
+            group_stranded_.assign(ng, 0);
+            if (masked_buses_.empty()) return;
+            for (int g = 0; g < ng; ++g) {
+                if (data_.grp_count(g) != 1) continue;
+                const int ctrl_bus = data_.bus(data_.grp_start(g));
+                if (std::find(masked_buses_.begin(), masked_buses_.end(), ctrl_bus) != masked_buses_.end())
+                    group_stranded_[g] = 1;
+            }
+        }
+
         int                            my_size_;     // number of controllers
         VoltageControlSolverData       data_;        // per-solve controller data (refreshed every update_state)
         RealVect                       q_;           // running reactive injection per controller (pu, gen convention)
@@ -842,10 +904,17 @@ class LS2G_API VoltageControl
         std::vector<int>               vm_cols_;     // vm column of each group's regulated bus (-1 if none)
         std::vector<std::vector<int> > share_rows_;  // sharing rows of each group (size N-1)
         std::vector<int>               h_qrow_;      // handle (q_row, q_col) per controller
-        std::vector<int>               h_slope_;     // handle (v_row, q_col) per controller (-1 unless SVC)
+        std::vector<int>               h_slope_;     // handle (v_row, q_col) per controller (-1 unless
+                                                       // SVC or a lone (cnt==1) controller -- see
+                                                       // declare_feature_entries / set_masked_buses)
         std::vector<int>               h_vm_;        // handle (v_row, vm_col) per group
         std::vector<std::vector<int> > h_shareA_;    // handle (share_row, q_col_{k+1}) per group
         std::vector<std::vector<int> > h_shareB_;    // handle (share_row, q_col_1) per group
+        std::vector<int>               masked_buses_;    // last set_masked_buses() argument, verbatim
+        std::vector<char>              group_stranded_;  // per group: 1 iff cnt==1 and its lone
+                                                           // controller's bus is masked; derived from
+                                                           // masked_buses_ by _recompute_group_stranded(),
+                                                           // called from update_state(); empty when unset
 };
 
 
@@ -933,6 +1002,13 @@ public:
     void set_masked_buses(const std::vector<int>& solver_bus_ids) {
         masked_buses_ = solver_bus_ids;
         masked_dirty_ = true;
+        // forward to the VoltageControl extension when present (both AC
+        // instantiations carry it -- see the SingleSlackNRSystem / MultiSlackNRSystem
+        // aliases below): lets a stranded singleton controller's voltage row be
+        // repurposed instead of staying structurally singular. A no-op elsewhere
+        // (_find_extension returns nullptr when VoltageControl is not in Rest...).
+        VoltageControl* vc = _find_extension<VoltageControl>();
+        if (vc != nullptr) vc->set_masked_buses(masked_buses_);
     }
 
     // ----- NR iteration primitives -----------------------------------------------
@@ -1372,6 +1448,26 @@ private:
     }
     template <class T>
     const T* _find_extension() const {
+        return _find_extension_impl<T>(std::make_index_sequence<sizeof...(Rest)>{});
+    }
+
+    // ---- same search, mutable overload -------------------------------------------
+    // Needed by set_masked_buses() (non-const) to forward into VoltageControl; kept
+    // separate from the const version above rather than const_cast-ing its result.
+    template <class T, class U>
+    static void _maybe_set_ext_mut(T*& /*found*/, U& /*ext*/) {}
+    template <class T>
+    static void _maybe_set_ext_mut(T*& found, T& ext) { found = &ext; }
+
+    template <class T, std::size_t... Is>
+    T* _find_extension_impl(std::index_sequence<Is...>) {
+        T* found = nullptr;
+        int dummy[] = { 0, (_maybe_set_ext_mut<T>(found, std::get<Is>(extensions_)), 0)... };
+        (void)dummy;
+        return found;
+    }
+    template <class T>
+    T* _find_extension() {
         return _find_extension_impl<T>(std::make_index_sequence<sizeof...(Rest)>{});
     }
 

--- a/src/core/powerflow_algorithm/NRSystemVoltageControl.cpp
+++ b/src/core/powerflow_algorithm/NRSystemVoltageControl.cpp
@@ -34,6 +34,9 @@ void VoltageControl::update_state(
     my_size_ = data_.n_controllers();
     // per-solve init: the reactive injection state starts at 0 (gen convention)
     q_ = RealVect::Zero(my_size_);
+    // data_ is now current for this compute_pf() call -- safe to derive
+    // group_stranded_ from it (see set_masked_buses / _recompute_group_stranded).
+    _recompute_group_stranded();
 }
 
 } // namespace ls2g

--- a/src/tests/test_batch_voltage_control.cpp
+++ b/src/tests/test_batch_voltage_control.cpp
@@ -107,6 +107,59 @@ LSGrid make_remote_gen_grid()
     return grid;
 }
 
+// 3-bus grid shaped like the "regulated bus stranded" grid above turned inside
+// out: bus 0 (slack) --line-- bus 1 (D, the REGULATED bus, on the path to the
+// rest of the grid) --trafo-- bus 2 (B, a LEAF carrying the sole controller).
+// Tripping the trafo strands the CONTROLLER's own bus, not the regulated one --
+// the scenario a lone (cnt == 1) group now falls back to plain PQ for instead of
+// diverging (see VoltageControl::set_masked_buses in NRSystem.hpp).
+const int LEAF_NB_BUS = 3;
+const int LEAF_BUS_D = 1;
+const int LEAF_BUS_B = 2;
+
+LSGrid make_leaf_remote_gen_grid()
+{
+    LSGrid grid;
+    grid.set_sn_mva(100.);
+    grid.set_init_vm_pu(1.0);
+    const RealVect bus_vn_kv = RealVect::Constant(LEAF_NB_BUS, 138.);
+    grid.init_bus(static_cast<unsigned int>(LEAF_NB_BUS), 1, bus_vn_kv, 0, 0);
+
+    RealVect line_r(1), line_x(1);
+    line_r << 0.01; line_x << 0.1;
+    CplxVect line_h(1); line_h << cplx_type(0., 0.);
+    Eigen::VectorXi line_from(1), line_to(1);
+    line_from << 0; line_to << LEAF_BUS_D;
+    grid.init_powerlines(line_r, line_x, line_h, line_from, line_to);
+
+    RealVect tr_r(1), tr_x(1), tr_ratio(1), tr_shift(1);
+    tr_r << 0.005; tr_x << 0.08; tr_ratio << 1.0; tr_shift << 0.0;
+    CplxVect tr_b(1); tr_b << cplx_type(0., 0.);
+    std::vector<bool> tr_tap_hv(1, true);
+    Eigen::VectorXi tr_bus1(1), tr_bus2(1);
+    tr_bus1 << LEAF_BUS_D; tr_bus2 << LEAF_BUS_B;
+    grid.init_trafo(tr_r, tr_x, tr_b, tr_ratio, tr_shift, tr_tap_hv, tr_bus1, tr_bus2, false);
+
+    RealVect load_p(1), load_q(1);
+    load_p << LOAD_P; load_q << LOAD_Q;
+    Eigen::VectorXi load_bus(1); load_bus << LEAF_BUS_D;
+    grid.init_loads(load_p, load_q, load_bus);
+
+    RealVect gen_p(2), gen_v(2), gen_min_q(2), gen_max_q(2);
+    Eigen::VectorXi gen_bus(2);
+    gen_p << 0., 0.;
+    gen_v << 1.02, V_SET;
+    gen_min_q << -1000., -1000.;
+    gen_max_q << 1000., 1000.;
+    gen_bus << 0, LEAF_BUS_B;
+    grid.init_generators(gen_p, gen_v, gen_min_q, gen_max_q, gen_bus);
+
+    grid.add_gen_slackbus(0, 1.);
+    grid.set_gen_regulated_bus(1, LEAF_BUS_D);
+    grid.tell_solver_need_reset();
+    return grid;
+}
+
 // slack generator at bus 0, plus TWO generators (buses 1 and 2, deliberately
 // different reactive ranges) both remotely regulating bus 3 at the same setpoint.
 // One control group of two controllers: two Q columns against one voltage row plus
@@ -438,6 +491,140 @@ TEST_CASE("a contingency stranding a regulated bus is reported, not silently wro
         CHECK(ca.converged()[0] == 0);
         for (int b = 0; b < NB_BUS; ++b) CHECK(std::abs(ca.get_voltages()(0, b)) == 0.);
     }
+}
+
+TEST_CASE("a contingency stranding a lone controller's own bus falls back to plain PQ", "[batch][vctrl][mask]")
+{
+    // Mirror image of the previous test: the trafo strands bus 2 (B, the sole
+    // controller's own bus), not bus 1 (D, the regulated one). A single-shot
+    // powerflow on the same post-contingency grid (trafo out, controller
+    // explicitly disconnected -- what a rebuilt topology does once it drops the
+    // controller from its group) is the reference: bus D should float free of
+    // V_SET, not diverge and not stay pinned to it.
+    LSGrid ref_grid = make_leaf_remote_gen_grid();
+    ref_grid.change_algorithm(AlgorithmType::NR_SparseLU);
+    ref_grid.deactivate_trafo(0);
+    ref_grid.deactivate_gen(1);
+    const CplxVect ref = ref_grid.ac_pf(
+        CplxVect::Constant(static_cast<Eigen::Index>(ref_grid.total_bus()), cplx_type(1., 0.)), 30, 1e-10);
+    REQUIRE(ref.size() == LEAF_NB_BUS);
+    // guard the guard: the reference really doesn't hold D at V_SET any more
+    CHECK(std::abs(std::abs(ref(LEAF_BUS_D)) - V_SET) > 1e-4);
+
+    for (bool handle_disconnected : {false, true}) {
+        INFO("handle_disconnected_grid = " << handle_disconnected);
+        LSGrid grid = make_leaf_remote_gen_grid();
+        grid.change_algorithm(AlgorithmType::NR_SparseLU);
+        ContingencyAnalysis ca(grid, /*compute_limit_violations=*/true);
+        ca.set_handle_disconnected_grid(handle_disconnected);
+        ca.add_n1(1);  // trafo 0: 1 powerline (id 0) precedes it, so its id is 1
+        ca.compute(CplxVect::Constant(static_cast<Eigen::Index>(grid.total_bus()), cplx_type(1., 0.)), 30, 1e-10);
+        REQUIRE(ca.get_voltages().rows() == 1);
+        REQUIRE(ca.converged().size() == 1);
+        if (!handle_disconnected) {
+            // default mode: still skipped outright, unchanged behaviour
+            CHECK(ca.converged()[0] == 0);
+            for (int b = 0; b < LEAF_NB_BUS; ++b) CHECK(std::abs(ca.get_voltages()(0, b)) == 0.);
+            continue;
+        }
+        CHECK(ca.converged()[0] == 1);
+        for (int b : {0, LEAF_BUS_D}) {
+            INFO("bus " << b);
+            CHECK(std::abs(ca.get_voltages()(0, b)) == Approx(std::abs(ref(b))).epsilon(1e-8));
+            CHECK(std::arg(ca.get_voltages()(0, b)) == Approx(std::arg(ref(b))).margin(1e-9));
+        }
+        // bus B (the masked/stranded one) reports 0, same convention as every
+        // other masked bus
+        CHECK(std::abs(ca.get_voltages()(0, LEAF_BUS_B)) == 0.);
+    }
+}
+
+TEST_CASE("a stranded member of a SHARED control group is unaffected by the cnt==1 fallback", "[batch][vctrl][mask]")
+{
+    // bus 0 (slack) --line-- bus 1 (D, regulated) --trafoA-- bus 2 (ctrl A)
+    //                                              --trafoB-- bus 3 (ctrl B)
+    // Generators on buses 2 AND 3 both remotely regulate bus 1: a cnt==2 group.
+    // Tripping trafo A strands ctrl A's own bus only -- bus 1 (D) and ctrl B
+    // (bus 3) both stay live. The fallback added for the lone (cnt==1) case in
+    // the previous test deliberately does NOT extend to a partially-stranded
+    // shared group (set_masked_buses / _recompute_group_stranded skip any group
+    // with grp_count() != 1) -- this pins that the cnt==2 case is bit-for-bit
+    // unaffected by that change.
+    //
+    // It happens NOT to diverge: ctrl A's own Q unknown loses its coupling to
+    // its (now masked) bus, but stays coupled to the group's sharing row, which
+    // is untouched by masking -- so the augmented system stays non-singular. The
+    // voltage row only ever depended on Vm(bus 1) (no slope declared for a GEN
+    // in a cnt>1 group, before or after this change), so bus 1 still lands on
+    // V_SET, courtesy of ctrl B alone; ctrl A's Q comes out as whatever the
+    // sharing formula slaves it to, with no bearing on anything physical since
+    // its own bus's real power-balance equation is masked away. That is exactly
+    // what LSGrid::ac_pf on the same post-contingency grid (trafo A out, gen A
+    // left fully connected but electrically isolated) also produces, so it is
+    // used as the reference below.
+    const int SH_NB_BUS = 4;
+    LSGrid grid;
+    grid.set_sn_mva(100.);
+    grid.set_init_vm_pu(1.0);
+    const RealVect bus_vn_kv = RealVect::Constant(SH_NB_BUS, 138.);
+    grid.init_bus(static_cast<unsigned int>(SH_NB_BUS), 1, bus_vn_kv, 0, 0);
+
+    RealVect line_r(1), line_x(1);
+    line_r << 0.01; line_x << 0.1;
+    CplxVect line_h(1); line_h << cplx_type(0., 0.);
+    Eigen::VectorXi line_from(1), line_to(1);
+    line_from << 0; line_to << 1;
+    grid.init_powerlines(line_r, line_x, line_h, line_from, line_to);
+
+    RealVect tr_r(2), tr_x(2), tr_ratio(2), tr_shift(2);
+    tr_r << 0.005, 0.005; tr_x << 0.08, 0.08; tr_ratio << 1.0, 1.0; tr_shift << 0.0, 0.0;
+    CplxVect tr_b(2); tr_b << cplx_type(0., 0.), cplx_type(0., 0.);
+    std::vector<bool> tr_tap_hv(2, true);
+    Eigen::VectorXi tr_bus1(2), tr_bus2(2);
+    tr_bus1 << 1, 1; tr_bus2 << 2, 3;
+    grid.init_trafo(tr_r, tr_x, tr_b, tr_ratio, tr_shift, tr_tap_hv, tr_bus1, tr_bus2, false);
+
+    RealVect load_p(1), load_q(1);
+    load_p << LOAD_P; load_q << LOAD_Q;
+    Eigen::VectorXi load_bus(1); load_bus << 1;
+    grid.init_loads(load_p, load_q, load_bus);
+
+    RealVect gen_p(3), gen_v(3), gen_min_q(3), gen_max_q(3);
+    Eigen::VectorXi gen_bus(3);
+    gen_p << 0., 0., 0.;
+    gen_v << 1.02, V_SET, V_SET;
+    gen_min_q << -1000., -1000., -1000.;
+    gen_max_q << 1000., 1000., 1000.;
+    gen_bus << 0, 2, 3;
+    grid.init_generators(gen_p, gen_v, gen_min_q, gen_max_q, gen_bus);
+    grid.add_gen_slackbus(0, 1.);
+    grid.set_gen_regulated_bus(1, 1);  // gen on bus 2 regulates bus 1
+    grid.set_gen_regulated_bus(2, 1);  // gen on bus 3 regulates bus 1 too
+    grid.tell_solver_need_reset();
+
+    LSGrid ref_grid = grid;  // (LSGrid's copy ctor resets solver-side state only, not the model)
+    ref_grid.change_algorithm(AlgorithmType::NR_SparseLU);
+    ref_grid.deactivate_trafo(0);  // trafo A
+    ref_grid.deactivate_gen(1);    // ctrl A
+    const CplxVect ref = ref_grid.ac_pf(
+        CplxVect::Constant(static_cast<Eigen::Index>(ref_grid.total_bus()), cplx_type(1., 0.)), 30, 1e-10);
+    REQUIRE(ref.size() == SH_NB_BUS);
+    CHECK(std::abs(ref(1)) == Approx(V_SET).epsilon(1e-8));  // ctrl B alone still holds bus 1
+
+    grid.change_algorithm(AlgorithmType::NR_SparseLU);
+    ContingencyAnalysis ca(grid, /*compute_limit_violations=*/true);
+    ca.set_handle_disconnected_grid(true);
+    ca.add_n1(1);  // trafo A (1--2): 1 powerline precedes the trafos, so its id is 1
+    ca.compute(CplxVect::Constant(static_cast<Eigen::Index>(grid.total_bus()), cplx_type(1., 0.)), 30, 1e-10);
+    REQUIRE(ca.get_voltages().rows() == 1);
+    REQUIRE(ca.converged().size() == 1);
+    CHECK(ca.converged()[0] == 1);
+    for (int b : {0, 1, 3}) {
+        INFO("bus " << b);
+        CHECK(std::abs(ca.get_voltages()(0, b)) == Approx(std::abs(ref(b))).epsilon(1e-8));
+        CHECK(std::arg(ca.get_voltages()(0, b)) == Approx(std::arg(ref(b))).margin(1e-9));
+    }
+    CHECK(std::abs(ca.get_voltages()(0, 2)) == 0.);  // ctrl A's own (masked) bus
 }
 
 TEST_CASE("stale solver state on the source grid cannot leak into a batch", "[batch][stale]")

--- a/src/tests/test_batch_voltage_control.cpp
+++ b/src/tests/test_batch_voltage_control.cpp
@@ -539,6 +539,42 @@ TEST_CASE("a contingency stranding a lone controller's own bus falls back to pla
     }
 }
 
+TEST_CASE("the fallback also works through the multi-threaded batch path", "[batch][vctrl][mask]")
+{
+    // set_may_mask_voltage_control gets wired differently for the single-threaded
+    // _algo (re-asserted + a forced rebuild in _maybe_prepare_masks, since _algo is
+    // a long-lived member that may already have sparsity built) than for the
+    // per-thread algos spawned fresh every compute() (told directly in
+    // init_thread, no rebuild needed -- their first build_J_sparsity() already
+    // sees it). Exercise the second path specifically: >= 2 contingencies with
+    // nb_thread >= 2 actually engages it.
+    LSGrid ref_grid = make_leaf_remote_gen_grid();
+    ref_grid.change_algorithm(AlgorithmType::NR_SparseLU);
+    ref_grid.deactivate_trafo(0);
+    ref_grid.deactivate_gen(1);
+    const CplxVect ref = ref_grid.ac_pf(
+        CplxVect::Constant(static_cast<Eigen::Index>(ref_grid.total_bus()), cplx_type(1., 0.)), 30, 1e-10);
+    REQUIRE(ref.size() == LEAF_NB_BUS);
+
+    LSGrid grid = make_leaf_remote_gen_grid();
+    grid.change_algorithm(AlgorithmType::NR_SparseLU);
+    ContingencyAnalysis ca(grid, /*compute_limit_violations=*/true);
+    ca.set_handle_disconnected_grid(true);
+    ca.set_nb_thread(2);
+    ca.add_n1(0);  // the line: no stranding, just here to force nb_thread == 2
+    ca.add_n1(1);  // the trafo: strands ctrl's own bus, as in the test above
+    ca.compute(CplxVect::Constant(static_cast<Eigen::Index>(grid.total_bus()), cplx_type(1., 0.)), 30, 1e-10);
+    REQUIRE(ca.get_voltages().rows() == 2);
+    REQUIRE(ca.converged().size() == 2);
+    CHECK(ca.converged()[1] == 1);
+    for (int b : {0, LEAF_BUS_D}) {
+        INFO("bus " << b);
+        CHECK(std::abs(ca.get_voltages()(1, b)) == Approx(std::abs(ref(b))).epsilon(1e-8));
+        CHECK(std::arg(ca.get_voltages()(1, b)) == Approx(std::arg(ref(b))).margin(1e-9));
+    }
+    CHECK(std::abs(ca.get_voltages()(1, LEAF_BUS_B)) == 0.);
+}
+
 TEST_CASE("a stranded member of a SHARED control group is unaffected by the cnt==1 fallback", "[batch][vctrl][mask]")
 {
     // bus 0 (slack) --line-- bus 1 (D, regulated) --trafoA-- bus 2 (ctrl A)


### PR DESCRIPTION
## Summary

- Fixes a `ContingencyAnalysis` / `SecurityAnalysis` `handle_disconnected_grid` bug: a contingency that strands a lone (single-controller) remote voltage regulator's own bus — e.g. a generator that reaches its regulated bus only through a transformer that trips — used to come back as a DIVERGENCE. Bus masking is a value-only Jacobian edit (no sparsity/dimension change, so the symbolic factorization is reused), but the `VoltageControl` extension's bordered voltage row survived untouched and kept demanding `Vm(regulated) == v_set` while the controller's own reactive-injection unknown lost its only coupling once its bus's P/Q rows were masked to identity — a structurally singular system.
- For a group with exactly one controller, that row is now repurposed (only when the mask strands the controller's own bus) into a plain `Q_c == 0` pin, using one extra Jacobian slot per such controller. The regulated bus then falls back to its own ordinary PQ equations, matching what a rebuilt (single-shot) topology already does once the disconnected controller drops out of its group.
- That extra slot is reserved **only** when it can ever be used: `NRAlgo` / `AlgorithmSelector` gained `set_may_mask_voltage_control(bool)`, wired by `BaseBatchSweep` exactly when `handle_disconnected_grid` is enabled for a given run (on the long-lived member algo, with a forced sparsity rebuild since it may already have sparsity built; and on every freshly-spawned per-thread algo in the multi-threaded path, no rebuild needed there). Plain `ac_pf`, `TimeSeriesCPP`, and a `ContingencyAnalysis`/`ScenarioSweep` that never turns `handle_disconnected_grid` on stay bit-for-bit as cheap as before this change, regardless of how many remote-regulating generators or SVCs the grid has.

## Scope

Deliberately narrow, matching an explicit request during review:
- Only a group with exactly one controller (`cnt == 1`) is covered. A group shared by more than one controller regulating the same bus is untouched — stranding one of several members stays exactly as it was before (it happens not to diverge either, for an unrelated reason: the surviving sharing-row coupling keeps the system non-singular; see the new "unaffected by the cnt==1 fallback" test).
- Stranding the *regulated* bus itself (rather than a controller's bus) also stays a DIVERGENCE — that case has no well-defined fallback under the "same sparsity every contingency" masking design, and even a rebuilt single-shot topology has no support for it either (it raises).
- A finer per-controller gate (reserving the slot only for controllers whose bus appears in *this run's actual* contingency set, using the `_li_masked` data `_select_ref_slack_and_masks` already computes) was considered and intentionally not implemented: it would need a new "contingency set changed since sparsity was built" invalidation path that doesn't exist today, and getting it wrong would silently reintroduce the same singular-Jacobian bug this PR fixes.

## Test plan

- [x] Full C++ suite built from scratch (Eigen `NR_SparseLU`, no KLU) against this branch's `dev_1.0.1` base: 252 test cases / 591203 assertions, all green.
- [x] New regression tests in `src/tests/test_batch_voltage_control.cpp`:
  - the fix itself: a stranded lone controller now converges and matches a manually-disconnected single-shot reference, with the `handle_disconnected_grid=False` case unchanged (still skipped outright)
  - the `cnt>1` scope boundary is pinned as unaffected
  - the fix also works through the multi-threaded batch path (exercises the per-thread `set_may_mask_voltage_control` wiring specifically), run 3x to rule out scheduling flakiness

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Dkbg9xyFV7Paj7ui2GQSyH

---
_Generated by [Claude Code](https://claude.ai/code/session_01Dkbg9xyFV7Paj7ui2GQSyH)_