### PR TITLE
Continuation powerflow with per-element load / generation steering

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -162,8 +162,9 @@ TODO: a "combine mode" axis for ``ScenarioSweepCPP`` choosing between the curren
   nose rather than rounding it.
 - [ADDED] ``load_steering`` / ``gen_steering``: per-element coefficients in [0, 1] steering which
   loads and generators move during a continuation (0 holds an element at its base value).
-  Generation follows the load by default, the slack taking only the losses, as MATPOWER requires
-  of a target case.
+  Generation follows the load by default, slack machines included: unlike in MATPOWER, whose
+  rule rests on a slack ``Pg`` being an output, a distributed-slack participant's setpoint is a
+  genuine input here.
 - [ADDED] ``ContinuationSweepCPP``, a batch algorithm alongside the four existing ones: the whole
   curve costs one symbolic factorization, whatever the number of points.
 - [ADDED] ``LightSimBackend(loader_method="matpower")``: a grid2op environment can now ship a

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -156,6 +156,16 @@ TODO: a "combine mode" axis for ``ScenarioSweepCPP`` choosing between the curren
 
 [1.0.1] 2026-xx-yy
 --------------------
+- [ADDED] ``ContinuationPowerFlow`` / ``run_cpf``: a continuation powerflow tracing the PV curve
+  from the grid's injections to a target state, stopping at the voltage-collapse nose. Options
+  and defaults follow MATPOWER's ``cpf.*``. Natural parameterisation, so the curve stops at the
+  nose rather than rounding it.
+- [ADDED] ``load_steering`` / ``gen_steering``: per-element coefficients in [0, 1] steering which
+  loads and generators move during a continuation (0 holds an element at its base value).
+  Generation follows the load by default, the slack taking only the losses, as MATPOWER requires
+  of a target case.
+- [ADDED] ``ContinuationSweepCPP``, a batch algorithm alongside the four existing ones: the whole
+  curve costs one symbolic factorization, whatever the number of points.
 - [ADDED] ``LightSimBackend(loader_method="matpower")``: a grid2op environment can now ship a
   MATPOWER case (``grid.m`` / ``grid.mat``) as its powergrid, next to pandapower's ``grid.json``
   and pypowsybl's ``grid.xiidm``. One substation per matpower bus, grid2op default names.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,47 +47,22 @@ have to reason about and how much is tests, docs and changelog:
 ```
 | | added | removed |
 |---|---|---|
-| **C++ (src/core, src/bindings)** | +968 | -0 |
+| **C++ (src/core, src/bindings)** | +970 | -0 |
 | **Python (package)** | +384 | -0 |
-| **Tests** | +764 | -0 |
-| **Docs + changelog** | +160 | -0 |
-| total | +2277 | -0 |
+| **Tests** | +922 | -0 |
+| **Docs + changelog** | +212 | -0 |
+| total | +2489 | -0 |
 ```
 
-Buckets, in this order (drop a row that is empty):
-
-- **C++** — `src/core/**` and `src/bindings/**` (`.cpp` / `.hpp` / `.tpp`), tests excluded.
-- **Python** — `lightsim2grid/**.py`, tests excluded.
-- **Tests** — `src/tests/**` and `lightsim2grid/tests/**`, whatever the language.
-- **Docs + changelog** — `docs/**` and any `.rst` / `.md`, `CHANGELOG.rst` included.
-- **Build / other** — everything left (CMake, CI, fixtures), so the total is the real total.
-
-Generate it against the PR's BASE branch rather than counting by hand:
+`utils/pr_diff_stats.py` produces it — it holds the bucket definitions, so they stay in one
+place rather than being restated here:
 
 ```
-python3 - "$(git merge-base origin/<base> HEAD)" <<'EOF'
-import subprocess, sys, fnmatch
-out = subprocess.run(["git", "diff", "--numstat", sys.argv[1] + "...HEAD"],
-                     capture_output=True, text=True).stdout
-def bucket(p):
-    if fnmatch.fnmatch(p, "src/tests/*") or fnmatch.fnmatch(p, "lightsim2grid/tests/*"): return "tests"
-    if p.startswith("docs/") or p.endswith((".rst", ".md")): return "docs"
-    if p.startswith(("src/core/", "src/bindings/")) and p.endswith((".cpp", ".hpp", ".tpp", ".h")): return "cpp"
-    if p.startswith("lightsim2grid/") and p.endswith(".py"): return "python"
-    return "other"
-tot = {}
-for line in out.strip().splitlines():
-    a, d, path = line.split("\t")
-    if a == "-": continue          # binary file
-    e = tot.setdefault(bucket(path), [0, 0]); e[0] += int(a); e[1] += int(d)
-rows = [("cpp", "C++ (src/core, src/bindings)"), ("python", "Python (package)"),
-        ("tests", "Tests"), ("docs", "Docs + changelog"), ("other", "Build / other")]
-print("| | added | removed |\n|---|---|---|")
-for k, label in rows:
-    if k in tot: print(f"| **{label}** | +{tot[k][0]} | -{tot[k][1]} |")
-print(f"| total | +{sum(v[0] for v in tot.values())} | -{sum(v[1] for v in tot.values())} |")
-EOF
+python3 utils/pr_diff_stats.py                # against origin/dev_1.0.1 (the default)
+python3 utils/pr_diff_stats.py origin/main    # against another base branch
 ```
+
+Run it against the PR's own base branch, and paste the table as the first thing in the body.
 
 ## Build
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,6 +37,58 @@ Rules:
   followed by `git push --force-with-lease`. This is the case that actually bites: the
   mistake is usually noticed only after CI has run.
 
+## Pull requests: lead with the diff breakdown
+
+A PR here routinely runs to one or two thousand lines, which is daunting to open and tells
+a reviewer nothing about where the work actually is. **Start every PR body with a table
+splitting the diff by kind**, so the reader can see at a glance how much of it is code they
+have to reason about and how much is tests, docs and changelog:
+
+```
+| | added | removed |
+|---|---|---|
+| **C++ (src/core, src/bindings)** | +968 | -0 |
+| **Python (package)** | +384 | -0 |
+| **Tests** | +764 | -0 |
+| **Docs + changelog** | +160 | -0 |
+| total | +2277 | -0 |
+```
+
+Buckets, in this order (drop a row that is empty):
+
+- **C++** — `src/core/**` and `src/bindings/**` (`.cpp` / `.hpp` / `.tpp`), tests excluded.
+- **Python** — `lightsim2grid/**.py`, tests excluded.
+- **Tests** — `src/tests/**` and `lightsim2grid/tests/**`, whatever the language.
+- **Docs + changelog** — `docs/**` and any `.rst` / `.md`, `CHANGELOG.rst` included.
+- **Build / other** — everything left (CMake, CI, fixtures), so the total is the real total.
+
+Generate it against the PR's BASE branch rather than counting by hand:
+
+```
+python3 - "$(git merge-base origin/<base> HEAD)" <<'EOF'
+import subprocess, sys, fnmatch
+out = subprocess.run(["git", "diff", "--numstat", sys.argv[1] + "...HEAD"],
+                     capture_output=True, text=True).stdout
+def bucket(p):
+    if fnmatch.fnmatch(p, "src/tests/*") or fnmatch.fnmatch(p, "lightsim2grid/tests/*"): return "tests"
+    if p.startswith("docs/") or p.endswith((".rst", ".md")): return "docs"
+    if p.startswith(("src/core/", "src/bindings/")) and p.endswith((".cpp", ".hpp", ".tpp", ".h")): return "cpp"
+    if p.startswith("lightsim2grid/") and p.endswith(".py"): return "python"
+    return "other"
+tot = {}
+for line in out.strip().splitlines():
+    a, d, path = line.split("\t")
+    if a == "-": continue          # binary file
+    e = tot.setdefault(bucket(path), [0, 0]); e[0] += int(a); e[1] += int(d)
+rows = [("cpp", "C++ (src/core, src/bindings)"), ("python", "Python (package)"),
+        ("tests", "Tests"), ("docs", "Docs + changelog"), ("other", "Build / other")]
+print("| | added | removed |\n|---|---|---|")
+for k, label in rows:
+    if k in tot: print(f"| **{label}** | +{tot[k][0]} | -{tot[k][1]} |")
+print(f"| total | +{sum(v[0] for v in tot.values())} | -{sum(v[1] for v in tot.values())} |")
+EOF
+```
+
 ## Build
 
 The vendored dependencies are git submodules and start empty — a build fails with

--- a/docs/continuation_powerflow.rst
+++ b/docs/continuation_powerflow.rst
@@ -1,0 +1,133 @@
+Continuation Power Flow
+=======================================
+
+Goal
+--------------------------
+
+A continuation power flow (CPF) traces the solution curve of a grid as its injections
+move from where they are now towards a target state, and reports where that curve turns
+back on itself -- the "nose", i.e. the maximum loading the grid can serve at all. It
+answers "how much more load can this grid take, and which bus gives way first", which a
+sequence of ordinary powerflows cannot: near the collapse point the Newton-Raphson simply
+stops converging, and a divergence does not tell you whether the grid is at its limit or
+your starting point was bad.
+
+The parameter along the curve is called :math:`\lambda`: :math:`\lambda = 0` is the grid's
+own state, :math:`\lambda = 1` the target state. This is MATPOWER's ``runcpf``
+formulation, and the option names and defaults below follow its ``cpf.*`` options.
+
+.. note::
+    This is a *natural* parameterisation: the corrector solves at a fixed
+    :math:`\lambda`, so the curve stops **at** the nose and does not trace the lower
+    branch. Rounding the nose needs an arc-length parameterisation (MATPOWER's
+    ``cpf.parameterization`` 2 / 3), which is not implemented yet.
+
+Basic usage
+--------------------------
+
+.. code-block:: python
+
+    import pandapower.networks as pn
+    from lightsim2grid.network import init_from_pandapower
+    from lightsim2grid import run_cpf
+
+    grid = init_from_pandapower(pn.case118())
+
+    res = run_cpf(grid, loading_factor=3.0)
+    print(res.msg)
+    print(f"collapse at {res.lam_max:.3f} of the requested increase")
+    print(f"ie a load {1 + res.lam_max * (3.0 - 1.0):.3f} times the base one")
+
+``res`` is a :class:`lightsim2grid.continuationPowerflow.CPFResult`: ``lam``, ``V``,
+``Vm``, ``Va_deg``, ``tangent_lam``, ``lam_max``, ``success`` and ``msg``. The helper
+``plot_pv_curve(res)`` draws the PV curve of the worst buses if matplotlib is installed.
+
+Steering which elements move
+--------------------------------
+
+By default every load grows together and generation follows, so the direction is
+"the whole grid, uniformly". Two vectors change that, one coefficient per element in
+``[0, 1]``: **0 holds that element at its base value, 1 moves it fully**.
+
+.. code-block:: python
+
+    import numpy as np
+
+    # only the loads of one area grow; everything else stays put
+    steering = np.zeros(len(grid.get_loads()))
+    steering[my_area_load_ids] = 1.0
+    res = run_cpf(grid, loading_factor=3.0, load_steering=steering)
+
+    # ... and this one grows at only 40% of the rate of the others
+    steering[another_load_id] = 0.4
+
+``gen_steering`` is the same, per generator. Its default is 1 for every non-slack
+generator and 0 for the slack ones, so generation follows the load and the slack picks up
+only the incremental losses -- MATPOWER requires exactly that of a target case ("same as
+base case w.r.t. Qg and slack Pg"). Passing ``gen_steering=0`` instead holds generation
+fixed and makes the slack supply the whole increase; that is a legitimate study, but it
+traces a **different curve with a different nose**, so do not compare the two margins.
+
+``scale_q=True`` (the default) scales each load's reactive power by the same coefficient
+as its active power, i.e. at constant power factor. For a direction that no combination
+of these expresses, ``direction=`` takes explicit per-element deltas in MW / MVAr:
+
+.. code-block:: python
+
+    res = run_cpf(grid, direction={"load_p": delta_load_p, "gen_p": delta_gen_p})
+
+Performance
+--------------------------
+
+The continuation is a batch algorithm
+(:class:`lightsim2grid.lightsim2grid_cpp.ContinuationSweepCPP`), not a Python loop around
+``ac_pf``: the topology is fixed for the whole curve, so the Jacobian's sparsity pattern
+is too, and the **whole curve costs one symbolic factorization** whatever the number of
+points. Every corrector after the first only refactorizes, and each predictor is a single
+triangular solve reusing the factorization the corrector left standing -- which is what
+makes tracing a curve of several hundred points affordable.
+
+You can check this on any run::
+
+    cpf = ContinuationPowerFlow(grid)
+    res = cpf.run(loading_factor=3.0)
+    assert cpf.cpp.get_linear_solver_stats().nb_analyze == 1
+
+Only the Newton-Raphson algorithms are supported (the predictor needs a Jacobian);
+``AlgorithmType.GaussSeidel``, the fast-decoupled family and the DC algorithms are
+refused with an explicit message.
+
+Options
+--------------------------
+
+Named and defaulted after MATPOWER's ``cpf.*``:
+
+===========================  =========  ==============================================
+option                       default    meaning
+===========================  =========  ==============================================
+``step``                     0.05       nominal step, an arc length along the tangent
+``step_min``                 1e-4       failing at this step ends the curve
+``step_max``                 0.2        largest step the adaptation may grow to
+``adapt_step``               ``False``  adapt the step to the predictor's error
+``adapt_step_damping``       0.7        damping of that adaptation
+``adapt_step_tol``           1e-3       predictor error the adaptation aims at
+``nose_tol``                 1e-5       ``tangent_lam`` below this means "at the nose"
+``stop_at_lam``              ``None``   stop at this lambda instead of at the nose
+``max_steps``                1000       hard cap on the number of traced points
+``exact_tangent``            ``False``  refactorize J at each point before its tangent
+===========================  =========  ==============================================
+
+``tangent_lam`` is the tangent's :math:`\lambda` component. With this parameterisation it
+is strictly positive and *tends to zero* at the nose -- it is a threshold, never a sign
+change.
+
+Detailed usage
+--------------------------
+
+.. automodule:: lightsim2grid.continuationPowerflow
+    :members:
+    :autosummary:
+
+* :ref:`genindex`
+* :ref:`modindex`
+* :ref:`search`

--- a/docs/continuation_powerflow.rst
+++ b/docs/continuation_powerflow.rst
@@ -61,12 +61,27 @@ By default every load grows together and generation follows, so the direction is
     # ... and this one grows at only 40% of the rate of the others
     steering[another_load_id] = 0.4
 
-``gen_steering`` is the same, per generator. Its default is 1 for every non-slack
-generator and 0 for the slack ones, so generation follows the load and the slack picks up
-only the incremental losses -- MATPOWER requires exactly that of a target case ("same as
-base case w.r.t. Qg and slack Pg"). Passing ``gen_steering=0`` instead holds generation
-fixed and makes the slack supply the whole increase; that is a legitimate study, but it
-traces a **different curve with a different nose**, so do not compare the two margins.
+``gen_steering`` is the same, per generator, and also defaults to all ones: generation
+follows the load. Passing ``gen_steering=0`` instead holds generation fixed and makes the
+slack supply the whole increase; that is a legitimate study, but it traces a **different
+curve with a different nose**, so do not compare the two margins.
+
+.. note::
+    MATPOWER requires a target case to be "same as base case w.r.t. Qg and slack Pg", and
+    slack machines are deliberately *not* excluded here even so. MATPOWER's rule exists
+    because a slack bus has no active-power equation, so its ``Pg`` is an output of the
+    powerflow rather than an input -- specifying a change there asks for something the
+    solver ignores. That reasoning holds for a **single slack** in lightsim2grid too
+    (scaling the slack machine's ``target_p`` leaves the solution bit-identical), which
+    makes excluding it a no-op rather than a correction. It does **not** hold for a
+    **distributed slack**, where every participant's ``target_p`` genuinely enters its
+    bus' equation -- excluding them would silently freeze most of the generation on a grid
+    whose slack is spread over many machines. One rule for every generator is simpler and
+    correct in both cases.
+
+    Either way the slack machine's *output* still follows the load: with every other
+    machine scaled by :math:`k` it ends up producing roughly :math:`k` times its base
+    power. Holding its setpoint would never have held its production.
 
 ``scale_q=True`` (the default) scales each load's reactive power by the same coefficient
 as its active power, i.e. at constant power factor. For a direction that no combination

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -62,6 +62,7 @@ This is a work in progress at the moment
    time_series
    security_analysis
    scenario_sweep
+   continuation_powerflow
    cpp_library
    solver_plugin
    binary_serialization

--- a/lightsim2grid/__init__.py
+++ b/lightsim2grid/__init__.py
@@ -128,6 +128,12 @@ except ImportError as exc_:  # noqa: F841
     # grid2op is not installed, the ScenarioSweep module will not be available
     pass
 
+# the continuation powerflow works on an LSGrid directly, it needs no grid2op
+from lightsim2grid.continuationPowerflow import ContinuationPowerFlow, run_cpf  # noqa: F401
+__all__.append("ContinuationPowerFlow")
+__all__.append("run_cpf")
+__all__.append("continuationPowerflow")
+
 try:
     from lightsim2grid.rewards import N1ContingencyReward  # noqa: F401
     __all__.append("rewards")

--- a/lightsim2grid/continuationPowerflow.py
+++ b/lightsim2grid/continuationPowerflow.py
@@ -1,0 +1,362 @@
+# Copyright (c) 2020-2026, RTE (https://www.rte-france.com)
+# See AUTHORS.txt
+# This Source Code Form is subject to the terms of the Mozilla Public License, version 2.0.
+# If a copy of the Mozilla Public License, version 2.0 was not distributed with this file,
+# you can obtain one at http://mozilla.org/MPL/2.0/.
+# SPDX-License-Identifier: MPL-2.0
+# This file is part of LightSim2grid, LightSim2grid implements a c++ backend targeting the Grid2Op platform.
+
+"""
+Continuation powerflow (CPF): trace the PV curve of a grid up to its voltage-collapse
+"nose" point.
+
+Everything numerical happens in C++ (:class:`lightsim2grid.lightsim2grid_cpp.ContinuationSweepCPP`,
+see ``src/core/batch_algorithm/ContinuationSweep.hpp``). This module only turns a
+loading factor and a pair of steering vectors into the *target injection state* the C++
+class continues towards, and presents the traced curve back.
+"""
+
+__all__ = ["ContinuationPowerFlow", "CPFResult", "run_cpf", "plot_pv_curve"]
+
+import numpy as np
+
+from .lightsim2grid_cpp import ContinuationSweepCPP
+
+
+class CPFResult:
+    """
+    One traced curve. Attributes:
+
+    lam: ``(n_points,)``
+        The continuation parameter at each point. ``lam[0]`` is 0 (the base case) and
+        ``lam == 1`` is the target state, i.e. the full requested increase. So the load
+        of load ``l`` at point ``i`` is ``load_p[l] * (1 + alpha[l] * (k - 1) * lam[i])``
+        with ``k`` the loading factor and ``alpha`` the steering vector.
+    V: ``(n_points, n_bus)`` complex
+        Bus voltages at each point, in the grid's own bus ordering. Buses that are not
+        part of the solved system read exactly ``0``.
+    Vm, Va_deg: ``(n_points, n_bus)``
+        Magnitude (pu) and angle (degrees) of ``V``.
+    tangent_lam: ``(n_points,)``
+        The tangent's lambda component at each point, in ``(0, 1]``. It tends to zero as
+        the curve turns: that is the collapse indicator. The last point has no tangent
+        computed after it and reads 0.
+    lam_max: float
+        The largest lambda reached, i.e. the loading margin along the chosen direction.
+    success: bool
+        Whether the curve reached its requested end (the nose, or ``stop_at_lam``).
+    msg: str
+        Why the run stopped, in words.
+    nb_retries: int
+        How many times a corrector failed and the step had to be halved.
+    """
+
+    def __init__(self, lam, V, tangent_lam, success, msg, nb_retries, cpp):
+        self.lam = lam
+        self.V = V
+        self.Vm = np.abs(V)
+        self.Va_deg = np.rad2deg(np.angle(V))
+        self.tangent_lam = tangent_lam
+        self.success = success
+        self.msg = msg
+        self.nb_retries = nb_retries
+        self.lam_max = float(lam[-1]) if lam.size else 0.0
+        #: the underlying C++ object, for the timers, the flows and the linear-solver counters
+        self.cpp = cpp
+
+    def __repr__(self):
+        return (f"CPFResult(success={self.success}, n_points={self.lam.size}, "
+                f"lam_max={self.lam_max:.4f}, msg={self.msg!r})")
+
+
+def _checked_steering(vect, nb_el, name):
+    """A steering vector: one coefficient per element, finite, in [0, 1]."""
+    arr = np.asarray(vect, dtype=float).ravel()
+    if arr.shape[0] != nb_el:
+        raise ValueError(f"{name}: expected one coefficient per element ({nb_el}), "
+                         f"got {arr.shape[0]}.")
+    if not np.all(np.isfinite(arr)):
+        raise ValueError(f"{name}: every coefficient must be finite.")
+    if np.any(arr < 0.0) or np.any(arr > 1.0):
+        raise ValueError(f"{name}: every coefficient must be in [0, 1] "
+                         f"(got min {arr.min()}, max {arr.max()}). A coefficient of 0 "
+                         f"keeps that element at its base value; 1 moves it fully.")
+    return arr
+
+
+class ContinuationPowerFlow:
+    """
+    Continuation powerflow on a :class:`lightsim2grid.network.LSGrid`.
+
+    The curve runs from the grid's own injection state (``lambda = 0``) to a *target*
+    state (``lambda = 1``), following the classical predictor / corrector scheme. This
+    is MATPOWER's ``runcpf`` formulation, and the option names and defaults below follow
+    its ``cpf.*`` options so that nothing here is a new concept.
+
+    The target is built for you from a loading factor and two steering vectors:
+
+    - ``load_steering`` -- one coefficient per load, in ``[0, 1]``. A load with 0 does
+      not move during the continuation; a load with 1 moves fully. Defaults to all ones
+      (every load scaled).
+    - ``gen_steering`` -- the same, per generator. Defaults to 1 for every non-slack
+      generator and 0 for the slack ones, so generation follows the load and the slack
+      only picks up the incremental losses -- MATPOWER requires exactly that of a target
+      case ("same as base case w.r.t. Qg and slack Pg"). Pass ``0`` to hold generation
+      fixed and let the slack supply the whole increase instead; that traces a different
+      curve, with a different nose.
+
+    .. warning::
+        This is a *natural* parameterisation: the corrector solves at a fixed lambda, so
+        the curve stops AT the nose and does not trace the lower branch. That needs an
+        arc-length parameterisation (MATPOWER's ``cpf.parameterization`` 2 / 3), which is
+        not implemented yet; when it is, it will become the default here as it is there.
+
+    Examples
+    ---------
+
+    .. code-block:: python
+
+        import numpy as np
+        from lightsim2grid.network import init_from_pandapower
+        from lightsim2grid.continuationPowerflow import ContinuationPowerFlow
+        import pandapower.networks as pn
+
+        grid = init_from_pandapower(pn.case118())
+
+        # how much margin is there if every load grows together?
+        cpf = ContinuationPowerFlow(grid)
+        res = cpf.run(loading_factor=3.0)
+        print(res.lam_max)
+
+        # ... and if only the loads of one area grow?
+        steering = np.zeros(len(grid.get_loads()))
+        steering[my_area_load_ids] = 1.0
+        res = cpf.run(loading_factor=3.0, load_steering=steering)
+
+    """
+
+    def __init__(self, grid, algorithm=None):
+        self._grid = grid
+        self._cpp = ContinuationSweepCPP(grid)
+        if algorithm is not None:
+            self._cpp.change_algorithm(algorithm)
+
+        self._base_load_p = np.array(grid.get_load_target_p(), dtype=float)
+        self._base_load_q = np.array([el.target_q_mvar for el in grid.get_loads()], dtype=float)
+        self._base_gen_p = np.array(grid.get_gen_target_p(), dtype=float)
+        self._base_sgen_p = np.array(grid.get_sgen_target_p(), dtype=float)
+        self._gen_is_slack = np.array([el.is_slack for el in grid.get_generators()], dtype=bool)
+
+    @property
+    def cpp(self):
+        """The underlying C++ object (timers, flows, linear-solver counters)."""
+        return self._cpp
+
+    def _build_target(self, loading_factor, load_steering, gen_steering, scale_q, direction):
+        """
+        Returns the four target axes, as ``{axis_name: values}``; an axis that does not
+        move is left out entirely (the C++ side then treats it as "unchanged").
+        """
+        if direction is not None:
+            if load_steering is not None or gen_steering is not None:
+                raise ValueError("run(): pass either `direction` (explicit per-element deltas) "
+                                 "or `load_steering` / `gen_steering` (a steered loading "
+                                 "factor), not both -- they are two ways of saying the same "
+                                 "thing and there is no sensible way to combine them.")
+            known = {"load_p": self._base_load_p, "load_q": self._base_load_q,
+                     "gen_p": self._base_gen_p, "sgen_p": self._base_sgen_p}
+            unknown = set(direction) - set(known)
+            if unknown:
+                raise ValueError(f"run(): unknown key(s) {sorted(unknown)} in `direction`; "
+                                 f"expected any of {sorted(known)}.")
+            target = {}
+            for axis, delta in direction.items():
+                base = known[axis]
+                delta = np.asarray(delta, dtype=float).ravel()
+                if delta.shape[0] != base.shape[0]:
+                    raise ValueError(f"run(): direction['{axis}'] has {delta.shape[0]} entries, "
+                                     f"expected {base.shape[0]}.")
+                target[axis] = base + delta
+            return target
+
+        if not np.isfinite(loading_factor) or loading_factor <= 1.0:
+            raise ValueError(f"run(): loading_factor must be a finite number strictly greater "
+                             f"than 1 (got {loading_factor}); it is the factor the steered "
+                             f"elements reach at lambda = 1.")
+        growth = loading_factor - 1.0
+
+        if load_steering is None:
+            alpha = np.ones(self._base_load_p.shape[0], dtype=float)
+        else:
+            alpha = _checked_steering(load_steering, self._base_load_p.shape[0], "load_steering")
+
+        if gen_steering is None:
+            # MATPOWER-like: generation follows the load, the slack only takes the losses.
+            beta = (~self._gen_is_slack).astype(float)
+        elif np.isscalar(gen_steering):
+            beta = _checked_steering(np.full(self._base_gen_p.shape[0], float(gen_steering)),
+                                     self._base_gen_p.shape[0], "gen_steering")
+        else:
+            beta = _checked_steering(gen_steering, self._base_gen_p.shape[0], "gen_steering")
+
+        target = {"load_p": self._base_load_p * (1.0 + alpha * growth),
+                  "gen_p": self._base_gen_p * (1.0 + beta * growth)}
+        if scale_q:
+            # constant power factor per load: P and Q scaled by the same coefficient
+            target["load_q"] = self._base_load_q * (1.0 + alpha * growth)
+        return target
+
+    def run(self,
+            loading_factor=2.0,
+            load_steering=None,
+            gen_steering=None,
+            scale_q=True,
+            direction=None,
+            stop_at_lam=None,
+            step=0.05,
+            step_min=1e-4,
+            step_max=0.2,
+            adapt_step=False,
+            adapt_step_damping=0.7,
+            adapt_step_tol=1e-3,
+            nose_tol=1e-5,
+            max_steps=1000,
+            exact_tangent=False,
+            v_init=None,
+            max_iter=10,
+            tol=1e-8):
+        """
+        Trace the curve and return a :class:`CPFResult`.
+
+        Parameters
+        ----------
+        loading_factor: ``float``
+            What the fully-steered elements reach at ``lambda = 1``: 2.0 means "twice the
+            base load". Must be > 1.
+        load_steering: ``np.ndarray``, optional
+            One coefficient per load, in ``[0, 1]``; see the class docstring. ``None``
+            (default) means all ones.
+        gen_steering: ``np.ndarray`` or ``float``, optional
+            One coefficient per generator, in ``[0, 1]``, or a single number applied to
+            every generator. ``None`` (default) means 1 for non-slack generators and 0
+            for slack ones, so generation follows the load. Pass ``0`` to let the slack
+            supply the whole increase.
+        scale_q: ``bool``
+            Scale each load's reactive power by the same coefficient as its active power
+            (constant power factor, the default). ``False`` holds Q at its base value.
+        direction: ``dict``, optional
+            Escape hatch: explicit per-element DELTAS from the base state, in MW / MVAr,
+            as ``{"load_p": ..., "load_q": ..., "gen_p": ..., "sgen_p": ...}`` (any
+            subset). Mutually exclusive with the steering arguments.
+        stop_at_lam: ``float``, optional
+            Stop once lambda reaches this value (MATPOWER's numeric ``cpf.stop_at``).
+            ``None`` (default) traces until the nose.
+        step, step_min, step_max, adapt_step, adapt_step_damping, adapt_step_tol, nose_tol:
+            The continuation's step control, named and defaulted as MATPOWER's ``cpf.*``.
+        max_steps: ``int``
+            Hard cap on the number of traced points.
+        exact_tangent: ``bool``
+            Refactorize the Jacobian at each converged point before taking its tangent.
+            Off by default: the tangent then reuses the factorization the corrector left
+            standing, which is one Newton iterate behind the converged point.
+        v_init: ``np.ndarray``, optional
+            Starting voltage, one entry per grid bus. Defaults to a flat 1.04 pu start.
+        max_iter, tol:
+            Passed to every corrector's Newton-Raphson.
+        """
+        target = self._build_target(loading_factor, load_steering, gen_steering,
+                                    scale_q, direction)
+
+        self._cpp.clear_target()
+        if "load_p" in target:
+            self._cpp.set_target_load_p(target["load_p"])
+        if "load_q" in target:
+            self._cpp.set_target_load_q(target["load_q"])
+        if "gen_p" in target:
+            self._cpp.set_target_gen_p(target["gen_p"])
+        if "sgen_p" in target:
+            self._cpp.set_target_sgen_p(target["sgen_p"])
+
+        self._cpp.step = step
+        self._cpp.step_min = step_min
+        self._cpp.step_max = step_max
+        self._cpp.adapt_step = adapt_step
+        self._cpp.adapt_step_damping = adapt_step_damping
+        self._cpp.adapt_step_tol = adapt_step_tol
+        self._cpp.nose_tol = nose_tol
+        self._cpp.max_steps = max_steps
+        self._cpp.exact_tangent = exact_tangent
+        self._cpp.stop_at_lam = -1.0 if stop_at_lam is None else float(stop_at_lam)
+
+        if v_init is None:
+            v_init = np.full(self._grid.total_bus(), 1.04, dtype=complex)
+        self._cpp.compute(v_init, max_iter, tol)
+
+        return CPFResult(lam=np.array(self._cpp.get_lam(), dtype=float, copy=True),
+                         V=np.array(self._cpp.get_voltages(), dtype=complex, copy=True),
+                         tangent_lam=np.array(self._cpp.get_tangent_lam(), dtype=float, copy=True),
+                         success=bool(self._cpp.get_status() == 1),
+                         msg=self._cpp.get_msg(),
+                         nb_retries=self._cpp.nb_retries(),
+                         cpp=self._cpp)
+
+
+def run_cpf(grid, **kwargs):
+    """
+    One-shot helper: build a :class:`ContinuationPowerFlow` on ``grid`` and run it.
+    Every keyword argument is forwarded to :func:`ContinuationPowerFlow.run`, except
+    ``algorithm`` which selects the Newton-Raphson algorithm to use.
+
+    .. code-block:: python
+
+        from lightsim2grid.continuationPowerflow import run_cpf
+        res = run_cpf(grid, loading_factor=3.0)
+        print(f"collapse at {res.lam_max:.3f} of the requested increase")
+    """
+    algorithm = kwargs.pop("algorithm", None)
+    return ContinuationPowerFlow(grid, algorithm=algorithm).run(**kwargs)
+
+
+def plot_pv_curve(res, bus_indices=None, figsize=(10, 4)):
+    """
+    Plot ``|V|`` against lambda for the given buses, and the tangent's lambda component
+    against the point index (which falls towards 0 at the nose).
+
+    Needs matplotlib. ``bus_indices`` defaults to the ten buses whose voltage drops most
+    along the curve -- the ones that actually say something about the collapse.
+    """
+    try:
+        import matplotlib.pyplot as plt
+    except ImportError as exc:
+        raise ImportError("plot_pv_curve needs matplotlib, which is not installed. "
+                          "Install it with `pip install matplotlib`, or read "
+                          "res.lam / res.Vm yourself.") from exc
+
+    if res.lam.size == 0:
+        raise ValueError("plot_pv_curve: this result holds no traced point (the base case "
+                         f"did not converge). msg: {res.msg}")
+
+    Vm = res.Vm
+    if bus_indices is None:
+        # buses that are actually in the solved system (the others read exactly 0)
+        alive = np.flatnonzero(Vm[0] > 0.0)
+        drop = Vm[0, alive] - Vm[-1, alive]
+        bus_indices = alive[np.argsort(drop)[::-1][:10]]
+
+    fig, (ax_pv, ax_t) = plt.subplots(1, 2, figsize=figsize)
+    for bus in bus_indices:
+        ax_pv.plot(res.lam, Vm[:, bus], marker=".", markersize=3, label=f"bus {bus}")
+    ax_pv.set_xlabel(r"$\lambda$")
+    ax_pv.set_ylabel(r"$|V|$ [pu]")
+    ax_pv.set_title("PV curve")
+    if len(bus_indices) <= 10:
+        ax_pv.legend(fontsize="small")
+
+    ax_t.plot(res.tangent_lam, marker=".", markersize=3)
+    ax_t.axhline(0.0, linestyle="--", linewidth=1, color="k")
+    ax_t.set_xlabel("point index")
+    ax_t.set_ylabel(r"$t_\lambda$")
+    ax_t.set_title(r"tangent $\lambda$ component ($\to 0$ at the nose)")
+
+    fig.tight_layout()
+    return fig

--- a/lightsim2grid/continuationPowerflow.py
+++ b/lightsim2grid/continuationPowerflow.py
@@ -98,12 +98,27 @@ class ContinuationPowerFlow:
     - ``load_steering`` -- one coefficient per load, in ``[0, 1]``. A load with 0 does
       not move during the continuation; a load with 1 moves fully. Defaults to all ones
       (every load scaled).
-    - ``gen_steering`` -- the same, per generator. Defaults to 1 for every non-slack
-      generator and 0 for the slack ones, so generation follows the load and the slack
-      only picks up the incremental losses -- MATPOWER requires exactly that of a target
-      case ("same as base case w.r.t. Qg and slack Pg"). Pass ``0`` to hold generation
-      fixed and let the slack supply the whole increase instead; that traces a different
-      curve, with a different nose.
+    - ``gen_steering`` -- the same, per generator. Defaults to all ones, so generation
+      follows the load. Pass ``0`` to hold generation fixed and let the slack supply the
+      whole increase instead; that traces a different curve, with a different nose.
+
+    .. note::
+        MATPOWER requires a target case to be "same as base case w.r.t. Qg and slack Pg",
+        and the slack machines are deliberately NOT excluded here even so. The reason for
+        MATPOWER's rule is that a slack bus has no active-power equation, so its ``Pg`` is
+        an output of the powerflow rather than an input -- asking for it to change would
+        be asking for something the solver ignores. That reasoning transfers to a single
+        slack in lightsim2grid (scaling the slack machine's ``target_p`` there is provably
+        inert: the solution is bit-identical), which makes excluding it a no-op rather
+        than a correction. It does NOT transfer to a distributed slack, where every
+        participant's ``target_p`` genuinely enters its bus' equation -- and excluding
+        them all would silently freeze most of the generation on a grid whose slack is
+        spread over many machines. One rule for every generator is both simpler and right
+        in both cases.
+
+        Either way the slack machine's *output* still follows the load: with every other
+        machine scaled by ``k`` it ends up producing roughly ``k`` times its base power.
+        Holding its setpoint would never have held its production.
 
     .. warning::
         This is a *natural* parameterisation: the corrector solves at a fixed lambda, so
@@ -145,7 +160,6 @@ class ContinuationPowerFlow:
         self._base_load_q = np.array([el.target_q_mvar for el in grid.get_loads()], dtype=float)
         self._base_gen_p = np.array(grid.get_gen_target_p(), dtype=float)
         self._base_sgen_p = np.array(grid.get_sgen_target_p(), dtype=float)
-        self._gen_is_slack = np.array([el.is_slack for el in grid.get_generators()], dtype=bool)
 
     @property
     def cpp(self):
@@ -191,8 +205,10 @@ class ContinuationPowerFlow:
             alpha = _checked_steering(load_steering, self._base_load_p.shape[0], "load_steering")
 
         if gen_steering is None:
-            # MATPOWER-like: generation follows the load, the slack only takes the losses.
-            beta = (~self._gen_is_slack).astype(float)
+            # Every generator follows the load, the slack machines included -- see the
+            # class docstring for why they are NOT a special case here, unlike in
+            # MATPOWER's target-case rule.
+            beta = np.ones(self._base_gen_p.shape[0], dtype=float)
         elif np.isscalar(gen_steering):
             beta = _checked_steering(np.full(self._base_gen_p.shape[0], float(gen_steering)),
                                      self._base_gen_p.shape[0], "gen_steering")
@@ -238,9 +254,9 @@ class ContinuationPowerFlow:
             (default) means all ones.
         gen_steering: ``np.ndarray`` or ``float``, optional
             One coefficient per generator, in ``[0, 1]``, or a single number applied to
-            every generator. ``None`` (default) means 1 for non-slack generators and 0
-            for slack ones, so generation follows the load. Pass ``0`` to let the slack
-            supply the whole increase.
+            every generator. ``None`` (default) means all ones, so generation follows the
+            load. Pass ``0`` to hold generation fixed and let the slack supply the whole
+            increase. See the class docstring on why slack machines are not excluded.
         scale_q: ``bool``
             Scale each load's reactive power by the same coefficient as its active power
             (constant power factor, the default). ``False`` holds Q at its base value.

--- a/lightsim2grid/tests/test_continuation_powerflow.py
+++ b/lightsim2grid/tests/test_continuation_powerflow.py
@@ -242,19 +242,21 @@ class TestContinuationPowerFlow(unittest.TestCase):
         V_a, V_b = solve(False), solve(True)
         self.assertGreater(np.max(np.abs(V_a - V_b)), 1e-3)
 
-    def test_direction_that_moves_nothing_is_refused(self):
+    def test_direction_the_slack_absorbs_stops_instead_of_being_traced(self):
         """
-        The companion of the zero-direction guard: steering ONLY the single slack machine
-        gives a non-zero direction whose every effect the slack absorption cancels, so no
-        bus voltage moves at all. Without the guard lambda marches to its target over a
-        thousand points on which |V| changes by 1e-15, and the run reports success.
+        Steering ONLY the single slack machine is a legal thing to ask for -- it moves a
+        real input, just not one the powerflow reads -- so it is not refused. What it must
+        not do is look like a result: before this was handled, lambda marched to 20.8 over
+        a thousand points on which |V| changed by 3e-15, and the run reported success.
         """
         beta = self.gen_is_slack.astype(float)
-        with self.assertRaises(RuntimeError) as ctx:
-            ContinuationPowerFlow(_case14()).run(loading_factor=2.0,
-                                                 load_steering=np.zeros(self.nb_load),
-                                                 gen_steering=beta)
-        self.assertIn("moves no bus voltage", str(ctx.exception))
+        res = ContinuationPowerFlow(_case14()).run(loading_factor=2.0,
+                                                   load_steering=np.zeros(self.nb_load),
+                                                   gen_steering=beta)
+        self.assertFalse(res.success)
+        self.assertEqual(res.lam.size, 1)      # the base case, and nothing past it
+        self.assertEqual(res.lam_max, 0.0)
+        self.assertIn("absorbed by the slack", res.msg)
 
     def test_gen_steering_zero_leaves_generation_fixed(self):
         cpf = ContinuationPowerFlow(_case14())

--- a/lightsim2grid/tests/test_continuation_powerflow.py
+++ b/lightsim2grid/tests/test_continuation_powerflow.py
@@ -63,7 +63,7 @@ class TestContinuationPowerFlow(unittest.TestCase):
         if alpha is None:
             alpha = np.ones(self.nb_load)
         if beta is None:
-            beta = (~self.gen_is_slack).astype(float)
+            beta = np.ones(self.nb_gen)
         grid = _case14()
         for l_id, val in enumerate(self.base_load_p * (1.0 + alpha * lam * (k - 1.0))):
             grid.change_p_load(l_id, val)
@@ -81,13 +81,17 @@ class TestContinuationPowerFlow(unittest.TestCase):
         res = ContinuationPowerFlow(_case14()).run(loading_factor=k)
         self.assertTrue(res.success, res.msg)
         self.assertGreater(res.lam.size, 20)
-        # every 20th point, plus the last one before the nose (where both this and the
-        # reference solve are ill-conditioned, hence the looser tolerance there)
+        # Every 20th point. The tolerance is keyed on tangent_lam, which IS the
+        # conditioning of the point: near the nose the Jacobian is nearly singular and
+        # the reference solve is just as ill-conditioned as the traced one, so demanding
+        # 1e-8 there would be testing the arithmetic, not the algorithm.
         for i in list(range(1, res.lam.size - 1, 20)):
             V = self._solve_at(res.lam[i], k)
             self.assertGreater(V.shape[0], 0, f"the reference solve diverged at lam={res.lam[i]}")
-            np.testing.assert_allclose(V, res.V[i], atol=1e-8,
-                                       err_msg=f"traced point {i} (lam={res.lam[i]}) is not a solution")
+            atol = 1e-8 if res.tangent_lam[i] > 1e-3 else 1e-4
+            np.testing.assert_allclose(V, res.V[i], atol=atol,
+                                       err_msg=f"traced point {i} (lam={res.lam[i]}, "
+                                               f"tangent_lam={res.tangent_lam[i]:.2e}) is not a solution")
 
     def test_nose_matches_a_bisection_on_the_loading_factor(self):
         """
@@ -190,13 +194,67 @@ class TestContinuationPowerFlow(unittest.TestCase):
         self.assertAlmostEqual(target["load_p"][4], self.base_load_p[4])
         self.assertAlmostEqual(target["load_q"][4], self.base_load_q[4])
 
-    def test_gen_steering_default_scales_with_load_and_spares_the_slack(self):
+    def test_gen_steering_default_scales_every_generator_slack_included(self):
+        """
+        Slack machines are NOT a special case, unlike in MATPOWER's target-case rule --
+        see the class docstring. The two tests below pin the two facts that justify it.
+        """
         cpf = ContinuationPowerFlow(_case14())
         target = cpf._build_target(3.0, None, None, True, None)
-        np.testing.assert_allclose(target["gen_p"][self.gen_is_slack],
-                                   self.base_gen_p[self.gen_is_slack])
-        np.testing.assert_allclose(target["gen_p"][~self.gen_is_slack],
-                                   3.0 * self.base_gen_p[~self.gen_is_slack])
+        np.testing.assert_allclose(target["gen_p"], 3.0 * self.base_gen_p)
+
+    def test_single_slack_machine_setpoint_is_inert(self):
+        """
+        Why excluding the slack would be a no-op rather than a correction, with ONE slack:
+        that bus has no active-power equation, so the machine's target_p never reaches the
+        mismatch. Scaling it leaves the solution bit-identical -- and the machine's actual
+        output unchanged, because that output is what balances the grid, not what was asked
+        of it.
+        """
+        slack_id = int(np.flatnonzero(self.gen_is_slack)[0])
+        self.assertGreater(self.base_gen_p[slack_id], 0.0)  # or the test proves nothing
+
+        grid_a = _case14()
+        V_a = grid_a.ac_pf(self.v_init, 30, 1e-11)
+        grid_b = _case14()
+        grid_b.change_p_gen(slack_id, 2.0 * self.base_gen_p[slack_id])
+        V_b = grid_b.ac_pf(self.v_init, 30, 1e-11)
+
+        np.testing.assert_array_equal(V_a, V_b)
+        self.assertAlmostEqual(grid_a.get_generators()[slack_id].res_p_mw,
+                               grid_b.get_generators()[slack_id].res_p_mw, places=9)
+
+    def test_distributed_slack_participant_setpoint_is_not_inert(self):
+        """
+        ... and why the exclusion cannot simply be kept anyway: with a DISTRIBUTED slack a
+        participant's target_p does enter its bus' equation, so excluding every slack
+        machine would silently freeze real generation.
+        """
+        slack_id = int(np.flatnonzero(self.gen_is_slack)[0])
+
+        def solve(scale):
+            grid = _case14()
+            grid.add_gen_slackbus(1, 0.5)  # a second participant -> distributed slack
+            if scale:
+                grid.change_p_gen(slack_id, 2.0 * self.base_gen_p[slack_id])
+            return grid.ac_pf(self.v_init, 30, 1e-11)
+
+        V_a, V_b = solve(False), solve(True)
+        self.assertGreater(np.max(np.abs(V_a - V_b)), 1e-3)
+
+    def test_direction_that_moves_nothing_is_refused(self):
+        """
+        The companion of the zero-direction guard: steering ONLY the single slack machine
+        gives a non-zero direction whose every effect the slack absorption cancels, so no
+        bus voltage moves at all. Without the guard lambda marches to its target over a
+        thousand points on which |V| changes by 1e-15, and the run reports success.
+        """
+        beta = self.gen_is_slack.astype(float)
+        with self.assertRaises(RuntimeError) as ctx:
+            ContinuationPowerFlow(_case14()).run(loading_factor=2.0,
+                                                 load_steering=np.zeros(self.nb_load),
+                                                 gen_steering=beta)
+        self.assertIn("moves no bus voltage", str(ctx.exception))
 
     def test_gen_steering_zero_leaves_generation_fixed(self):
         cpf = ContinuationPowerFlow(_case14())
@@ -354,11 +412,11 @@ class TestContinuationPowerFlowMultiSlack(unittest.TestCase):
         base_load_p = np.array(self.grid.get_load_target_p(), dtype=float)
         base_load_q = np.array([el.target_q_mvar for el in self.grid.get_loads()], dtype=float)
         base_gen_p = np.array(self.grid.get_gen_target_p(), dtype=float)
-        # read is_slack off the DISTRIBUTED grid, not self.grid: update_slack_weights
-        # promotes further generators to slack participants, and gen_steering's default
-        # (scale with the load, spare the slack) keys off exactly that set.
-        is_slack = np.array([el.is_slack for el in self._distributed().get_generators()], dtype=bool)
-        beta = (~is_slack).astype(float)
+        # gen_steering's default is all ones -- slack participants included, which is
+        # exactly what matters here: with a distributed slack their setpoints are real
+        # inputs, so freezing them would trace a different curve (see
+        # test_distributed_slack_participant_setpoint_is_not_inert).
+        beta = np.ones(base_gen_p.shape[0])
 
         for i in [1, res.lam.size // 2]:
             lam = res.lam[i]

--- a/lightsim2grid/tests/test_continuation_powerflow.py
+++ b/lightsim2grid/tests/test_continuation_powerflow.py
@@ -1,0 +1,378 @@
+# Copyright (c) 2020-2026, RTE (https://www.rte-france.com)
+# See AUTHORS.txt
+# This Source Code Form is subject to the terms of the Mozilla Public License, version 2.0.
+# If a copy of the Mozilla Public License, version 2.0 was not distributed with this file,
+# you can obtain one at http://mozilla.org/MPL/2.0/.
+# SPDX-License-Identifier: MPL-2.0
+# This file is part of LightSim2grid, LightSim2grid implements a c++ backend targeting the Grid2Op platform.
+
+"""
+Continuation powerflow (ContinuationSweepCPP + the ContinuationPowerFlow wrapper).
+
+The oracles used here are deliberately independent of the continuation itself:
+
+- every traced point must equal a plain ``LSGrid.ac_pf`` run at the same injections
+  (``test_every_point_matches_a_direct_solve`` -- this is the correctness test, everything
+  else is a property of it);
+- the nose lambda must equal a brute-force bisection on the loading factor, i.e. the
+  largest factor for which an ordinary powerflow still converges;
+- the whole curve must cost exactly ONE symbolic factorization, which is the reason a
+  continuation belongs in the batch layer at all.
+
+Two traps have their own tests because getting them wrong produces a plausible-looking
+curve rather than an error: the sign of the load direction (loads are stamped into Sbus
+with a MINUS, so increasing them must LOWER the voltages), and a zero direction (which
+would otherwise walk lambda along a curve on which nothing moves and report success).
+"""
+
+import unittest
+import warnings
+
+import numpy as np
+
+with warnings.catch_warnings():
+    warnings.filterwarnings("ignore")
+    import pandapower.networks as pn
+
+from lightsim2grid import AlgorithmType
+from lightsim2grid.network import init_from_pandapower
+from lightsim2grid.continuationPowerflow import ContinuationPowerFlow, run_cpf
+
+
+def _case14():
+    with warnings.catch_warnings():
+        warnings.filterwarnings("ignore")
+        return init_from_pandapower(pn.case14())
+
+
+class TestContinuationPowerFlow(unittest.TestCase):
+    def setUp(self):
+        self.grid = _case14()
+        self.nb_bus = self.grid.total_bus()
+        self.base_load_p = np.array(self.grid.get_load_target_p(), dtype=float)
+        self.base_load_q = np.array([el.target_q_mvar for el in self.grid.get_loads()], dtype=float)
+        self.base_gen_p = np.array(self.grid.get_gen_target_p(), dtype=float)
+        self.gen_is_slack = np.array([el.is_slack for el in self.grid.get_generators()], dtype=bool)
+        self.nb_load = self.base_load_p.shape[0]
+        self.nb_gen = self.base_gen_p.shape[0]
+        self.v_init = np.full(self.nb_bus, 1.04, dtype=complex)
+
+    # ---- helpers -----------------------------------------------------------
+    def _solve_at(self, lam, k, alpha=None, beta=None, scale_q=True, max_iter=100, tol=1e-10):
+        """A plain powerflow at the injections the continuation should have at `lam`."""
+        if alpha is None:
+            alpha = np.ones(self.nb_load)
+        if beta is None:
+            beta = (~self.gen_is_slack).astype(float)
+        grid = _case14()
+        for l_id, val in enumerate(self.base_load_p * (1.0 + alpha * lam * (k - 1.0))):
+            grid.change_p_load(l_id, val)
+        if scale_q:
+            for l_id, val in enumerate(self.base_load_q * (1.0 + alpha * lam * (k - 1.0))):
+                grid.change_q_load(l_id, val)
+        for g_id, val in enumerate(self.base_gen_p * (1.0 + beta * lam * (k - 1.0))):
+            grid.change_p_gen(g_id, val)
+        return grid.ac_pf(self.v_init, max_iter, tol)
+
+    # ---- correctness -------------------------------------------------------
+    def test_every_point_matches_a_direct_solve(self):
+        """Each traced (lam, V) is a genuine solution of the powerflow at that lambda."""
+        k = 4.0
+        res = ContinuationPowerFlow(_case14()).run(loading_factor=k)
+        self.assertTrue(res.success, res.msg)
+        self.assertGreater(res.lam.size, 20)
+        # every 20th point, plus the last one before the nose (where both this and the
+        # reference solve are ill-conditioned, hence the looser tolerance there)
+        for i in list(range(1, res.lam.size - 1, 20)):
+            V = self._solve_at(res.lam[i], k)
+            self.assertGreater(V.shape[0], 0, f"the reference solve diverged at lam={res.lam[i]}")
+            np.testing.assert_allclose(V, res.V[i], atol=1e-8,
+                                       err_msg=f"traced point {i} (lam={res.lam[i]}) is not a solution")
+
+    def test_nose_matches_a_bisection_on_the_loading_factor(self):
+        """
+        The nose is the largest lambda for which a powerflow still converges. Found here
+        without any continuation at all, by bisection, and compared with what the CPF
+        reports.
+        """
+        k = 4.0
+        res = ContinuationPowerFlow(_case14()).run(loading_factor=k)
+        self.assertTrue(res.success, res.msg)
+
+        def solvable(lam):
+            return self._solve_at(lam, k, max_iter=100, tol=1e-8).shape[0] > 0
+
+        lo, hi = 0.0, 3.0
+        self.assertTrue(solvable(lo))
+        self.assertFalse(solvable(hi))
+        for _ in range(40):
+            mid = 0.5 * (lo + hi)
+            if solvable(mid):
+                lo = mid
+            else:
+                hi = mid
+        self.assertAlmostEqual(res.lam_max, lo, delta=1e-4 * max(1.0, lo))
+
+    def test_one_analyze_for_the_whole_curve(self):
+        """
+        The entire premise of putting a continuation in the batch layer: one symbolic
+        factorization, however many points the curve has.
+        """
+        cpf = ContinuationPowerFlow(_case14())
+        res = cpf.run(loading_factor=4.0)
+        self.assertGreater(res.lam.size, 50)
+        stats = cpf.cpp.get_linear_solver_stats()
+        self.assertEqual(stats.nb_analyze, 1)
+        self.assertGreater(stats.nb_refactorize, res.lam.size)
+
+    def test_loading_lowers_the_voltages(self):
+        """
+        The load direction's sign. Loads are stamped into Sbus with a MINUS, so a
+        direction that increases them must DECREASE the voltages -- get this backwards
+        and the continuation happily traces the grid unloading instead.
+        """
+        res = ContinuationPowerFlow(_case14()).run(loading_factor=4.0)
+        alive = np.flatnonzero(res.Vm[0] > 0.0)
+        worst = alive[np.argmax(res.Vm[0, alive] - res.Vm[-1, alive])]
+        self.assertLess(res.Vm[-1, worst], res.Vm[0, worst])
+        # and it gets there monotonically, not by wandering
+        self.assertTrue(np.all(np.diff(res.Vm[:, worst]) <= 1e-9))
+
+    def test_tangent_lam_falls_to_zero_at_the_nose(self):
+        res = ContinuationPowerFlow(_case14()).run(loading_factor=4.0)
+        self.assertTrue(res.success, res.msg)
+        # strictly positive throughout (this parameterisation cannot make it change
+        # sign), and collapsing towards 0 at the end
+        self.assertTrue(np.all(res.tangent_lam[:-1] > 0.0))
+        self.assertLess(res.tangent_lam[-2], res.tangent_lam[0])
+        self.assertLess(res.tangent_lam[-2], 1e-4)
+
+    # ---- steering ----------------------------------------------------------
+    def test_all_ones_steering_is_the_default(self):
+        a = ContinuationPowerFlow(_case14()).run(loading_factor=3.0)
+        b = ContinuationPowerFlow(_case14()).run(loading_factor=3.0,
+                                                 load_steering=np.ones(self.nb_load))
+        np.testing.assert_array_equal(a.lam, b.lam)
+        np.testing.assert_array_equal(a.V, b.V)
+
+    def test_steering_one_load_moves_only_that_bus(self):
+        load_id = 3
+        alpha = np.zeros(self.nb_load)
+        alpha[load_id] = 1.0
+        cpf = ContinuationPowerFlow(_case14())
+        cpf.run(loading_factor=3.0, load_steering=alpha, gen_steering=0.0)
+        direction = np.array(cpf.cpp.get_direction_solver())
+        moved = np.flatnonzero(np.abs(direction) > 1e-12)
+        self.assertEqual(moved.size, 1)
+        # case14 has no disconnected bus, so solver and grid ids coincide here
+        self.assertEqual(int(moved[0]), self.grid.get_loads()[load_id].bus_id)
+
+    def test_steered_curve_matches_a_direct_solve(self):
+        """The steering reaches the solver: the traced points are solutions of the
+        STEERED problem, not of the uniform one."""
+        k = 3.0
+        alpha = np.zeros(self.nb_load)
+        alpha[[2, 5]] = [1.0, 0.4]
+        beta = np.zeros(self.nb_gen)
+        res = ContinuationPowerFlow(_case14()).run(loading_factor=k, load_steering=alpha,
+                                                   gen_steering=0.0)
+        for i in [1, res.lam.size // 2]:
+            V = self._solve_at(res.lam[i], k, alpha=alpha, beta=beta)
+            self.assertGreater(V.shape[0], 0)
+            np.testing.assert_allclose(V, res.V[i], atol=1e-8)
+
+    def test_zero_coefficient_load_does_not_move(self):
+        """A load steered with 0 keeps its base value all along the curve."""
+        alpha = np.ones(self.nb_load)
+        alpha[4] = 0.0
+        cpf = ContinuationPowerFlow(_case14())
+        target = cpf._build_target(3.0, alpha, None, True, None)
+        self.assertAlmostEqual(target["load_p"][4], self.base_load_p[4])
+        self.assertAlmostEqual(target["load_q"][4], self.base_load_q[4])
+
+    def test_gen_steering_default_scales_with_load_and_spares_the_slack(self):
+        cpf = ContinuationPowerFlow(_case14())
+        target = cpf._build_target(3.0, None, None, True, None)
+        np.testing.assert_allclose(target["gen_p"][self.gen_is_slack],
+                                   self.base_gen_p[self.gen_is_slack])
+        np.testing.assert_allclose(target["gen_p"][~self.gen_is_slack],
+                                   3.0 * self.base_gen_p[~self.gen_is_slack])
+
+    def test_gen_steering_zero_leaves_generation_fixed(self):
+        cpf = ContinuationPowerFlow(_case14())
+        target = cpf._build_target(3.0, None, 0.0, True, None)
+        np.testing.assert_allclose(target["gen_p"], self.base_gen_p)
+
+    def test_scale_q_false_keeps_reactive_load(self):
+        cpf = ContinuationPowerFlow(_case14())
+        target = cpf._build_target(3.0, None, None, False, None)
+        self.assertNotIn("load_q", target)
+
+    def test_slack_supplied_margin_is_smaller_than_the_shared_one(self):
+        """
+        Sanity on the modelling choice: holding generation fixed makes the slack supply
+        the whole increase, which collapses the grid earlier than sharing it out.
+        """
+        shared = ContinuationPowerFlow(_case14()).run(loading_factor=4.0)
+        slack_only = ContinuationPowerFlow(_case14()).run(loading_factor=4.0, gen_steering=0.0)
+        self.assertLess(slack_only.lam_max, shared.lam_max)
+
+    # ---- explicit direction ------------------------------------------------
+    def test_explicit_direction(self):
+        delta = np.zeros(self.nb_load)
+        delta[1] = 50.0  # +50 MW on load 1, nothing else moves
+        cpf = ContinuationPowerFlow(_case14())
+        cpf.run(direction={"load_p": delta}, stop_at_lam=1.0)
+        direction = np.array(cpf.cpp.get_direction_solver())
+        moved = np.flatnonzero(np.abs(direction) > 1e-12)
+        self.assertEqual(moved.size, 1)
+        self.assertEqual(int(moved[0]), self.grid.get_loads()[1].bus_id)
+        # a load is a NEGATIVE injection: +50 MW of load is -50 MW at the bus
+        sn_mva = self.grid.get_sn_mva()
+        self.assertAlmostEqual(direction[moved[0]].real, -50.0 / sn_mva)
+
+    def test_direction_and_steering_are_mutually_exclusive(self):
+        with self.assertRaises(ValueError):
+            ContinuationPowerFlow(_case14()).run(direction={"load_p": np.zeros(self.nb_load)},
+                                                 load_steering=np.ones(self.nb_load))
+
+    # ---- stopping ----------------------------------------------------------
+    def test_stop_at_lam_lands_exactly_on_it(self):
+        res = ContinuationPowerFlow(_case14()).run(loading_factor=2.0, stop_at_lam=0.5)
+        self.assertTrue(res.success, res.msg)
+        self.assertAlmostEqual(res.lam[-1], 0.5, places=12)
+        # and that point is a real solution
+        V = self._solve_at(0.5, 2.0)
+        np.testing.assert_allclose(V, res.V[-1], atol=1e-8)
+
+    def test_max_steps_stops_the_curve(self):
+        res = ContinuationPowerFlow(_case14()).run(loading_factor=4.0, max_steps=5)
+        self.assertFalse(res.success)
+        self.assertEqual(res.lam.size, 6)  # the base case + 5 steps
+        self.assertIn("maximum number of steps", res.msg)
+
+    def test_adapt_step_reaches_the_same_nose_in_fewer_points(self):
+        fixed = ContinuationPowerFlow(_case14()).run(loading_factor=4.0, adapt_step=False)
+        adapt = ContinuationPowerFlow(_case14()).run(loading_factor=4.0, adapt_step=True)
+        self.assertTrue(adapt.success, adapt.msg)
+        self.assertAlmostEqual(adapt.lam_max, fixed.lam_max, delta=1e-3)
+        self.assertLess(adapt.lam.size, fixed.lam.size)
+
+    def test_exact_tangent_reaches_the_same_nose(self):
+        loose = ContinuationPowerFlow(_case14()).run(loading_factor=4.0)
+        exact = ContinuationPowerFlow(_case14()).run(loading_factor=4.0, exact_tangent=True)
+        self.assertTrue(exact.success, exact.msg)
+        self.assertAlmostEqual(exact.lam_max, loose.lam_max, delta=1e-3)
+
+    # ---- refusals ----------------------------------------------------------
+    def test_zero_direction_is_refused(self):
+        """Not a degenerate curve, a meaningless run -- see the module docstring."""
+        with self.assertRaises(RuntimeError) as ctx:
+            ContinuationPowerFlow(_case14()).run(loading_factor=3.0,
+                                                 load_steering=np.zeros(self.nb_load),
+                                                 gen_steering=0.0)
+        self.assertIn("direction is zero", str(ctx.exception))
+
+    def test_non_newton_algorithm_is_refused(self):
+        cpf = ContinuationPowerFlow(_case14(), algorithm=AlgorithmType.GaussSeidel)
+        with self.assertRaises(RuntimeError) as ctx:
+            cpf.run(loading_factor=2.0)
+        self.assertIn("Newton-Raphson", str(ctx.exception))
+
+    def test_dc_algorithm_is_refused(self):
+        cpf = ContinuationPowerFlow(_case14(), algorithm=AlgorithmType.DC_SparseLU)
+        with self.assertRaises(RuntimeError) as ctx:
+            cpf.run(loading_factor=2.0)
+        self.assertIn("AC", str(ctx.exception))
+
+    def test_loading_factor_must_exceed_one(self):
+        for bad in (1.0, 0.5, -1.0, np.nan):
+            with self.assertRaises(ValueError):
+                ContinuationPowerFlow(_case14()).run(loading_factor=bad)
+
+    def test_steering_out_of_range_is_refused(self):
+        for bad in (np.full(self.nb_load, 1.5), np.full(self.nb_load, -0.1)):
+            with self.assertRaises(ValueError):
+                ContinuationPowerFlow(_case14()).run(loading_factor=2.0, load_steering=bad)
+
+    def test_steering_wrong_size_is_refused(self):
+        with self.assertRaises(ValueError):
+            ContinuationPowerFlow(_case14()).run(loading_factor=2.0,
+                                                 load_steering=np.ones(self.nb_load + 1))
+
+    def test_multithreading_is_refused(self):
+        """The points are chained, so there is nothing to split."""
+        cpf = ContinuationPowerFlow(_case14())
+        with self.assertRaises(RuntimeError):
+            cpf.cpp.set_nb_thread(4)
+
+    # ---- API ---------------------------------------------------------------
+    def test_run_cpf_helper(self):
+        res = run_cpf(_case14(), loading_factor=2.0, stop_at_lam=0.25)
+        self.assertTrue(res.success, res.msg)
+        self.assertAlmostEqual(res.lam[-1], 0.25, places=12)
+        self.assertEqual(res.V.shape, (res.lam.size, self.nb_bus))
+        self.assertEqual(res.Vm.shape, res.V.shape)
+        self.assertEqual(res.Va_deg.shape, res.V.shape)
+
+    def test_results_survive_a_second_run(self):
+        """The result object holds copies, not views into the C++ buffers."""
+        cpf = ContinuationPowerFlow(_case14())
+        first = cpf.run(loading_factor=2.0, stop_at_lam=0.3)
+        lam_before = first.lam.copy()
+        V_before = first.V.copy()
+        cpf.run(loading_factor=4.0)
+        np.testing.assert_array_equal(first.lam, lam_before)
+        np.testing.assert_array_equal(first.V, V_before)
+
+
+class TestContinuationPowerFlowMultiSlack(unittest.TestCase):
+    """
+    The tangent's right-hand side is built from the NRLedger, so it must be right for a
+    distributed slack too -- where the augmented Jacobian carries an extra column (the
+    absorbed slack power) that does not depend on lambda.
+    """
+
+    def setUp(self):
+        self.grid = _case14()
+        self.v_init = np.full(self.grid.total_bus(), 1.04, dtype=complex)
+
+    def _distributed(self):
+        grid = _case14()
+        # every generator participates in the slack
+        nb_gen = len(grid.get_generators())
+        grid.update_slack_weights(np.ones(nb_gen, dtype=bool))
+        return grid
+
+    def test_distributed_slack_curve_matches_a_direct_solve(self):
+        k = 3.0
+        cpf = ContinuationPowerFlow(self._distributed())
+        res = cpf.run(loading_factor=k)
+        self.assertTrue(res.success, res.msg)
+        self.assertEqual(cpf.cpp.get_linear_solver_stats().nb_analyze, 1)
+
+        base_load_p = np.array(self.grid.get_load_target_p(), dtype=float)
+        base_load_q = np.array([el.target_q_mvar for el in self.grid.get_loads()], dtype=float)
+        base_gen_p = np.array(self.grid.get_gen_target_p(), dtype=float)
+        # read is_slack off the DISTRIBUTED grid, not self.grid: update_slack_weights
+        # promotes further generators to slack participants, and gen_steering's default
+        # (scale with the load, spare the slack) keys off exactly that set.
+        is_slack = np.array([el.is_slack for el in self._distributed().get_generators()], dtype=bool)
+        beta = (~is_slack).astype(float)
+
+        for i in [1, res.lam.size // 2]:
+            lam = res.lam[i]
+            grid = self._distributed()
+            for l_id, val in enumerate(base_load_p * (1.0 + lam * (k - 1.0))):
+                grid.change_p_load(l_id, val)
+            for l_id, val in enumerate(base_load_q * (1.0 + lam * (k - 1.0))):
+                grid.change_q_load(l_id, val)
+            for g_id, val in enumerate(base_gen_p * (1.0 + beta * lam * (k - 1.0))):
+                grid.change_p_gen(g_id, val)
+            V = grid.ac_pf(self.v_init, 100, 1e-10)
+            self.assertGreater(V.shape[0], 0, f"reference solve diverged at lam={lam}")
+            np.testing.assert_allclose(V, res.V[i], atol=1e-8)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/bindings/python/binding_batch.cpp
+++ b/src/bindings/python/binding_batch.cpp
@@ -8,6 +8,7 @@
 
 #include "binding_declarations.hpp"
 #include "batch_algorithm/BaseBatchSweep.hpp"
+#include "batch_algorithm/ContinuationSweep.hpp"
 #include "batch_algorithm/LimitViolation.hpp"
 #include "help_fun_msg.hpp"
 
@@ -211,6 +212,126 @@ void bind_batch(py::module_& m) {
                       [](const TimeSeries & self){ return self.get_init_from_n_powerflow(); },
                       [](TimeSeries & self, bool val){ self.set_init_from_n_powerflow(val); },
                       DocTimeSeries::init_from_n_powerflow.c_str());
+
+    // ContinuationSweepCPP: a SIBLING of the four BaseBatchSweep instantiations, not
+    // a fifth one -- see batch_algorithm/ContinuationSweep.hpp for why. It shares the
+    // base class (and therefore the one-analyze-per-run guarantee, the timers and the
+    // result accessors) but decides its own rows, so it has its own binding block
+    // rather than going through bind_batch_sweep_common.
+    py::class_<ContinuationSweep>(m, "ContinuationSweepCPP",
+        "Continuation powerflow: traces the solution curve from the grid's own "
+        "injection state (lambda = 0) to a target one (lambda = 1), and stops at the "
+        "voltage-collapse 'nose' or at a requested lambda.\n\n"
+        "Set the target with set_target_load_p / set_target_load_q / set_target_gen_p "
+        "/ set_target_sgen_p (any axis left unset stays at the grid's own values), "
+        "then call compute(). The option names follow MATPOWER's cpf.* so a runcpf "
+        "user is on familiar ground. Newton-Raphson algorithms only.\n\n"
+        "Prefer the `lightsim2grid.continuationPowerflow.ContinuationPowerFlow` "
+        "wrapper, which builds the target from a loading factor and per-load / "
+        "per-generator steering vectors.")
+        .def(py::init<const LSGrid &>())
+
+        // solver control
+        .def("change_algorithm", py::overload_cast<const AlgorithmType&>(&ContinuationSweep::change_algorithm), DocLSGrid::change_algorithm.c_str())
+        .def("change_algorithm", py::overload_cast<const std::string&>(&ContinuationSweep::change_algorithm), DocLSGrid::change_algorithm_by_name.c_str())
+        .def("available_default_algorithms", &ContinuationSweep::available_default_algorithms, DocLSGrid::available_default_algorithms.c_str())
+        .def("get_algo_type", &ContinuationSweep::get_algo_type, DocLSGrid::get_algo_type.c_str())
+        .def("get_algo_name", &ContinuationSweep::get_algo_name, "Registry name of the selected algorithm.")
+        .def("get_algo_config", &ContinuationSweep::get_algo_config, "Config of the internal solver.")
+        .def("set_algo_config", &ContinuationSweep::set_algo_config, py::arg("config"), "See get_algo_config().")
+
+        // the target state
+        .def("set_target_gen_p", &ContinuationSweep::set_target_gen_p, py::arg("gen_p"),
+             "Target active generator setpoints (n_gen,), in MW. Unset means 'unchanged'.")
+        .def("set_target_sgen_p", &ContinuationSweep::set_target_sgen_p, py::arg("sgen_p"),
+             "Target active static-generator setpoints (n_sgen,), in MW. Unset means 'unchanged'.")
+        .def("set_target_load_p", &ContinuationSweep::set_target_load_p, py::arg("load_p"),
+             "Target active load setpoints (n_load,), in MW. Unset means 'unchanged'.")
+        .def("set_target_load_q", &ContinuationSweep::set_target_load_q, py::arg("load_q"),
+             "Target reactive load setpoints (n_load,), in MVAr. Unset means 'unchanged'.")
+        .def("clear_target", &ContinuationSweep::clear_target, "Forget every target axis set so far.")
+
+        // options (MATPOWER cpf.* names and defaults)
+        .def_property("step", &ContinuationSweep::get_step, &ContinuationSweep::set_step,
+                      "Nominal continuation step, as an arc length along the unit tangent "
+                      "(MATPOWER cpf.step, default 0.05).")
+        .def_property("step_min", &ContinuationSweep::get_step_min, &ContinuationSweep::set_step_min,
+                      "Smallest step the corrector-failure retry may shrink to; failing at this "
+                      "step ends the curve (MATPOWER cpf.step_min, default 1e-4).")
+        .def_property("step_max", &ContinuationSweep::get_step_max, &ContinuationSweep::set_step_max,
+                      "Largest step the adaptation may grow to (MATPOWER cpf.step_max, default 0.2).")
+        .def_property("adapt_step", &ContinuationSweep::get_adapt_step, &ContinuationSweep::set_adapt_step,
+                      "Adapt the step to the predictor's error (MATPOWER cpf.adapt_step, default False).")
+        .def_property("adapt_step_damping", &ContinuationSweep::get_adapt_step_damping, &ContinuationSweep::set_adapt_step_damping,
+                      "Damping of the step adaptation (MATPOWER cpf.adapt_step_damping, default 0.7).")
+        .def_property("adapt_step_tol", &ContinuationSweep::get_adapt_step_tol, &ContinuationSweep::set_adapt_step_tol,
+                      "Target predictor error the adaptation aims at (MATPOWER cpf.adapt_step_tol, default 1e-3).")
+        .def_property("nose_tol", &ContinuationSweep::get_nose_tol, &ContinuationSweep::set_nose_tol,
+                      "The curve is declared at the nose when the tangent's lambda component falls "
+                      "below this (MATPOWER cpf.nose_tol, default 1e-5). Note that this "
+                      "parameterisation makes that component strictly positive, tending to zero at "
+                      "the nose -- it is a threshold, never a sign change.")
+        .def_property("stop_at_lam", &ContinuationSweep::get_stop_at_lam, &ContinuationSweep::set_stop_at_lam,
+                      "Stop once lambda reaches this value (MATPOWER's numeric cpf.stop_at). "
+                      "Non-positive (the default) means 'trace until the nose'.")
+        .def_property("max_steps", &ContinuationSweep::get_max_steps, &ContinuationSweep::set_max_steps,
+                      "Hard cap on the number of traced points (default 1000).")
+        .def_property("exact_tangent", &ContinuationSweep::get_exact_tangent, &ContinuationSweep::set_exact_tangent,
+                      "Rebuild and refactorize the Jacobian at each converged point before taking "
+                      "its tangent (default False). Off, the tangent uses the factorization the "
+                      "corrector left standing, which is one NR iterate behind the converged point.")
+
+        .def("compute", &ContinuationSweep::compute, py::call_guard<py::gil_scoped_release>(),
+             py::arg("Vinit"), py::arg("max_iter"), py::arg("tol"),
+             "Trace the curve. Raises if the target is identical to the base state, or if "
+             "the selected algorithm is not Newton-Raphson based.")
+
+        // results
+        .def("get_status", &ContinuationSweep::get_status,
+             "1 if the curve reached its requested end (the nose, or stop_at_lam), 0 otherwise.")
+        .def("get_msg", &ContinuationSweep::get_msg, "Why the run stopped, in words.")
+        .def("nb_points", &ContinuationSweep::nb_points,
+             "Number of traced points, the base case included.")
+        .def("get_lam", &ContinuationSweep::get_lam, py::return_value_policy::reference_internal,
+             "Lambda at each traced point; lam[0] == 0 is the base case, lam == 1 the target.")
+        .def("get_tangent_lam", &ContinuationSweep::get_tangent_lam, py::return_value_policy::reference_internal,
+             "The tangent's lambda component at each point, in (0, 1]; it tends to 0 at the "
+             "nose. The last point has none and reads 0.")
+        .def("get_lam_max", &ContinuationSweep::get_lam_max, "Largest lambda reached.")
+        .def("nb_retries", &ContinuationSweep::nb_retries,
+             "How many times a corrector failed and the step had to be halved.")
+        .def("get_direction_solver", &ContinuationSweep::get_direction_solver, py::return_value_policy::reference_internal,
+             "The direction actually used (Sbus_target - Sbus_base), in solver bus ordering "
+             "and per unit.")
+        .def("get_voltages", &ContinuationSweep::get_voltages, DocTimeSeries::get_voltages.c_str(), py::return_value_policy::reference_internal)
+        .def("compute_flows", &ContinuationSweep::compute_flows, DocTimeSeries::compute_flows.c_str())
+        .def("compute_power_flows", &ContinuationSweep::compute_power_flows, DocTimeSeries::compute_power_flows.c_str())
+        .def("get_flows", &ContinuationSweep::get_flows, DocTimeSeries::get_flows.c_str(), py::return_value_policy::reference_internal)
+        .def("get_power_flows", &ContinuationSweep::get_power_flows, DocTimeSeries::get_power_flows.c_str(), py::return_value_policy::reference_internal)
+
+        // timers / counters
+        .def("total_time", &ContinuationSweep::total_time, DocTimeSeries::total_time.c_str())
+        .def("solver_time", &ContinuationSweep::solver_time, DocTimeSeries::solver_time.c_str())
+        .def("preprocessing_time", &ContinuationSweep::preprocessing_time, DocTimeSeries::preprocessing_time.c_str())
+        .def("nb_solved", &ContinuationSweep::nb_solved, DocTimeSeries::nb_solved.c_str())
+        .def("nb_converged", &ContinuationSweep::nb_converged, DocTimeSeries::nb_converged.c_str())
+        .def("get_linear_solver_stats", &ContinuationSweep::get_linear_solver_stats,
+             "Linear-solver counters for the whole curve. nb_analyze must be 1 however many "
+             "points were traced -- that is the entire reason a continuation belongs in the "
+             "batch layer. More than 1 means something changed the Jacobian's sparsity.")
+        .def("clear", &ContinuationSweep::clear, DocTimeSeries::clear.c_str())
+        .def("close", &ContinuationSweep::clear, DocTimeSeries::clear.c_str())
+
+        // bound although any value but 1 is rejected, for the same reason TimeSeriesCPP
+        // binds it: a user who finds the attribute gets an explanation instead of an
+        // AttributeError. The points of a curve are chained, so there is nothing to split.
+        .def("set_nb_thread", &ContinuationSweep::set_nb_thread, py::arg("nb_thread"),
+             "Always 1: the points of a continuation are chained (each is predicted from "
+             "the previous one's tangent), so the curve cannot be split over threads.")
+        .def_property("nb_thread",
+                      [](const ContinuationSweep & self){ return self.get_nb_thread(); },
+                      [](ContinuationSweep & self, int val){ self.set_nb_thread(val); },
+                      DocTimeSeries::nb_thread.c_str());
 
     py::class_<InjectionSweep> injection_sweep(m, "InjectionSweepCPP", DocInjectionSweep::InjectionSweep.c_str());
     bind_batch_sweep_common(injection_sweep);

--- a/src/core/AlgorithmSelector.hpp
+++ b/src/core/AlgorithmSelector.hpp
@@ -279,6 +279,25 @@ class LS2G_API AlgorithmSelector final
             get_prt_solver("set_pv_pinned_buses", false)->set_pv_pinned_buses(solver_bus_ids);
         }
 
+        // continuation powerflow primitives (ContinuationSweep) -- NR-based
+        // algorithms only, guarded exactly like get_J: both read state the last
+        // powerflow left behind, so asking a solver that did not run it is a bug.
+        bool supports_cpf() const {
+            return get_prt_solver("supports_cpf", false)->supports_cpf();
+        }
+        bool cpf_tangent(const Eigen::Ref<const CplxVect>& dir_solver, RealVect& z) {
+            check_right_solver("cpf_tangent");
+            return get_prt_solver("cpf_tangent", false)->cpf_tangent(dir_solver, z);
+        }
+        void cpf_predict(const Eigen::Ref<const RealVect>& z, real_type coeff, CplxVect& V_pred) const {
+            check_right_solver("cpf_predict");
+            get_prt_solver("cpf_predict", false)->cpf_predict(z, coeff, V_pred);
+        }
+        bool cpf_refactorize_at_current() {
+            check_right_solver("cpf_refactorize_at_current");
+            return get_prt_solver("cpf_refactorize_at_current", false)->cpf_refactorize_at_current();
+        }
+
         Eigen::SparseMatrix<real_type> get_J_python() const {
             Eigen::SparseMatrix<real_type> res = get_J();
             return res;

--- a/src/core/batch_algorithm/CMakeLists.txt
+++ b/src/core/batch_algorithm/CMakeLists.txt
@@ -3,5 +3,6 @@ list(APPEND SOURCES
     "${CMAKE_CURRENT_SOURCE_DIR}/YbusPolicy.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/SbusPolicy.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/BaseBatchSweep.cpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/ContinuationSweep.cpp"
 )
 set(SOURCES ${SOURCES} PARENT_SCOPE)

--- a/src/core/batch_algorithm/ContinuationSweep.cpp
+++ b/src/core/batch_algorithm/ContinuationSweep.cpp
@@ -1,0 +1,339 @@
+// Copyright (c) 2020-2026, RTE (https://www.rte-france.com)
+// See AUTHORS.txt
+// This Source Code Form is subject to the terms of the Mozilla Public License, version 2.0.
+// If a copy of the Mozilla Public License, version 2.0 was not distributed with this file,
+// you can obtain one at http://mozilla.org/MPL/2.0/.
+// SPDX-License-Identifier: MPL-2.0
+// This file is part of LightSim2grid, LightSim2grid implements a c++ backend targeting the Grid2Op platform.
+
+#include "ContinuationSweep.hpp"
+
+#include <algorithm>
+#include <cmath>
+#include <sstream>
+
+namespace ls2g {
+
+real_type ContinuationSweep::_checked_positive(real_type v, const char * name)
+{
+    if(!std::isfinite(v) || (v <= 0.)){
+        std::ostringstream exc_;
+        exc_ << "ContinuationSweep: " << name << " must be a finite, strictly positive "
+             << "number, got " << v << ".";
+        throw std::runtime_error(exc_.str());
+    }
+    return v;
+}
+
+void ContinuationSweep::set_max_steps(int v)
+{
+    if(v < 1){
+        std::ostringstream exc_;
+        exc_ << "ContinuationSweep: max_steps must be >= 1, got " << v << ".";
+        throw std::runtime_error(exc_.str());
+    }
+    _max_steps = v;
+}
+
+SbusPolicy::Vary::RealMat ContinuationSweep::_delta_row(const RealVect & target,
+                                                        const Eigen::Ref<const RealVect> & base,
+                                                        const char * axis_name)
+{
+    SbusPolicy::Vary::RealMat res = SbusPolicy::Vary::RealMat::Zero(1, base.size());
+    if(target.size() == 0) return res;  // axis never set: no contribution
+    if(target.size() != base.size()){
+        std::ostringstream exc_;
+        exc_ << "ContinuationSweep::set_target_" << axis_name << ": expected one value per "
+             << "element (" << base.size() << "), got " << target.size() << ".";
+        throw std::runtime_error(exc_.str());
+    }
+    res.row(0) = (target - base).transpose();
+    return res;
+}
+
+void ContinuationSweep::_build_direction(int nb_buses_solver,
+                                         const SolverBusIdVect & id_me_to_solver)
+{
+    const auto & generators = _grid_model.get_generators_as_data();
+    const auto & s_generators = _grid_model.get_static_generators_as_data();
+    const auto & loads = _grid_model.get_loads_as_data();
+    const char * algo_name = "ContinuationSweep";
+
+    const SbusPolicy::Vary::RealMat d_gen_p =
+        _delta_row(_target_gen_p, _grid_model.get_gen_target_p(), "gen_p");
+    const SbusPolicy::Vary::RealMat d_sgen_p =
+        _delta_row(_target_sgen_p, _grid_model.get_sgen_target_p(), "sgen_p");
+    const SbusPolicy::Vary::RealMat d_load_p =
+        _delta_row(_target_load_p, _grid_model.get_load_target_p(), "load_p");
+    const SbusPolicy::Vary::RealMat d_load_q =
+        _delta_row(_target_load_q, loads.get_target_q(), "load_q");
+
+    // Same scatter, same signs (generation adds, load subtracts) and same sn_mva
+    // division as an ordinary Sbus build -- these are SbusPolicy::Vary's own helpers,
+    // used here on the DELTAS rather than on two absolute states, which is the same
+    // thing by linearity and saves assembling the base and target injections only to
+    // subtract them.
+    SbusPolicy::Vary::CplxMat dir = SbusPolicy::Vary::CplxMat::Zero(1, nb_buses_solver);
+    bool add_ = true;
+    SbusPolicy::Vary::fill_SBus_real(dir, generators, d_gen_p, id_me_to_solver, add_, algo_name);
+    SbusPolicy::Vary::fill_SBus_real(dir, s_generators, d_sgen_p, id_me_to_solver, add_, algo_name);
+    add_ = false;
+    SbusPolicy::Vary::fill_SBus_real(dir, loads, d_load_p, id_me_to_solver, add_, algo_name);
+    SbusPolicy::Vary::fill_SBus_imag(dir, loads, d_load_q, id_me_to_solver, add_, algo_name);
+
+    const real_type sn_mva = _grid_model.get_sn_mva();
+    if(std::abs(sn_mva - 1.0) > BaseConstants::_tol_equal_float){
+        dir.array() /= static_cast<cplx_type>(sn_mva);
+    }
+    _direction = dir.row(0).transpose();
+}
+
+bool ContinuationSweep::_restore_at(const CplxVect & V_last, real_type lam_last,
+                                    int max_iter, real_type tol)
+{
+    CplxVect V = V_last;
+    const CplxVect Sbus = ac_cache_.inj + lam_last * _direction;
+    const bool conv = compute_one_powerflow(
+        ac_cache_.mat, V, Sbus,
+        active_layout().slack_bus_id_solver.as_eigen(), active_layout().slack_weights,
+        active_layout().bus_pv.as_eigen(), active_layout().bus_pq.as_eigen(),
+        max_iter, tol);
+    if(!conv) return false;
+    // V_last is already a solution, so the solve above converged on its very first
+    // convergence check and never entered the NR loop -- which means it never
+    // refactorized either, and the standing factorization is still the diverged one
+    // this restore exists to discard. Rebuild it explicitly.
+    return _algo.cpf_refactorize_at_current();
+}
+
+real_type ContinuationSweep::_adapted_step(real_type step,
+                                           const CplxVect & V_corr,
+                                           const CplxVect & V_pred) const
+{
+    // MATPOWER's cpf_error: the infinity norm of (corrected - predicted) over the
+    // free state variables -- angles at pv and pq buses, magnitudes at pq buses --
+    // and lambda. The lambda term is omitted here because it is structurally zero:
+    // this parameterisation's corrector holds lambda FIXED at its predicted value
+    // (that is what makes it "natural"), so lam_corrected == lam_predicted exactly.
+    // It reappears with a parameterisation that solves for lambda too.
+    real_type err = 0.;
+    const auto pv = active_layout().bus_pv.as_eigen();
+    const auto pq = active_layout().bus_pq.as_eigen();
+    for(Eigen::Index k = 0; k < pv.size(); ++k){
+        const int b = pv(k);
+        err = std::max(err, std::abs(std::arg(V_corr(b)) - std::arg(V_pred(b))));
+    }
+    for(Eigen::Index k = 0; k < pq.size(); ++k){
+        const int b = pq(k);
+        err = std::max(err, std::abs(std::arg(V_corr(b)) - std::arg(V_pred(b))));
+        err = std::max(err, std::abs(std::abs(V_corr(b)) - std::abs(V_pred(b))));
+    }
+    if(!(err > 0.)) return _step_max;  // a perfect prediction: take the largest step
+
+    const real_type scale = std::min(static_cast<real_type>(2.),
+                                     static_cast<real_type>(1.) +
+                                     _adapt_step_damping * (_adapt_step_tol / err - static_cast<real_type>(1.)));
+    real_type res = step * scale;
+    if(res > _step_max) res = _step_max;
+    if(res < _step_min) res = _step_min;
+    return res;
+}
+
+void ContinuationSweep::compute(const Eigen::Ref<const CplxVect> & Vinit,
+                                int max_iter, real_type tol)
+{
+    auto timer = CustTimer();
+    auto timer_preproc = CustTimer();
+
+    const size_t nb_total_bus = _reset_data_and_check_vinit(Vinit);
+    _status = 0;
+    _msg.clear();
+    _nb_points = 0;
+    _nb_retries = 0;
+    _timer_thread_init = 0.;
+
+    if(!_algo.ac_solver_used()){
+        throw std::runtime_error("ContinuationSweep::compute: a continuation powerflow is an AC "
+                                 "method; the current algorithm is a DC one. Pick an AC "
+                                 "(Newton-Raphson) algorithm with change_algorithm().");
+    }
+    if(!_algo.supports_cpf()){
+        std::ostringstream exc_;
+        exc_ << "ContinuationSweep::compute: the algorithm '" << _algo.get_name() << "' is not "
+             << "Newton-Raphson based, so it has no Jacobian to take a tangent from. Pick one of "
+             << "the NR algorithms (eg NR_KLU / NR_SparseLU).";
+        throw std::runtime_error(exc_.str());
+    }
+    if(_step_min > _step_max){
+        std::ostringstream exc_;
+        exc_ << "ContinuationSweep::compute: step_min (" << _step_min << ") is larger than "
+             << "step_max (" << _step_max << ").";
+        throw std::runtime_error(exc_.str());
+    }
+
+    const bool ac_solver_used = true;
+    CplxVect Vinit_solver = prepare_solver_input_base(Vinit, ac_solver_used);
+    _build_direction(nb_buses_solver_, active_layout().id_me_to_solver);
+
+    // A zero direction is not a degenerate curve, it is a meaningless run: J . z = 0
+    // gives z = 0, the tangent normalises to (0, ..., 1), and lambda would march to
+    // its target along a curve on which nothing moves -- reporting success for a
+    // continuation that continued nothing. Refuse it instead.
+    if(_direction.size() == 0 || _direction.cwiseAbs().maxCoeff() <= 0.){
+        throw std::runtime_error("ContinuationSweep::compute: the direction is zero -- the target "
+                                 "state is identical to the base state (or no target was set, or "
+                                 "every steered element is disconnected). Set at least one of "
+                                 "set_target_gen_p / set_target_sgen_p / set_target_load_p / "
+                                 "set_target_load_q to something that differs from the grid's own "
+                                 "values.");
+    }
+
+    // Reserve the whole curve up front: the base case plus at most _max_steps points.
+    // _voltages is truncated to the points actually traced at the end of this
+    // function, so get_voltages() / compute_flows_from_Vs() see exactly nb_points()
+    // rows and nothing has to know about the reservation.
+    const Eigen::Index nb_rows = static_cast<Eigen::Index>(_max_steps) + 1;
+    _lam = RealVect::Zero(nb_rows);
+    _tangent_lam = RealVect::Zero(nb_rows);
+
+    // The base case ("n" powerflow): this is what builds the Jacobian sparsity and
+    // pays the ONE symbolic factorization for the whole curve. It leaves the control
+    // in "nothing changed", so every corrector below refactorizes numerically only.
+    const bool base_conv = _finish_preprocessing(
+        static_cast<size_t>(nb_rows), nb_total_bus, Vinit_solver, static_cast<size_t>(max_iter),
+        tol, timer_preproc);
+
+    if(!base_conv){
+        std::ostringstream msg_;
+        msg_ << "the base case (lambda = 0) did not converge (error: " << _algo.get_error()
+             << "); nothing can be continued from it.";
+        _msg = msg_.str();
+        _voltages = CplxMat::Zero(0, static_cast<Eigen::Index>(nb_total_bus));
+        _lam = RealVect(); _tangent_lam = RealVect();
+        _timer_total = timer.duration();
+        return;
+    }
+
+    // ---- point 0: the base case ------------------------------------------------
+    CplxVect V_last = _algo.get_V();
+    real_type lam = 0.;
+    _voltages.row(0)(active_layout().id_solver_to_me.as_eigen()) = V_last.array();
+    _lam(0) = 0.;
+    _nb_points = 1;
+
+    real_type step = _step;
+    RealVect z;
+    CplxVect V_pred;
+
+    for(int it = 0; it < _max_steps; ++it){
+        // ---- predictor ---------------------------------------------------------
+        if(_exact_tangent && !_algo.cpf_refactorize_at_current()){
+            _msg = "could not refactorize the Jacobian at a converged point (exact_tangent).";
+            break;
+        }
+        if(!_algo.cpf_tangent(_direction, z)){
+            std::ostringstream msg_;
+            msg_ << "the tangent system could not be solved at lambda = " << lam
+                 << " (error: " << _algo.get_error() << "); the Jacobian is most likely singular, "
+                 << "which happens AT the nose point.";
+            _msg = msg_.str();
+            break;
+        }
+
+        // unit tangent: t = [z; 1] / ||[z; 1]||, so `step` is an arc length and t_lam
+        // is 1/norm -- strictly positive, tending to 0 as the curve turns (see the
+        // class comment: this parameterisation cannot show a sign change).
+        const real_type norm = std::sqrt(static_cast<real_type>(1.) + z.squaredNorm());
+        const real_type t_lam = static_cast<real_type>(1.) / norm;
+        _tangent_lam(_nb_points - 1) = t_lam;
+
+        if(t_lam < _nose_tol){
+            std::ostringstream msg_;
+            msg_ << "nose point reached at lambda = " << lam << " (the tangent's lambda component "
+                 << "fell to " << t_lam << ", below nose_tol = " << _nose_tol << ").";
+            _msg = msg_.str();
+            _status = 1;
+            break;
+        }
+
+        real_type this_step = step;
+        real_type lam_pred = lam + this_step * t_lam;
+        bool last_point = false;
+        if(_stop_at_lam > 0. && lam_pred >= _stop_at_lam){
+            // do not overshoot the requested lambda: shrink this step so the
+            // predictor lands exactly on it.
+            this_step = (_stop_at_lam - lam) / t_lam;
+            lam_pred = _stop_at_lam;
+            last_point = true;
+        }
+        _algo.cpf_predict(z, this_step / norm, V_pred);
+
+        // ---- corrector ---------------------------------------------------------
+        CplxVect V = V_pred;
+        const CplxVect Sbus = ac_cache_.inj + lam_pred * _direction;
+        const bool conv = compute_one_powerflow(
+            ac_cache_.mat, V, Sbus,
+            active_layout().slack_bus_id_solver.as_eigen(), active_layout().slack_weights,
+            active_layout().bus_pv.as_eigen(), active_layout().bus_pq.as_eigen(),
+            max_iter, tol);
+
+        if(!conv){
+            // Not a failed row: a step that was too long. Halve it and try the same
+            // point again -- unless we are already at step_min, in which case there
+            // is no solution just ahead and this IS the end of the curve (in
+            // practice, the nose).
+            ++_nb_retries;
+            if(this_step <= _step_min){
+                std::ostringstream msg_;
+                msg_ << "the corrector stopped converging at lambda = " << lam
+                     << " with the smallest allowed step (" << _step_min << "): this is the end "
+                     << "of the traceable curve, ie the nose point (to go past it, a "
+                     << "parameterisation that keeps the corrector non-singular is needed).";
+                _msg = msg_.str();
+                _status = 1;
+                break;
+            }
+            step = std::max(_step_min, this_step * static_cast<real_type>(0.5));
+            // the diverged solve left (Va, Vm) and the standing factorization at some
+            // diverged iterate; both feed the next tangent, so put them back.
+            if(!_restore_at(V_last, lam, max_iter, tol)){
+                _msg = "could not re-establish the last converged point after a corrector failure.";
+                break;
+            }
+            continue;
+        }
+
+        // ---- accept the point --------------------------------------------------
+        if(_adapt_step) step = _adapted_step(step, V, V_pred);
+
+        lam = lam_pred;
+        V_last = V;
+        _voltages.row(_nb_points)(active_layout().id_solver_to_me.as_eigen()) = V_last.array();
+        _lam(_nb_points) = lam;
+        ++_nb_points;
+
+        if(last_point){
+            std::ostringstream msg_;
+            msg_ << "reached the requested lambda = " << _stop_at_lam << ".";
+            _msg = msg_.str();
+            _status = 1;
+            break;
+        }
+    }
+
+    if(_msg.empty()){
+        std::ostringstream msg_;
+        msg_ << "stopped after the maximum number of steps (" << _max_steps << ") at lambda = "
+             << lam << "; raise max_steps, or step, to go further.";
+        _msg = msg_.str();
+    }
+
+    // truncate every result to the points actually traced
+    _voltages.conservativeResize(_nb_points, _voltages.cols());
+    _lam.conservativeResize(_nb_points);
+    _tangent_lam.conservativeResize(_nb_points);
+
+    _timer_total = timer.duration();
+}
+
+} // namespace ls2g

--- a/src/core/batch_algorithm/ContinuationSweep.cpp
+++ b/src/core/batch_algorithm/ContinuationSweep.cpp
@@ -14,25 +14,25 @@
 
 namespace ls2g {
 
-real_type ContinuationSweep::_checked_positive(real_type v, const char * name)
+real_type ContinuationSweep::_checked_positive(real_type x, const char * name)
 {
-    if(!std::isfinite(v) || (v <= 0.)){
+    if(!std::isfinite(x) || (x <= 0.)){
         std::ostringstream exc_;
         exc_ << "ContinuationSweep: " << name << " must be a finite, strictly positive "
-             << "number, got " << v << ".";
+             << "number, got " << x << ".";
         throw std::runtime_error(exc_.str());
     }
-    return v;
+    return x;
 }
 
-void ContinuationSweep::set_max_steps(int v)
+void ContinuationSweep::set_max_steps(int x)
 {
-    if(v < 1){
+    if(x < 1){
         std::ostringstream exc_;
-        exc_ << "ContinuationSweep: max_steps must be >= 1, got " << v << ".";
+        exc_ << "ContinuationSweep: max_steps must be >= 1, got " << x << ".";
         throw std::runtime_error(exc_.str());
     }
-    _max_steps = v;
+    _max_steps = x;
 }
 
 SbusPolicy::Vary::RealMat ContinuationSweep::_delta_row(const RealVect & target,
@@ -222,8 +222,16 @@ void ContinuationSweep::compute(const Eigen::Ref<const CplxVect> & Vinit,
     _nb_points = 1;
 
     real_type step = _step;
+    // Every buffer the loop needs, allocated ONCE here and assigned into afterwards:
+    // declared inside, each iteration would construct and free a fresh nb_bus vector,
+    // and a curve is hundreds of iterations long. They are four distinct vectors
+    // because each is read after the next is written: V_pred feeds the step adaptation
+    // AFTER the corrector has overwritten V_corr, and V_last must survive a corrector
+    // failure so the retry can be re-seeded from it (see _restore_at).
     RealVect z;
     CplxVect V_pred;
+    CplxVect V_corr;
+    CplxVect Sbus;
 
     for(int it = 0; it < _max_steps; ++it){
         // ---- predictor ---------------------------------------------------------
@@ -280,7 +288,8 @@ void ContinuationSweep::compute(const Eigen::Ref<const CplxVect> & Vinit,
         //
         // Checked on the first predictor only: which unknowns a direction reaches is a
         // property of it and of the topology, and neither changes along the curve.
-        if (it == 0 && V_pred == V_last) {
+        if (it == 0 &&
+            (V_pred - V_last).cwiseAbs().maxCoeff() <= BaseConstants::_tol_equal_float) {
             _msg = "the direction moves no bus voltage: everything it asks for is absorbed by "
                    "the slack. Scaling the machine at a single slack bus does this -- it "
                    "changes a real input, but not one the powerflow reads, since that bus' "
@@ -292,10 +301,10 @@ void ContinuationSweep::compute(const Eigen::Ref<const CplxVect> & Vinit,
         }
 
         // ---- corrector ---------------------------------------------------------
-        CplxVect V = V_pred;
-        const CplxVect Sbus = ac_cache_.inj + lam_pred * _direction;
+        V_corr = V_pred;   // compute_one_powerflow overwrites it with the solution
+        Sbus = ac_cache_.inj + lam_pred * _direction;
         const bool conv = compute_one_powerflow(
-            ac_cache_.mat, V, Sbus,
+            ac_cache_.mat, V_corr, Sbus,
             active_layout().slack_bus_id_solver.as_eigen(), active_layout().slack_weights,
             active_layout().bus_pv.as_eigen(), active_layout().bus_pq.as_eigen(),
             max_iter, tol);
@@ -327,10 +336,10 @@ void ContinuationSweep::compute(const Eigen::Ref<const CplxVect> & Vinit,
         }
 
         // ---- accept the point --------------------------------------------------
-        if(_adapt_step) step = _adapted_step(step, V, V_pred);
+        if(_adapt_step) step = _adapted_step(step, V_corr, V_pred);
 
         lam = lam_pred;
-        V_last = V;
+        V_last = V_corr;
         _voltages.row(_nb_points)(active_layout().id_solver_to_me.as_eigen()) = V_last.array();
         _lam(_nb_points) = lam;
         ++_nb_points;

--- a/src/core/batch_algorithm/ContinuationSweep.cpp
+++ b/src/core/batch_algorithm/ContinuationSweep.cpp
@@ -35,7 +35,7 @@ void ContinuationSweep::set_max_steps(int x)
     _max_steps = x;
 }
 
-SbusPolicy::Vary::RealMat ContinuationSweep::_delta_row(const RealVect & target,
+SbusPolicy::Vary::RealMat ContinuationSweep::_delta_row(const Eigen::Ref<const RealVect> & target,
                                                         const Eigen::Ref<const RealVect> & base,
                                                         const char * axis_name)
 {
@@ -88,7 +88,7 @@ void ContinuationSweep::_build_direction(int nb_buses_solver,
     _direction = dir.row(0).transpose();
 }
 
-bool ContinuationSweep::_restore_at(const CplxVect & V_last, real_type lam_last,
+bool ContinuationSweep::_restore_at(const Eigen::Ref<const CplxVect> & V_last, real_type lam_last,
                                     int max_iter, real_type tol)
 {
     CplxVect V = V_last;
@@ -107,8 +107,8 @@ bool ContinuationSweep::_restore_at(const CplxVect & V_last, real_type lam_last,
 }
 
 real_type ContinuationSweep::_adapted_step(real_type step,
-                                           const CplxVect & V_corr,
-                                           const CplxVect & V_pred) const
+                                           const Eigen::Ref<const CplxVect> & V_corr,
+                                           const Eigen::Ref<const CplxVect> & V_pred) const
 {
     // MATPOWER's cpf_error: the infinity norm of (corrected - predicted) over the
     // free state variables -- angles at pv and pq buses, magnitudes at pq buses --

--- a/src/core/batch_algorithm/ContinuationSweep.cpp
+++ b/src/core/batch_algorithm/ContinuationSweep.cpp
@@ -268,6 +268,27 @@ void ContinuationSweep::compute(const Eigen::Ref<const CplxVect> & Vinit,
         }
         _algo.cpf_predict(z, this_step / norm, V_pred);
 
+        // A direction that moves no VOLTAGE. The zero-direction check above cannot see
+        // this one: the direction is genuinely non-zero and the tangent z is too, but
+        // its every non-zero component lies on an unknown that is not a voltage -- the
+        // slack-absorbed power, in the case that occurs in practice. Scaling the machine
+        // at a single slack bus is exactly that: its P equation exists and takes the
+        // direction, but the slack absorption cancels it one for one, so the machine's
+        // real output does not change and no bus moves. lambda would then march to its
+        // target along a curve on which nothing whatsoever happens, and the run would
+        // report success. Same meaningless run as a zero direction, so it is refused the
+        // same way. Checked on the first predictor only: which unknowns the direction
+        // reaches is a property of it and of the topology, and neither changes here.
+        if (it == 0 && V_pred == V_last) {
+            throw std::runtime_error(
+                "ContinuationSweep::compute: the direction moves no bus voltage. It is not "
+                "zero, but everything it does is absorbed by the slack: scaling the machine "
+                "at a single slack bus, for instance, changes its setpoint and nothing else, "
+                "because that setpoint is not what decides its output. Continuing would walk "
+                "lambda along a curve on which nothing changes. Steer at least one element "
+                "whose power the powerflow actually has to route.");
+        }
+
         // ---- corrector ---------------------------------------------------------
         CplxVect V = V_pred;
         const CplxVect Sbus = ac_cache_.inj + lam_pred * _direction;

--- a/src/core/batch_algorithm/ContinuationSweep.cpp
+++ b/src/core/batch_algorithm/ContinuationSweep.cpp
@@ -268,25 +268,27 @@ void ContinuationSweep::compute(const Eigen::Ref<const CplxVect> & Vinit,
         }
         _algo.cpf_predict(z, this_step / norm, V_pred);
 
-        // A direction that moves no VOLTAGE. The zero-direction check above cannot see
-        // this one: the direction is genuinely non-zero and the tangent z is too, but
-        // its every non-zero component lies on an unknown that is not a voltage -- the
-        // slack-absorbed power, in the case that occurs in practice. Scaling the machine
-        // at a single slack bus is exactly that: its P equation exists and takes the
-        // direction, but the slack absorption cancels it one for one, so the machine's
-        // real output does not change and no bus moves. lambda would then march to its
-        // target along a curve on which nothing whatsoever happens, and the run would
-        // report success. Same meaningless run as a zero direction, so it is refused the
-        // same way. Checked on the first predictor only: which unknowns the direction
-        // reaches is a property of it and of the topology, and neither changes here.
+        // A direction the slack absorbs entirely. Unlike a zero direction this is a
+        // perfectly legal thing to ask for -- scaling the machine at a single slack bus
+        // moves a real input, it is simply an input the powerflow does not read: that
+        // bus' P equation exists and takes the direction, but the slack-absorbed unknown
+        // cancels it one for one, so the machine's actual output is unchanged and no bus
+        // moves. So this is NOT refused. What is refused is pretending it went somewhere:
+        // continuing would march lambda to its target over hundreds of identical points
+        // and report a loading margin that is really an artefact of max_steps. Stop here
+        // instead, with the base case as the only point and a message saying why.
+        //
+        // Checked on the first predictor only: which unknowns a direction reaches is a
+        // property of it and of the topology, and neither changes along the curve.
         if (it == 0 && V_pred == V_last) {
-            throw std::runtime_error(
-                "ContinuationSweep::compute: the direction moves no bus voltage. It is not "
-                "zero, but everything it does is absorbed by the slack: scaling the machine "
-                "at a single slack bus, for instance, changes its setpoint and nothing else, "
-                "because that setpoint is not what decides its output. Continuing would walk "
-                "lambda along a curve on which nothing changes. Steer at least one element "
-                "whose power the powerflow actually has to route.");
+            _msg = "the direction moves no bus voltage: everything it asks for is absorbed by "
+                   "the slack. Scaling the machine at a single slack bus does this -- it "
+                   "changes a real input, but not one the powerflow reads, since that bus' "
+                   "generation is whatever balances the grid rather than what was asked of "
+                   "it. There is no loading margin along such a direction, so nothing is "
+                   "traced past the base case; steer something whose power the powerflow "
+                   "actually has to route.";
+            break;
         }
 
         // ---- corrector ---------------------------------------------------------

--- a/src/core/batch_algorithm/ContinuationSweep.hpp
+++ b/src/core/batch_algorithm/ContinuationSweep.hpp
@@ -227,7 +227,7 @@ class LS2G_API ContinuationSweep final : public BaseBatchSolverSynch
         // one target axis as a 1-row matrix of DELTAS (target - base), or a 1 x n
         // zero matrix when the axis was never set. `base` is the grid's own target
         // vector for that element type.
-        static SbusPolicy::Vary::RealMat _delta_row(const RealVect & target,
+        static SbusPolicy::Vary::RealMat _delta_row(const Eigen::Ref<const RealVect> & target,
                                                     const Eigen::Ref<const RealVect> & base,
                                                     const char * axis_name);
 
@@ -239,7 +239,7 @@ class LS2G_API ContinuationSweep final : public BaseBatchSolverSynch
         // Re-solving from V_last converges immediately -- and precisely BECAUSE it
         // converges immediately it never enters the NR loop and so never
         // refactorizes, which is why the refactorization is asked for explicitly.
-        bool _restore_at(const CplxVect & V_last, real_type lam_last,
+        bool _restore_at(const Eigen::Ref<const CplxVect> & V_last, real_type lam_last,
                          int max_iter, real_type tol);
 
         // MATPOWER's predictor-error step control (cpf.adapt_step):
@@ -248,8 +248,8 @@ class LS2G_API ContinuationSweep final : public BaseBatchSolverSynch
         // clipped to [step_min, step_max]. MATPOWER's error also carries a lambda
         // term; here it is structurally zero (see the definition).
         real_type _adapted_step(real_type step,
-                                const CplxVect & V_corr,
-                                const CplxVect & V_pred) const;
+                                const Eigen::Ref<const CplxVect> & V_corr,
+                                const Eigen::Ref<const CplxVect> & V_pred) const;
 
     private:
         // target state (empty axis == unchanged from base)

--- a/src/core/batch_algorithm/ContinuationSweep.hpp
+++ b/src/core/batch_algorithm/ContinuationSweep.hpp
@@ -1,0 +1,282 @@
+// Copyright (c) 2020-2026, RTE (https://www.rte-france.com)
+// See AUTHORS.txt
+// This Source Code Form is subject to the terms of the Mozilla Public License, version 2.0.
+// If a copy of the Mozilla Public License, version 2.0 was not distributed with this file,
+// you can obtain one at http://mozilla.org/MPL/2.0/.
+// SPDX-License-Identifier: MPL-2.0
+// This file is part of LightSim2grid, LightSim2grid implements a c++ backend targeting the Grid2Op platform.
+
+#ifndef CONTINUATIONSWEEP_H
+#define CONTINUATIONSWEEP_H
+
+#include "BaseBatchSolverSynch.hpp"
+#include "SbusPolicy.hpp"
+
+#include <string>
+
+namespace ls2g {
+
+/**
+Continuation powerflow (CPF): traces the solution curve from a BASE injection state
+to a TARGET one, following the classical predictor / corrector scheme, and stops at
+the "nose" (the steady-state loading limit) or at a requested lambda.
+
+--- Why this is a batch algorithm -------------------------------------------------
+
+A continuation is a sequence of powerflows on a FIXED Ybus where only the injection
+moves -- exactly the premise the batch layer is built on. Deriving from
+`BaseBatchSolverSynch` (rather than reimplementing a loop around `LSGrid::ac_pf`) is
+what buys the whole point of doing this in C++: `_finish_preprocessing` runs the base
+case with `tell_all_changed()`, which builds the Jacobian sparsity and pays the ONE
+symbolic factorization, and leaves the control in `tell_none_changed()`; every
+corrector after that refactorizes numerically only. For KLU on a non-trivial grid the
+symbolic analysis dominates, so a curve of 100 points costs one analyze, not 100.
+
+It is a SIBLING of `BaseBatchSweep`, not a fifth instantiation of it, because what
+distinguishes a continuation is not which of (Ybus, Sbus) varies -- in that taxonomy
+it is exactly TimeSeries' cell -- but WHO DECIDES THE NEXT ROW. Three consequences
+the four-algorithm template cannot express:
+  - the number of points is not known in advance (the step adapts, and the curve
+    stops at the nose);
+  - a diverged solve is not a result but a RETRY signal (halve the step and try the
+    same point again), where `BaseBatchSweep::_store_row_status` would record it as a
+    failed row and a chained instantiation would abandon the range;
+  - the rows are strictly sequential, so there is nothing to thread.
+
+--- The algorithm -----------------------------------------------------------------
+
+The parametrised system is
+
+    F(x, lam) = Scomp(x) - Sbus_base - lam . dir = 0,   dir = Sbus_target - Sbus_base
+
+so lam = 0 is the base case and lam = 1 the target case (MATPOWER's `runcpf`
+convention, and the reason the input is a target state rather than a scalar factor).
+
+PREDICTOR. Differentiating, J . (dx/dlam) = dir projected onto the mismatch rows (see
+NRSystem::cpf_rhs_into for the sign, which is derived from the residual convention
+rather than assumed). Writing z = dx/dlam, the tangent is normalised:
+
+    norm  = sqrt(1 + z.z),   t_lam = 1 / norm,   t_x = z / norm
+
+and the step is taken along that unit tangent, so `step` is an arc length and stays
+meaningful as the curve turns. The solve reuses the standing factorization -- one
+triangular solve, no refactorization (see BaseAlgo::cpf_tangent).
+
+Note that with this (natural) parameterisation t_lam is 1/norm and so is strictly
+POSITIVE by construction: it cannot change sign at the nose, it tends to zero there,
+as ||z|| -> infinity when J becomes singular. `nose_tol` is therefore a threshold on
+t_lam, not a sign test.
+
+CORRECTOR. An ordinary Newton-Raphson at the predicted, FIXED lambda. This is what
+makes this a phase-1 continuation: at the nose the corrector's system is singular, so
+the curve stops there and the lower branch is not traced. Rounding the nose needs the
+lambda unknown and a parameterisation equation inside the Jacobian (MATPOWER's
+`cpf.parameterization` 2 / 3), i.e. an NRSystem extension; that is deliberately left
+for later.
+
+--- Defaults ----------------------------------------------------------------------
+
+The option names and default values follow MATPOWER's `cpf.*` so that a user who
+knows `runcpf` is not faced with new concepts: step 0.05, step_min 1e-4, step_max
+0.2, adapt_step off, adapt_step_damping 0.7, adapt_step_tol 1e-3, nose_tol 1e-5,
+and "stop at the nose" unless a target lambda is given. The one place this cannot
+follow MATPOWER is the parameterisation, whose default there is pseudo arc length
+(see above).
+**/
+class LS2G_API ContinuationSweep : public BaseBatchSolverSynch
+{
+    public:
+        explicit ContinuationSweep(const LSGrid & init_grid_model):
+            BaseBatchSolverSynch(init_grid_model),
+            _step(static_cast<real_type>(0.05)),
+            _step_min(static_cast<real_type>(1e-4)),
+            _step_max(static_cast<real_type>(0.2)),
+            _adapt_step(false),
+            _adapt_step_damping(static_cast<real_type>(0.7)),
+            _adapt_step_tol(static_cast<real_type>(1e-3)),
+            _nose_tol(static_cast<real_type>(1e-5)),
+            _stop_at_lam(-1.),
+            _max_steps(1000),
+            _exact_tangent(false),
+            _status(0),
+            _nb_points(0),
+            _nb_retries(0)
+            {}
+
+        // Strictly sequential: point k is predicted from point k-1's tangent. Reported
+        // here so set_nb_thread(>1) refuses with the base class' own message.
+        bool supports_multithread() const override {return false;}
+
+        // ---- the target injection state ----------------------------------------
+        // One entry per grid element of the relevant type, in MW / MVAr, i.e. the
+        // same units and ordering as LSGrid::get_gen_target_p() and friends. An axis
+        // never set (or set empty) means "same as the base case", so it contributes
+        // nothing to the direction. Setting none of them at all is an error: the
+        // direction would be zero and the continuation would walk lambda along a
+        // curve that does not move.
+        void set_target_gen_p(const RealVect & values)  {_target_gen_p = values;}
+        void set_target_sgen_p(const RealVect & values) {_target_sgen_p = values;}
+        void set_target_load_p(const RealVect & values) {_target_load_p = values;}
+        void set_target_load_q(const RealVect & values) {_target_load_q = values;}
+        void clear_target(){
+            _target_gen_p = RealVect(); _target_sgen_p = RealVect();
+            _target_load_p = RealVect(); _target_load_q = RealVect();
+        }
+
+        // ---- options (MATPOWER cpf.* names) ------------------------------------
+        real_type get_step() const {return _step;}
+        void set_step(real_type v) {_step = _checked_positive(v, "step");}
+        real_type get_step_min() const {return _step_min;}
+        void set_step_min(real_type v) {_step_min = _checked_positive(v, "step_min");}
+        real_type get_step_max() const {return _step_max;}
+        void set_step_max(real_type v) {_step_max = _checked_positive(v, "step_max");}
+        bool get_adapt_step() const {return _adapt_step;}
+        void set_adapt_step(bool v) {_adapt_step = v;}
+        real_type get_adapt_step_damping() const {return _adapt_step_damping;}
+        void set_adapt_step_damping(real_type v) {_adapt_step_damping = _checked_positive(v, "adapt_step_damping");}
+        real_type get_adapt_step_tol() const {return _adapt_step_tol;}
+        void set_adapt_step_tol(real_type v) {_adapt_step_tol = _checked_positive(v, "adapt_step_tol");}
+        real_type get_nose_tol() const {return _nose_tol;}
+        void set_nose_tol(real_type v) {_nose_tol = _checked_positive(v, "nose_tol");}
+
+        // Stop when lambda reaches this value (MATPOWER's numeric `cpf.stop_at`).
+        // A non-positive value means "trace until the nose" ('NOSE').
+        real_type get_stop_at_lam() const {return _stop_at_lam;}
+        void set_stop_at_lam(real_type v) {_stop_at_lam = v;}
+
+        // Hard cap on the number of traced points, so a pathological curve cannot
+        // spin forever. Also the number of rows reserved up front.
+        int get_max_steps() const {return _max_steps;}
+        void set_max_steps(int v);
+
+        // Rebuild and refactorize J at each converged point before taking its
+        // tangent. Off by default: compute_pf leaves a factorization from its last
+        // refactorizing iteration, which is one iterate behind the converged point --
+        // approximate, but the corrector absorbs it. Worth turning on with a lazy
+        // RefactorPolicy (Chord), where "one iterate behind" can be several.
+        bool get_exact_tangent() const {return _exact_tangent;}
+        void set_exact_tangent(bool v) {_exact_tangent = v;}
+
+        // ---- run ----------------------------------------------------------------
+        void compute(const Eigen::Ref<const CplxVect> & Vinit, int max_iter, real_type tol);
+
+        // ---- results ------------------------------------------------------------
+        // 1 if the curve was traced to its requested end (the nose, or stop_at_lam),
+        // 0 otherwise (base case diverged, or the run stopped early -- see get_msg).
+        int get_status() const {return _status;}
+        const std::string & get_msg() const {return _msg;}
+
+        // Number of traced points, base case included. get_voltages() has exactly
+        // this many rows (it is truncated at the end of compute()).
+        Eigen::Index nb_points() const {return _nb_points;}
+
+        // lambda at each traced point; lam(0) == 0 (the base case).
+        const RealVect & get_lam() const {return _lam;}
+        // the tangent's lambda component at each traced point, in (0, 1]. It tends to
+        // zero at the nose -- that is the collapse indicator, see the class comment.
+        // The last point has no tangent computed after it and reads 0.
+        const RealVect & get_tangent_lam() const {return _tangent_lam;}
+        // largest lambda reached (0 if only the base case was solved).
+        real_type get_lam_max() const {return _nb_points > 0 ? _lam(_nb_points - 1) : static_cast<real_type>(0.);}
+        // how many times a corrector failed and the step had to be reduced.
+        int nb_retries() const {return _nb_retries;}
+
+        // The direction actually used, in solver ordering and per unit (empty before
+        // the first compute()). Exposed for tests and for anyone who wants to check
+        // what a steering vector resolved to.
+        const CplxVect & get_direction_solver() const {return _direction;}
+
+        // Branch flows at every traced point, same contract as the other batch
+        // algorithms' (one row per point, one column per powerline then trafo).
+        Eigen::Ref<RealMat> compute_flows() {
+            compute_flows_from_Vs();
+            return _amps_flows;
+        }
+        Eigen::Ref<RealMat> compute_power_flows() {
+            compute_flows_from_Vs(false);
+            return _active_power_flows;
+        }
+
+        // timers
+        double total_time() const {return _timer_total;}
+        double preprocessing_time() const {return _timer_pre_proc;}
+
+        void clear() override {
+            BaseBatchSolverSynch::clear();
+            clear_target();
+            _direction = CplxVect();
+            _lam = RealVect();
+            _tangent_lam = RealVect();
+            _nb_points = 0;
+            _nb_retries = 0;
+            _status = 0;
+            _msg.clear();
+        }
+
+    protected:
+        // Sbus_target - Sbus_base, in solver ordering and per unit, built from the
+        // four target axes through SbusPolicy::Vary's own element -> solver-bus
+        // scatter helpers (the same ones TimeSeries uses, so a load / generator maps
+        // to its bus, aggregates with the others on it, and gets divided by sn_mva
+        // exactly as in an ordinary solve). Everything the four axes do NOT cover is
+        // identical in the base and the target state and therefore cancels in the
+        // difference -- which is why this needs no equivalent of
+        // SbusPolicy::Vary::constant_sbus_pu.
+        void _build_direction(int nb_buses_solver, const SolverBusIdVect & id_me_to_solver);
+
+        // one target axis as a 1-row matrix of DELTAS (target - base), or a 1 x n
+        // zero matrix when the axis was never set. `base` is the grid's own target
+        // vector for that element type.
+        static SbusPolicy::Vary::RealMat _delta_row(const RealVect & target,
+                                                    const Eigen::Ref<const RealVect> & base,
+                                                    const char * axis_name);
+
+        static real_type _checked_positive(real_type v, const char * name);
+
+        // Re-establish the algorithm's state at the last converged point after a
+        // corrector diverged: the failed solve left (Va, Vm) and the standing
+        // factorization at some diverged iterate, and both feed the next tangent.
+        // Re-solving from V_last converges immediately -- and precisely BECAUSE it
+        // converges immediately it never enters the NR loop and so never
+        // refactorizes, which is why the refactorization is asked for explicitly.
+        bool _restore_at(const CplxVect & V_last, real_type lam_last,
+                         int max_iter, real_type tol);
+
+        // MATPOWER's predictor-error step control (cpf.adapt_step):
+        //   err        = ||[theta(pv,pq); |V|(pq)]_corrected - [..]_predicted||_inf
+        //   step_scale = min(2, 1 + damping . (tol/err - 1))
+        // clipped to [step_min, step_max]. MATPOWER's error also carries a lambda
+        // term; here it is structurally zero (see the definition).
+        real_type _adapted_step(real_type step,
+                                const CplxVect & V_corr,
+                                const CplxVect & V_pred) const;
+
+    private:
+        // target state (empty axis == unchanged from base)
+        RealVect _target_gen_p, _target_sgen_p, _target_load_p, _target_load_q;
+
+        // options
+        real_type _step;
+        real_type _step_min;
+        real_type _step_max;
+        bool      _adapt_step;
+        real_type _adapt_step_damping;
+        real_type _adapt_step_tol;
+        real_type _nose_tol;
+        real_type _stop_at_lam;
+        int       _max_steps;
+        bool      _exact_tangent;
+
+        // results
+        int         _status;
+        std::string _msg;
+        Eigen::Index _nb_points;
+        int         _nb_retries;
+        RealVect    _lam;
+        RealVect    _tangent_lam;
+        CplxVect    _direction;
+};
+
+} // namespace ls2g
+
+#endif // CONTINUATIONSWEEP_H

--- a/src/core/batch_algorithm/ContinuationSweep.hpp
+++ b/src/core/batch_algorithm/ContinuationSweep.hpp
@@ -83,7 +83,7 @@ and "stop at the nose" unless a target lambda is given. The one place this canno
 follow MATPOWER is the parameterisation, whose default there is pseudo arc length
 (see above).
 **/
-class LS2G_API ContinuationSweep : public BaseBatchSolverSynch
+class LS2G_API ContinuationSweep final : public BaseBatchSolverSynch
 {
     public:
         explicit ContinuationSweep(const LSGrid & init_grid_model):
@@ -114,10 +114,10 @@ class LS2G_API ContinuationSweep : public BaseBatchSolverSynch
         // nothing to the direction. Setting none of them at all is an error: the
         // direction would be zero and the continuation would walk lambda along a
         // curve that does not move.
-        void set_target_gen_p(const RealVect & values)  {_target_gen_p = values;}
-        void set_target_sgen_p(const RealVect & values) {_target_sgen_p = values;}
-        void set_target_load_p(const RealVect & values) {_target_load_p = values;}
-        void set_target_load_q(const RealVect & values) {_target_load_q = values;}
+        void set_target_gen_p(const Eigen::Ref<const RealVect> & values)  {_target_gen_p = values;}
+        void set_target_sgen_p(const Eigen::Ref<const RealVect> & values) {_target_sgen_p = values;}
+        void set_target_load_p(const Eigen::Ref<const RealVect> & values) {_target_load_p = values;}
+        void set_target_load_q(const Eigen::Ref<const RealVect> & values) {_target_load_q = values;}
         void clear_target(){
             _target_gen_p = RealVect(); _target_sgen_p = RealVect();
             _target_load_p = RealVect(); _target_load_q = RealVect();
@@ -125,29 +125,29 @@ class LS2G_API ContinuationSweep : public BaseBatchSolverSynch
 
         // ---- options (MATPOWER cpf.* names) ------------------------------------
         real_type get_step() const {return _step;}
-        void set_step(real_type v) {_step = _checked_positive(v, "step");}
+        void set_step(real_type x) {_step = _checked_positive(x, "step");}
         real_type get_step_min() const {return _step_min;}
-        void set_step_min(real_type v) {_step_min = _checked_positive(v, "step_min");}
+        void set_step_min(real_type x) {_step_min = _checked_positive(x, "step_min");}
         real_type get_step_max() const {return _step_max;}
-        void set_step_max(real_type v) {_step_max = _checked_positive(v, "step_max");}
+        void set_step_max(real_type x) {_step_max = _checked_positive(x, "step_max");}
         bool get_adapt_step() const {return _adapt_step;}
-        void set_adapt_step(bool v) {_adapt_step = v;}
+        void set_adapt_step(bool on) {_adapt_step = on;}
         real_type get_adapt_step_damping() const {return _adapt_step_damping;}
-        void set_adapt_step_damping(real_type v) {_adapt_step_damping = _checked_positive(v, "adapt_step_damping");}
+        void set_adapt_step_damping(real_type x) {_adapt_step_damping = _checked_positive(x, "adapt_step_damping");}
         real_type get_adapt_step_tol() const {return _adapt_step_tol;}
-        void set_adapt_step_tol(real_type v) {_adapt_step_tol = _checked_positive(v, "adapt_step_tol");}
+        void set_adapt_step_tol(real_type x) {_adapt_step_tol = _checked_positive(x, "adapt_step_tol");}
         real_type get_nose_tol() const {return _nose_tol;}
-        void set_nose_tol(real_type v) {_nose_tol = _checked_positive(v, "nose_tol");}
+        void set_nose_tol(real_type x) {_nose_tol = _checked_positive(x, "nose_tol");}
 
         // Stop when lambda reaches this value (MATPOWER's numeric `cpf.stop_at`).
         // A non-positive value means "trace until the nose" ('NOSE').
         real_type get_stop_at_lam() const {return _stop_at_lam;}
-        void set_stop_at_lam(real_type v) {_stop_at_lam = v;}
+        void set_stop_at_lam(real_type x) {_stop_at_lam = x;}
 
         // Hard cap on the number of traced points, so a pathological curve cannot
         // spin forever. Also the number of rows reserved up front.
         int get_max_steps() const {return _max_steps;}
-        void set_max_steps(int v);
+        void set_max_steps(int x);
 
         // Rebuild and refactorize J at each converged point before taking its
         // tangent. Off by default: compute_pf leaves a factorization from its last
@@ -155,7 +155,7 @@ class LS2G_API ContinuationSweep : public BaseBatchSolverSynch
         // approximate, but the corrector absorbs it. Worth turning on with a lazy
         // RefactorPolicy (Chord), where "one iterate behind" can be several.
         bool get_exact_tangent() const {return _exact_tangent;}
-        void set_exact_tangent(bool v) {_exact_tangent = v;}
+        void set_exact_tangent(bool on) {_exact_tangent = on;}
 
         // ---- run ----------------------------------------------------------------
         void compute(const Eigen::Ref<const CplxVect> & Vinit, int max_iter, real_type tol);
@@ -171,11 +171,11 @@ class LS2G_API ContinuationSweep : public BaseBatchSolverSynch
         Eigen::Index nb_points() const {return _nb_points;}
 
         // lambda at each traced point; lam(0) == 0 (the base case).
-        const RealVect & get_lam() const {return _lam;}
+        Eigen::Ref<const RealVect> get_lam() const {return _lam;}
         // the tangent's lambda component at each traced point, in (0, 1]. It tends to
         // zero at the nose -- that is the collapse indicator, see the class comment.
         // The last point has no tangent computed after it and reads 0.
-        const RealVect & get_tangent_lam() const {return _tangent_lam;}
+        Eigen::Ref<const RealVect> get_tangent_lam() const {return _tangent_lam;}
         // largest lambda reached (0 if only the base case was solved).
         real_type get_lam_max() const {return _nb_points > 0 ? _lam(_nb_points - 1) : static_cast<real_type>(0.);}
         // how many times a corrector failed and the step had to be reduced.
@@ -184,7 +184,7 @@ class LS2G_API ContinuationSweep : public BaseBatchSolverSynch
         // The direction actually used, in solver ordering and per unit (empty before
         // the first compute()). Exposed for tests and for anyone who wants to check
         // what a steering vector resolved to.
-        const CplxVect & get_direction_solver() const {return _direction;}
+        Eigen::Ref<const CplxVect> get_direction_solver() const {return _direction;}
 
         // Branch flows at every traced point, same contract as the other batch
         // algorithms' (one row per point, one column per powerline then trafo).
@@ -231,7 +231,7 @@ class LS2G_API ContinuationSweep : public BaseBatchSolverSynch
                                                     const Eigen::Ref<const RealVect> & base,
                                                     const char * axis_name);
 
-        static real_type _checked_positive(real_type v, const char * name);
+        static real_type _checked_positive(real_type x, const char * name);
 
         // Re-establish the algorithm's state at the last converged point after a
         // corrector diverged: the failed solve left (Va, Vm) and the standing

--- a/src/core/powerflow_algorithm/BaseAlgo.hpp
+++ b/src/core/powerflow_algorithm/BaseAlgo.hpp
@@ -491,6 +491,59 @@ class LS2G_API BaseAlgo : public BaseConstants
         virtual void set_switchable_vm_buses(const std::vector<int> & /*solver_bus_ids*/) {}
         virtual void set_pv_pinned_buses(const std::vector<int> & /*solver_bus_ids*/) {}
 
+        // ---- continuation powerflow (CPF) primitives ------------------------------
+        //
+        // The continuation loop itself lives in ContinuationSweep (a batch algorithm);
+        // what it needs from the algorithm is only these two operations, both of which
+        // require an augmented-Jacobian layout and a standing factorization, i.e. the
+        // Newton-Raphson family (see supports_cpf).
+        //
+        // The parametrised system is F(x, lam) = Scomp(x) - Sbus_base - lam . dir = 0,
+        // so dF/dlam = -dir and the tangent dx/dlam solves J . z = rhs(dir). Both calls
+        // are only meaningful right after a CONVERGED compute_pf: they read the
+        // algorithm's converged (Va, Vm) and reuse the factorization that solve left
+        // standing -- no analyze, no refactorize, which is the entire point of running
+        // a continuation in C++ rather than around it.
+        //
+        // Note that the standing factorization is J at the last iterate that actually
+        // (re)factorized, NOT at the converged point: compute_pf does not refactorize
+        // after its final convergence check. The tangent is therefore approximate --
+        // harmless, since the corrector fixes it, but it does mean the tangent quality
+        // degrades with a lazier RefactorPolicy (Chord in particular). Pass
+        // `exact_tangent` on the sweep to refactorize at the converged point instead.
+        virtual bool supports_cpf() const noexcept { return false; }
+
+        // Solves J . z = rhs(dir), where rhs projects the complex per-bus direction
+        // onto this algorithm's mismatch-equation ordering. `z` is resized to the
+        // number of unknowns. Returns false if the linear solve failed (`z` is then
+        // meaningless); throws if the algorithm has no J at all.
+        virtual bool cpf_tangent(const Eigen::Ref<const CplxVect> & /*dir_solver*/,
+                                 RealVect & /*z*/){
+            throw std::runtime_error("BaseAlgo::cpf_tangent: this algorithm is not "
+                                     "Newton-Raphson based and cannot support a continuation "
+                                     "powerflow (see supports_cpf).");
+        }
+
+        // Writes the predicted voltages V + coeff . (the (Va, Vm) part of z) into
+        // V_pred, reading the algorithm's own converged (Va, Vm). V_pred is resized.
+        virtual void cpf_predict(const Eigen::Ref<const RealVect> & /*z*/,
+                                 real_type /*coeff*/,
+                                 CplxVect & /*V_pred*/) const {
+            throw std::runtime_error("BaseAlgo::cpf_predict: this algorithm is not "
+                                     "Newton-Raphson based and cannot support a continuation "
+                                     "powerflow (see supports_cpf).");
+        }
+
+        // Rebuilds J at the current (converged) state and refactorizes it, so that a
+        // following cpf_tangent uses the exact Jacobian at that point rather than the
+        // one left standing by the last NR iteration. Numeric only -- the symbolic
+        // analysis (and therefore the whole batch's one-analyze premise) is untouched.
+        virtual bool cpf_refactorize_at_current(){
+            throw std::runtime_error("BaseAlgo::cpf_refactorize_at_current: this algorithm is "
+                                     "not Newton-Raphson based and cannot support a continuation "
+                                     "powerflow (see supports_cpf).");
+        }
+
         virtual AlgoConfig get_config() const { return AlgoConfig{}; }
         virtual void set_config(const AlgoConfig&) {}
         

--- a/src/core/powerflow_algorithm/NRAlgo.hpp
+++ b/src/core/powerflow_algorithm/NRAlgo.hpp
@@ -182,6 +182,56 @@ public:
         _system.set_pv_pinned_buses(solver_bus_ids);
     }
     
+    // ----- continuation powerflow (CPF) ----------------------------------------
+    // See BaseAlgo for the contract. Both operations are meaningful only right
+    // after a converged compute_pf: they read the converged (Va, Vm) and the
+    // factorization it left standing.
+    bool supports_cpf() const noexcept override { return true; }
+
+    bool cpf_tangent(const Eigen::Ref<const CplxVect> & dir_solver, RealVect & z) override {
+        const Eigen::Index n = _system.J().rows();
+        if(n <= 0){
+            throw std::runtime_error("NRAlgo::cpf_tangent: no Jacobian is available -- a "
+                                     "powerflow must have been solved first.");
+        }
+        if(dir_solver.size() != _system.Va().size()){
+            std::ostringstream exc_;
+            exc_ << "NRAlgo::cpf_tangent: the direction has " << dir_solver.size()
+                 << " entries while the solver has " << _system.Va().size() << " buses.";
+            throw std::runtime_error(exc_.str());
+        }
+        if(z.size() != n) z.resize(n);
+        _system.cpf_rhs_into(z, dir_solver);
+        // solve() reuses the standing factorization: no analyze, no refactorize.
+        const ErrorType err = _linear_solver.solve(z);
+        if(err != ErrorType::NoError){
+            err_ = err;
+            return false;
+        }
+        return true;
+    }
+
+    void cpf_predict(const Eigen::Ref<const RealVect> & z,
+                     real_type coeff,
+                     CplxVect & V_pred) const override {
+        _system.cpf_predict_into(V_pred, z, coeff);
+    }
+
+    bool cpf_refactorize_at_current() override {
+        if(_system.J().rows() <= 0){
+            throw std::runtime_error("NRAlgo::cpf_refactorize_at_current: no Jacobian is "
+                                     "available -- a powerflow must have been solved first.");
+        }
+        _system.fill_internal_variables();
+        _system.fill_J();
+        const ErrorType err = _linear_solver.refactorize(_system.J());
+        if(err != ErrorType::NoError){
+            err_ = err;
+            return false;
+        }
+        return true;
+    }
+
     // ----- scaling policy ------------------------------------------------------
     ScalingPolicyType get_scaling_policy_type()  const { return scaling_policy_->type(); }
     void set_scaling_policy(ScalingPolicyType t)  { 

--- a/src/core/powerflow_algorithm/NRSystem.hpp
+++ b/src/core/powerflow_algorithm/NRSystem.hpp
@@ -1144,6 +1144,33 @@ public:
     // "update these already-declared feature positions."
     void update_trailing_feature_values(int count, const Eigen::Ref<const RealVect>& deltas);
 
+    // ----- continuation powerflow (CPF) primitives --------------------------------
+    //
+    // Right-hand side of the tangent system J . z = rhs, for the parametrised
+    // problem F(x, lam) = Scomp(x) - Sbus - lam . dir, whose dF/dlam is -dir.
+    //
+    // The projection is exactly the one _residual_into performs on Sbus, and for the
+    // same reason: `res` there is `Sbus - Scomp` (the residual is NEGATED, see
+    // NRAlgo::compute_pf, which solves J . dx = res and applies +dx), so the Sbus
+    // term enters a P row with a PLUS sign. Hence rhs(p_row(b)) = +Re(dir(b)) and
+    // rhs(q_row(b)) = +Im(dir(b)).
+    //
+    // Custom rows (MultiSlack, Hvdc, VoltageControl) get zero: none of them depends
+    // on lam. Masked and PV-pinned rows get zero too, matching the identity rows
+    // fill_J writes for them -- so a masked bus contributes no tangent, exactly as it
+    // contributes no residual.
+    //
+    // Accumulates (+=) over the ledger's pair lists, like _residual_into, so a bus
+    // registered more than once sums rather than overwrites.
+    void cpf_rhs_into(Eigen::Ref<RealVect> rhs, const Eigen::Ref<const CplxVect>& dir) const;
+
+    // V_pred = (Va_ + coeff . z_theta, Vm_ + coeff . z_vm) in polar form, using the
+    // same ledger-driven (bus, col) walk as apply_step -- so a component that owns a
+    // voltage unknown is predicted exactly where the corrector would step it. The
+    // system's own state is NOT modified: this writes a trial voltage for the
+    // corrector to start from.
+    void cpf_predict_into(CplxVect& V_pred, const Eigen::Ref<const RealVect>& z, real_type coeff) const;
+
     // ----- Housekeeping ----------------------------------------------------------
 
     void clear_jacobian() {

--- a/src/core/powerflow_algorithm/NRSystem.tpp
+++ b/src/core/powerflow_algorithm/NRSystem.tpp
@@ -425,6 +425,62 @@ inline RealVect NRSystem<Base, Rest...>::mismatch() const
 }
 
 template <typename... Rest>
+inline void NRSystem<Base, Rest...>::cpf_rhs_into(Eigen::Ref<RealVect> rhs,
+                                                  const Eigen::Ref<const CplxVect>& dir) const
+{
+    assert(rhs.size() == static_cast<Eigen::Index>(total_state_variables()));
+    rhs.setZero();
+    // the SAME projection _residual_into applies to Sbus, sign included -- see the
+    // header comment. Accumulate, for the same multiplicity reason.
+    const std::vector<int>& p_buses = ledger_.p_buses();
+    const std::vector<int>& p_rows  = ledger_.p_rows();
+    for (size_t k = 0; k < p_buses.size(); ++k) rhs(p_rows[k]) += std::real(dir(p_buses[k]));
+    const std::vector<int>& q_buses = ledger_.q_buses();
+    const std::vector<int>& q_rows  = ledger_.q_rows();
+    for (size_t k = 0; k < q_buses.size(); ++k) rhs(q_rows[k]) += std::imag(dir(q_buses[k]));
+
+    // masked / PV-pinned rows are identity rows in J (see fill_J): zero them here so
+    // the tangent they produce is zero, exactly as _residual_into does for the residual.
+    if (!masked_buses_.empty()) {
+        for (int b : masked_buses_) {
+            const int pr = ledger_.p_row(b);
+            if (pr >= 0) rhs(pr) = static_cast<real_type>(0.);
+            const int qr = ledger_.q_row(b);
+            if (qr >= 0) rhs(qr) = static_cast<real_type>(0.);
+        }
+    }
+    for (int b : pv_pinned_buses_) {
+        const int qr = ledger_.q_row(b);
+        if (qr >= 0) rhs(qr) = static_cast<real_type>(0.);
+    }
+}
+
+template <typename... Rest>
+inline void NRSystem<Base, Rest...>::cpf_predict_into(CplxVect& V_pred,
+                                                      const Eigen::Ref<const RealVect>& z,
+                                                      real_type coeff) const
+{
+    // same (bus, col) walk as apply_step, but into scratch copies: the system's own
+    // (Va_, Vm_, V_) stay at the converged point, which is what the corrector falls
+    // back to if this prediction has to be retried with a smaller step.
+    if(Va_trial_cache_.size() != Va_.size()) Va_trial_cache_.resize(Va_.size());
+    if(Vm_trial_cache_.size() != Vm_.size()) Vm_trial_cache_.resize(Vm_.size());
+    Va_trial_cache_ = Va_;
+    Vm_trial_cache_ = Vm_;
+
+    const std::vector<int>& theta_buses = ledger_.theta_buses();
+    const std::vector<int>& theta_cols  = ledger_.theta_cols();
+    for (size_t k = 0; k < theta_buses.size(); ++k)
+        Va_trial_cache_(theta_buses[k]) += coeff * z(theta_cols[k]);
+    const std::vector<int>& vm_buses = ledger_.vm_buses();
+    const std::vector<int>& vm_cols  = ledger_.vm_cols();
+    for (size_t k = 0; k < vm_buses.size(); ++k)
+        Vm_trial_cache_(vm_buses[k]) += coeff * z(vm_cols[k]);
+
+    _reconstruct_V_into(V_pred, Va_trial_cache_, Vm_trial_cache_);
+}
+
+template <typename... Rest>
 inline void NRSystem<Base, Rest...>::apply_step(const Eigen::Ref<const RealVect>& dx)
 {
     // generic voltage updates, driven by the ledger's (bus, col) pair lists

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -79,6 +79,7 @@ add_executable(lightsim2grid_unit_tests
     test_batch_voltage_control.cpp
     test_timeseries_sbus.cpp
     test_injection_sweep.cpp
+    test_continuation_sweep.cpp
     test_scenario_sweep_violations.cpp
     test_bus_element_count.cpp
     test_kcl_from_results.cpp

--- a/src/tests/test_continuation_sweep.cpp
+++ b/src/tests/test_continuation_sweep.cpp
@@ -202,6 +202,43 @@ TEST_CASE("a zero direction is refused rather than traced", "[cpf]")
     REQUIRE_THROWS_AS(untargeted.compute(flat(grid), 20, 1e-10), std::runtime_error);
 }
 
+TEST_CASE("a direction the slack absorbs entirely is refused", "[cpf]")
+{
+    // The companion of the zero-direction guard, and the reason slack machines are NOT
+    // excluded from gen_steering the way MATPOWER excludes them from a target case: at a
+    // SINGLE slack bus the machine's target_p is inert, so a direction that only scales
+    // it is non-zero, produces a non-zero tangent (that bus does have a P equation, paired
+    // with the slack-absorbed unknown), and yet moves no voltage whatsoever -- the slack
+    // absorption cancels it one for one. Left alone, lambda marches to its target over a
+    // curve on which nothing happens, and the run reports success.
+    LSGrid grid = make_grid();
+    grid.change_p_gen(0, 30.);  // the slack machine, given a non-zero setpoint to scale
+    ContinuationSweep sweep(grid);
+    sweep.change_algorithm(AlgorithmType::NR_SparseLU);
+    RealVect gp(NB_GEN);
+    gp << 60., 20.;  // ONLY the slack machine moves
+    sweep.set_target_gen_p(gp);
+    REQUIRE_THROWS_AS(sweep.compute(flat(grid), 20, 1e-10), std::runtime_error);
+}
+
+TEST_CASE("a single slack machine's setpoint does not change the solution", "[cpf]")
+{
+    // What makes the test above true, stated on its own: with one slack bus the machine's
+    // target_p is an input the powerflow ignores -- its output is whatever balances the
+    // grid. (With a DISTRIBUTED slack this stops holding, which is exactly why excluding
+    // slack machines from the steering would be wrong there.)
+    LSGrid a = make_grid();
+    a.change_p_gen(0, 30.);
+    const CplxVect Va = a.ac_pf(flat(a), 30, 1e-11);
+
+    LSGrid b = make_grid();
+    b.change_p_gen(0, 60.);
+    const CplxVect Vb = b.ac_pf(flat(b), 30, 1e-11);
+
+    REQUIRE(Va.size() == Vb.size());
+    for (Eigen::Index i = 0; i < Va.size(); ++i) REQUIRE(Va(i) == Vb(i));
+}
+
 TEST_CASE("a continuation refuses an algorithm with no Jacobian", "[cpf]")
 {
     LSGrid grid = make_grid();

--- a/src/tests/test_continuation_sweep.cpp
+++ b/src/tests/test_continuation_sweep.cpp
@@ -1,0 +1,290 @@
+// Copyright (c) 2026, RTE (https://www.rte-france.com)
+// See AUTHORS.txt
+// This Source Code Form is subject to the terms of the Mozilla Public License, version 2.0.
+// If a copy of the Mozilla Public License, version 2.0 was not distributed with this file,
+// you can obtain one at http://mozilla.org/MPL/2.0/.
+// SPDX-License-Identifier: MPL-2.0
+// This file is part of LightSim2grid, LightSim2grid implements a c++ backend targeting the Grid2Op platform.
+
+// ContinuationSweep is a batch algorithm (a sibling of the four BaseBatchSweep
+// instantiations, see batch_algorithm/ContinuationSweep.hpp): it traces the solution
+// curve from the grid's own injections to a target state and stops at the nose.
+//
+// The oracle here is deliberately not another continuation: every traced point must be
+// a solution of the ORDINARY powerflow at the injections that point claims, which is
+// checked by re-solving with LSGrid::ac_pf. The rest pins what the class exists for --
+// one symbolic factorization for the whole curve -- and the two failure modes that
+// would otherwise produce a plausible-looking curve instead of an error: a direction
+// whose sign is inverted (the voltages would RISE under load) and a zero direction.
+
+#include <string>
+#include <vector>
+
+#include <catch2/catch_approx.hpp>
+#include <catch2/catch_test_macros.hpp>
+
+#include "LSGrid.hpp"
+#include "batch_algorithm/ContinuationSweep.hpp"
+
+using Catch::Approx;
+using ls2g::AlgorithmType;
+using ls2g::ContinuationSweep;
+using ls2g::CplxVect;
+using ls2g::LSGrid;
+using ls2g::RealVect;
+using ls2g::cplx_type;
+using ls2g::real_type;
+
+namespace {
+
+const int NB_BUS = 4;
+const int NB_GEN = 2;
+
+// 4-bus radial feeder 0-1-2-3, one load at bus 3, a slack generator at bus 0 and a PV
+// generator at bus 1. sn_mva deliberately != 1, so a direction built in MW that forgot
+// to divide by it would be off by a factor of 100.
+LSGrid make_grid()
+{
+    LSGrid g;
+    g.set_sn_mva(100.);
+    g.set_init_vm_pu(1.0);
+    const RealVect vn = RealVect::Constant(NB_BUS, 138.);
+    g.init_bus(static_cast<unsigned int>(NB_BUS), 1, vn, 0, 0);
+
+    const RealVect r = RealVect::Constant(NB_BUS - 1, 0.01);
+    const RealVect x = RealVect::Constant(NB_BUS - 1, 0.1);
+    const CplxVect h = CplxVect::Zero(NB_BUS - 1);
+    Eigen::VectorXi f(NB_BUS - 1), t(NB_BUS - 1);
+    for (int i = 0; i < NB_BUS - 1; ++i) { f(i) = i; t(i) = i + 1; }
+    g.init_powerlines(r, x, h, f, t);
+
+    RealVect lp(1), lq(1); lp << 50.; lq << 10.;
+    Eigen::VectorXi lb(1); lb << NB_BUS - 1;
+    g.init_loads(lp, lq, lb);
+
+    RealVect p(NB_GEN), v(NB_GEN), q(NB_GEN), qmin(NB_GEN), qmax(NB_GEN);
+    Eigen::VectorXi b(NB_GEN);
+    p << 0., 20.;
+    v << 1.02, 1.01;
+    q << 0., 0.;
+    qmin << -1000., -1000.;
+    qmax << 1000., 1000.;
+    b << 0, 1;
+    g.init_generators_full(p, v, q, std::vector<bool>{true, true}, qmin, qmax, b);
+    g.add_gen_slackbus(0, 1.);
+    return g;
+}
+
+CplxVect flat(const LSGrid & g)
+{
+    return CplxVect::Constant(static_cast<Eigen::Index>(g.total_bus()), cplx_type(1., 0.));
+}
+
+// the load's target active power at a given lambda, for a run that doubles it
+real_type load_p_at(real_type lam) { return 50. * (1. + lam); }
+real_type load_q_at(real_type lam) { return 10. * (1. + lam); }
+
+// Doubles the single load's P and Q, generation held fixed. A sweep cannot be returned
+// by value (BaseBatchSolverSynch is deliberately neither copyable nor movable -- the
+// solvers hold a pointer to its own _grid_model member), so this configures one in place.
+void setup_sweep(ContinuationSweep & sweep)
+{
+    sweep.change_algorithm(AlgorithmType::NR_SparseLU);
+    RealVect lp(1), lq(1);
+    lp << load_p_at(1.);
+    lq << load_q_at(1.);
+    sweep.set_target_load_p(lp);
+    sweep.set_target_load_q(lq);
+}
+
+}  // namespace
+
+TEST_CASE("a continuation traces points that are genuine powerflow solutions", "[cpf]")
+{
+    LSGrid grid = make_grid();
+    ContinuationSweep sweep(grid);
+    setup_sweep(sweep);
+    sweep.set_stop_at_lam(1.0);
+    sweep.compute(flat(grid), 20, 1e-10);
+
+    REQUIRE(sweep.get_status() == 1);
+    REQUIRE(sweep.nb_points() > 5);
+    REQUIRE(sweep.get_lam()(0) == Approx(0.).margin(1e-14));
+    REQUIRE(sweep.get_lam()(sweep.nb_points() - 1) == Approx(1.).margin(1e-12));
+
+    // every traced point, re-solved with an ordinary powerflow at its own injections
+    for (Eigen::Index i = 0; i < sweep.nb_points(); ++i) {
+        const real_type lam = sweep.get_lam()(i);
+        LSGrid ref = make_grid();
+        ref.change_p_load(0, load_p_at(lam));
+        ref.change_q_load(0, load_q_at(lam));
+        const CplxVect V = ref.ac_pf(flat(ref), 30, 1e-11);
+        REQUIRE(V.size() > 0);
+        for (Eigen::Index b = 0; b < V.size(); ++b) {
+            REQUIRE(std::abs(V(b) - sweep.get_voltages()(i, b)) < 1e-8);
+        }
+    }
+}
+
+TEST_CASE("the whole curve costs one symbolic factorization", "[cpf]")
+{
+    LSGrid grid = make_grid();
+    ContinuationSweep sweep(grid);
+    setup_sweep(sweep);
+    sweep.compute(flat(grid), 20, 1e-10);
+
+    REQUIRE(sweep.nb_points() > 10);
+    // ONE analyze however many points were traced -- the reason a continuation belongs
+    // in the batch layer rather than in a loop around LSGrid::ac_pf.
+    REQUIRE(sweep.get_linear_solver_stats().nb_analyze == 1);
+    REQUIRE(sweep.get_linear_solver_stats().nb_refactorize > sweep.nb_points());
+}
+
+TEST_CASE("loading the grid lowers its voltages", "[cpf]")
+{
+    // The sign of the load direction. A load is a NEGATIVE injection (LoadContainer::
+    // fillSbus subtracts it), so a direction that increases the load must decrease the
+    // voltages; inverting it traces the grid UNLOADING, converging happily all the way.
+    LSGrid grid = make_grid();
+    ContinuationSweep sweep(grid);
+    setup_sweep(sweep);
+    sweep.compute(flat(grid), 20, 1e-10);
+    REQUIRE(sweep.nb_points() > 2);
+
+    // the direction itself: one load of +50 MW at the end bus, ie -0.5 pu of injection
+    const CplxVect & dir = sweep.get_direction_solver();
+    REQUIRE(std::real(dir(NB_BUS - 1)) == Approx(-0.5));
+    REQUIRE(std::imag(dir(NB_BUS - 1)) == Approx(-0.1));
+
+    const Eigen::Index last = sweep.nb_points() - 1;
+    const real_type vm_first = std::abs(sweep.get_voltages()(0, NB_BUS - 1));
+    const real_type vm_last = std::abs(sweep.get_voltages()(last, NB_BUS - 1));
+    REQUIRE(vm_last < vm_first);
+    for (Eigen::Index i = 1; i < sweep.nb_points(); ++i) {
+        REQUIRE(std::abs(sweep.get_voltages()(i, NB_BUS - 1)) <=
+                std::abs(sweep.get_voltages()(i - 1, NB_BUS - 1)) + 1e-9);
+    }
+}
+
+TEST_CASE("the tangent's lambda component collapses at the nose", "[cpf]")
+{
+    LSGrid grid = make_grid();
+    ContinuationSweep sweep(grid);
+    setup_sweep(sweep);
+    sweep.compute(flat(grid), 20, 1e-10);
+
+    REQUIRE(sweep.get_status() == 1);  // stopped at the nose, not on the step cap
+    // strictly positive throughout -- this parameterisation cannot make it change sign,
+    // it only tends to zero (see ContinuationSweep.hpp)
+    for (Eigen::Index i = 0; i + 1 < sweep.nb_points(); ++i) {
+        REQUIRE(sweep.get_tangent_lam()(i) > 0.);
+    }
+    const Eigen::Index before_last = sweep.nb_points() - 2;
+    REQUIRE(sweep.get_tangent_lam()(before_last) < sweep.get_tangent_lam()(0));
+}
+
+TEST_CASE("a zero direction is refused rather than traced", "[cpf]")
+{
+    // Not a degenerate curve but a meaningless run: J . z = 0 gives z = 0, the tangent
+    // normalises to (0, ..., 1), and lambda would march to its target reporting success
+    // for a continuation that continued nothing.
+    LSGrid grid = make_grid();
+    ContinuationSweep sweep(grid);
+    sweep.change_algorithm(AlgorithmType::NR_SparseLU);
+    RealVect same(1);
+    same << 50.;  // exactly the grid's own value
+    sweep.set_target_load_p(same);
+    REQUIRE_THROWS_AS(sweep.compute(flat(grid), 20, 1e-10), std::runtime_error);
+
+    // and so is setting no target at all
+    ContinuationSweep untargeted(grid);
+    untargeted.change_algorithm(AlgorithmType::NR_SparseLU);
+    REQUIRE_THROWS_AS(untargeted.compute(flat(grid), 20, 1e-10), std::runtime_error);
+}
+
+TEST_CASE("a continuation refuses an algorithm with no Jacobian", "[cpf]")
+{
+    LSGrid grid = make_grid();
+
+    ContinuationSweep gauss(grid);
+    setup_sweep(gauss);
+    gauss.change_algorithm(AlgorithmType::GaussSeidel);
+    // change_algorithm() clears the object, so the target has to be set again
+    RealVect lp(1); lp << load_p_at(1.);
+    gauss.set_target_load_p(lp);
+    REQUIRE_THROWS_AS(gauss.compute(flat(grid), 20, 1e-10), std::runtime_error);
+
+    ContinuationSweep dc(grid);
+    setup_sweep(dc);
+    dc.change_algorithm(AlgorithmType::DC_SparseLU);
+    dc.set_target_load_p(lp);
+    REQUIRE_THROWS_AS(dc.compute(flat(grid), 20, 1e-10), std::runtime_error);
+}
+
+TEST_CASE("a continuation cannot be split over threads", "[cpf]")
+{
+    LSGrid grid = make_grid();
+    ContinuationSweep sweep(grid);
+    REQUIRE_FALSE(sweep.supports_multithread());
+    REQUIRE_THROWS_AS(sweep.set_nb_thread(4), std::runtime_error);
+    sweep.set_nb_thread(1);  // still allowed
+    REQUIRE(sweep.get_nb_thread() == 1);
+}
+
+TEST_CASE("stop_at_lam lands exactly on the requested lambda", "[cpf]")
+{
+    LSGrid grid = make_grid();
+    ContinuationSweep sweep(grid);
+    setup_sweep(sweep);
+    sweep.set_stop_at_lam(0.4);
+    sweep.compute(flat(grid), 20, 1e-10);
+
+    REQUIRE(sweep.get_status() == 1);
+    REQUIRE(sweep.get_lam_max() == Approx(0.4).margin(1e-12));
+
+    LSGrid ref = make_grid();
+    ref.change_p_load(0, load_p_at(0.4));
+    ref.change_q_load(0, load_q_at(0.4));
+    const CplxVect V = ref.ac_pf(flat(ref), 30, 1e-11);
+    REQUIRE(V.size() > 0);
+    const Eigen::Index last = sweep.nb_points() - 1;
+    for (Eigen::Index b = 0; b < V.size(); ++b) {
+        REQUIRE(std::abs(V(b) - sweep.get_voltages()(last, b)) < 1e-8);
+    }
+}
+
+TEST_CASE("an adaptive step reaches the same nose", "[cpf]")
+{
+    LSGrid grid = make_grid();
+
+    ContinuationSweep fixed(grid);
+    setup_sweep(fixed);
+    fixed.compute(flat(grid), 20, 1e-10);
+
+    ContinuationSweep adapt(grid);
+    setup_sweep(adapt);
+    adapt.set_adapt_step(true);
+    adapt.compute(flat(grid), 20, 1e-10);
+
+    REQUIRE(adapt.get_status() == 1);
+    REQUIRE(adapt.get_lam_max() == Approx(fixed.get_lam_max()).epsilon(1e-3));
+    REQUIRE(adapt.nb_points() < fixed.nb_points());
+}
+
+TEST_CASE("an exact tangent reaches the same nose", "[cpf]")
+{
+    LSGrid grid = make_grid();
+
+    ContinuationSweep loose(grid);
+    setup_sweep(loose);
+    loose.compute(flat(grid), 20, 1e-10);
+
+    ContinuationSweep exact(grid);
+    setup_sweep(exact);
+    exact.set_exact_tangent(true);
+    exact.compute(flat(grid), 20, 1e-10);
+
+    REQUIRE(exact.get_status() == 1);
+    REQUIRE(exact.get_lam_max() == Approx(loose.get_lam_max()).epsilon(1e-3));
+    REQUIRE(exact.get_linear_solver_stats().nb_analyze == 1);
+}

--- a/src/tests/test_continuation_sweep.cpp
+++ b/src/tests/test_continuation_sweep.cpp
@@ -25,6 +25,7 @@
 
 #include "LSGrid.hpp"
 #include "batch_algorithm/ContinuationSweep.hpp"
+#include "case_exotic_elements.hpp"
 
 using Catch::Approx;
 using ls2g::AlgorithmType;
@@ -202,7 +203,73 @@ TEST_CASE("a zero direction is refused rather than traced", "[cpf]")
     REQUIRE_THROWS_AS(untargeted.compute(flat(grid), 20, 1e-10), std::runtime_error);
 }
 
-TEST_CASE("a direction the slack absorbs entirely is refused", "[cpf]")
+TEST_CASE("a continuation is correct on a grid with HVDC droop and voltage control", "[cpf]")
+{
+    // The tangent's right-hand side is built from the NRLedger, which is what makes it
+    // correct for the AUGMENTED Jacobian rather than only for the plain P/Q block. This
+    // grid is where that claim is actually worth something: the exotic-elements case
+    // (IEEE14 + an SVC regulating in VOLTAGE mode + 3 HVDC lines, one of them with angle
+    // droop ENABLED + a phase-shifting transformer + storage) makes the Hvdc and
+    // VoltageControl extensions live, so the augmented J carries custom rows (the droop
+    // equation, the voltage-setpoint equations) and custom columns (the controllers'
+    // reactive unknowns) on top of the bus block.
+    //
+    // None of those rows depends on lambda, so the RHS must be exactly zero on every one
+    // of them. Get that wrong -- put the direction on a custom row, or shift the bus rows
+    // by the number of custom ones -- and the predictor pushes the state sideways: the
+    // corrector still converges (it is an ordinary NR at a fixed lambda) and the curve
+    // still looks plausible, so ONLY a check of this kind catches it.
+    LSGrid grid = ls2g_test::make_exotic_elements_grid();
+    const CplxVect v0 = CplxVect::Constant(static_cast<Eigen::Index>(grid.total_bus()), cplx_type(1., 0.));
+
+    // First: check this grid really does augment the Jacobian, so that the comparison
+    // below cannot pass vacuously if the fixture ever loses its exotic elements. The
+    // augmented J has strictly more rows than the bus block registers.
+    {
+        LSGrid probe = ls2g_test::make_exotic_elements_grid();
+        const CplxVect Vprobe = probe.ac_pf(v0, 30, 1e-10);
+        REQUIRE(Vprobe.size() > 0);
+        const Eigen::Index nb_bus_rows = probe.get_p_buses_solver().size() +
+                                         probe.get_q_buses_solver().size();
+        INFO("bus-owned rows: " << nb_bus_rows << ", augmented J: " << probe.get_J_python_solver().rows());
+        REQUIRE(probe.get_J_python_solver().rows() > nb_bus_rows);
+    }
+
+    // +50% on every load, generation left alone
+    const RealVect base_load_p = grid.get_load_target_p();
+    const RealVect base_load_q = grid.get_loads_as_data().get_target_q();
+    const RealVect target_load_p = base_load_p * static_cast<real_type>(1.5);
+    const RealVect target_load_q = base_load_q * static_cast<real_type>(1.5);
+
+    ContinuationSweep sweep(grid);
+    sweep.change_algorithm(AlgorithmType::NR_SparseLU);
+    sweep.set_target_load_p(target_load_p);
+    sweep.set_target_load_q(target_load_q);
+    sweep.set_stop_at_lam(1.0);
+    sweep.compute(v0, 20, 1e-9);
+
+    REQUIRE(sweep.get_status() == 1);
+    REQUIRE(sweep.nb_points() > 5);
+    REQUIRE(sweep.get_lam()(sweep.nb_points() - 1) == Approx(1.).margin(1e-12));
+    // still one symbolic factorization, extensions and all
+    REQUIRE(sweep.get_linear_solver_stats().nb_analyze == 1);
+
+    for (Eigen::Index i = 0; i < sweep.nb_points(); ++i) {
+        const real_type lam = sweep.get_lam()(i);
+        LSGrid ref = ls2g_test::make_exotic_elements_grid();
+        for (int l = 0; l < static_cast<int>(base_load_p.size()); ++l) {
+            ref.change_p_load(l, base_load_p(l) + lam * (target_load_p(l) - base_load_p(l)));
+            ref.change_q_load(l, base_load_q(l) + lam * (target_load_q(l) - base_load_q(l)));
+        }
+        const CplxVect V = ref.ac_pf(v0, 30, 1e-10);
+        REQUIRE(V.size() > 0);
+        for (Eigen::Index b = 0; b < V.size(); ++b) {
+            REQUIRE(std::abs(V(b) - sweep.get_voltages()(i, b)) < 1e-7);
+        }
+    }
+}
+
+TEST_CASE("a direction the slack absorbs entirely stops rather than being traced", "[cpf]")
 {
     // The companion of the zero-direction guard, and the reason slack machines are NOT
     // excluded from gen_steering the way MATPOWER excludes them from a target case: at a
@@ -218,7 +285,13 @@ TEST_CASE("a direction the slack absorbs entirely is refused", "[cpf]")
     RealVect gp(NB_GEN);
     gp << 60., 20.;  // ONLY the slack machine moves
     sweep.set_target_gen_p(gp);
-    REQUIRE_THROWS_AS(sweep.compute(flat(grid), 20, 1e-10), std::runtime_error);
+
+    // asking for this is legal, so it does not throw -- it just has nowhere to go
+    sweep.compute(flat(grid), 20, 1e-10);
+    CHECK(sweep.nb_points() == 1);           // the base case, and nothing past it
+    CHECK(sweep.get_status() == 0);
+    CHECK(sweep.get_lam_max() == Approx(0.).margin(1e-14));
+    CHECK(sweep.get_msg().find("absorbed by the slack") != std::string::npos);
 }
 
 TEST_CASE("a single slack machine's setpoint does not change the solution", "[cpf]")

--- a/src/tests/test_continuation_sweep.cpp
+++ b/src/tests/test_continuation_sweep.cpp
@@ -98,6 +98,65 @@ void setup_sweep(ContinuationSweep & sweep)
     sweep.set_target_load_q(lq);
 }
 
+// ---- exotic-elements helpers ------------------------------------------------------
+// A mutation of the exotic grid, applied identically to the grid the continuation runs
+// on and to every reference grid it is checked against.
+using ExoticMutation = void (*)(LSGrid &);
+
+void mut_none(LSGrid &) {}
+// an HVDC converter station's voltage setpoint: a VoltageControl input
+void mut_hvdc_station_v(LSGrid & g) { g.change_v1_dcline(1, 1.06); }
+// the transfer of the HVDC line that is NOT droop-controlled: an injection, which also
+// moves the droop-controlled line by moving the angles it responds to
+void mut_hvdc_transfer(LSGrid & g) { g.change_p_dcline(0, 15.); }
+
+// Traces a load-tripling continuation to the nose on the exotic grid under `mutate`,
+// checks the curve against ordinary powerflows on the SAME mutated grid, and returns the
+// nose. Returning the margin is what lets the caller compare two mutations; checking the
+// points is what makes "the margin moved" mean "it moved to another correct answer"
+// rather than "it moved because the run broke".
+real_type exotic_cpf_nose_checked(ExoticMutation mutate)
+{
+    LSGrid grid = ls2g_test::make_exotic_elements_grid();
+    mutate(grid);
+    const CplxVect v0 = CplxVect::Constant(static_cast<Eigen::Index>(grid.total_bus()), cplx_type(1., 0.));
+
+    const RealVect base_p = grid.get_load_target_p();
+    const RealVect base_q = grid.get_loads_as_data().get_target_q();
+    const RealVect tgt_p = base_p * static_cast<real_type>(3.);
+    const RealVect tgt_q = base_q * static_cast<real_type>(3.);
+
+    ContinuationSweep sweep(grid);
+    sweep.change_algorithm(AlgorithmType::NR_SparseLU);
+    sweep.set_target_load_p(tgt_p);
+    sweep.set_target_load_q(tgt_q);
+    sweep.compute(v0, 20, 1e-9);
+
+    REQUIRE(sweep.get_status() == 1);
+    REQUIRE(sweep.nb_points() > 20);
+    REQUIRE(sweep.get_linear_solver_stats().nb_analyze == 1);
+
+    for (Eigen::Index i = 0; i < sweep.nb_points(); i += 40) {
+        const real_type lam = sweep.get_lam()(i);
+        LSGrid ref = ls2g_test::make_exotic_elements_grid();
+        mutate(ref);
+        for (int l = 0; l < static_cast<int>(base_p.size()); ++l) {
+            ref.change_p_load(l, base_p(l) + lam * (tgt_p(l) - base_p(l)));
+            ref.change_q_load(l, base_q(l) + lam * (tgt_q(l) - base_q(l)));
+        }
+        const CplxVect V = ref.ac_pf(v0, 30, 1e-10);
+        REQUIRE(V.size() > 0);
+        // keyed on tangent_lam, which IS the conditioning of the point: at the nose the
+        // reference solve is as ill-conditioned as the traced one
+        const real_type atol = sweep.get_tangent_lam()(i) > 1e-3 ? 1e-6 : 1e-3;
+        for (Eigen::Index b = 0; b < V.size(); ++b) {
+            INFO("point " << i << " (lam=" << lam << ") bus " << b);
+            REQUIRE(std::abs(V(b) - sweep.get_voltages()(i, b)) < atol);
+        }
+    }
+    return sweep.get_lam_max();
+}
+
 }  // namespace
 
 TEST_CASE("a continuation traces points that are genuine powerflow solutions", "[cpf]")
@@ -267,6 +326,30 @@ TEST_CASE("a continuation is correct on a grid with HVDC droop and voltage contr
             REQUIRE(std::abs(V(b) - sweep.get_voltages()(i, b)) < 1e-7);
         }
     }
+}
+
+TEST_CASE("moving an exotic element moves the continuation", "[cpf]")
+{
+    // The test above shows a continuation RUNS on a grid with an SVC, HVDC and a phase
+    // shifter, and that its points solve. It does not show that any of those elements is
+    // actually READ: a continuation that quietly ignored the HVDC would trace a curve
+    // that still looked fine, because the corrector would ignore it consistently.
+    //
+    // So: move something exotic and require the margin to move with it. Each run is also
+    // checked point by point against ordinary powerflows on its own mutated grid (see
+    // exotic_cpf_nose_checked), so a margin that moved has moved to another CORRECT
+    // answer -- "different" and "still right", not just "different".
+    const real_type nose_base = exotic_cpf_nose_checked(mut_none);
+    const real_type nose_station_v = exotic_cpf_nose_checked(mut_hvdc_station_v);
+    const real_type nose_transfer = exotic_cpf_nose_checked(mut_hvdc_transfer);
+
+    // The nose is reproducible to ~1e-9 (see the bisection cross-check in the python
+    // suite), so 1e-4 is far outside anything numerical: these are real shifts.
+    INFO("base " << nose_base << ", station_v " << nose_station_v << ", transfer " << nose_transfer);
+    CHECK(std::abs(nose_station_v - nose_base) > 1e-4);
+    CHECK(std::abs(nose_transfer - nose_base) > 1e-4);
+    // and the two mutations are not accidentally the same perturbation
+    CHECK(std::abs(nose_station_v - nose_transfer) > 1e-4);
 }
 
 TEST_CASE("a direction the slack absorbs entirely stops rather than being traced", "[cpf]")

--- a/utils/pr_diff_stats.py
+++ b/utils/pr_diff_stats.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+# Copyright (c) 2020-2026, RTE (https://www.rte-france.com)
+# See AUTHORS.txt
+# This Source Code Form is subject to the terms of the Mozilla Public License, version 2.0.
+# If a copy of the Mozilla Public License, version 2.0 was not distributed with this file,
+# you can obtain one at http://mozilla.org/MPL/2.0/.
+# SPDX-License-Identifier: MPL-2.0
+# This file is part of LightSim2grid, LightSim2grid implements a c++ backend targeting the Grid2Op platform.
+
+"""
+Split a branch's diff into C++ / Python / tests / docs and print it as a markdown table,
+to put at the top of a pull request body.
+
+A PR here routinely runs to one or two thousand lines, which is daunting to open and says
+nothing about where the work actually is. The table says how much of it is code a reviewer
+has to reason about and how much is tests, docs and changelog::
+
+    python3 utils/pr_diff_stats.py                # against origin/dev_1.0.1 (the default)
+    python3 utils/pr_diff_stats.py origin/main    # against another base branch
+
+Counts the branch's own changes only (`git diff base...HEAD`), so commits that landed on
+the base branch meanwhile are not attributed to the PR.
+"""
+
+import fnmatch
+import subprocess
+import sys
+
+#: (bucket key, label), in the order the table prints them
+BUCKETS = [
+    ("cpp", "C++ (src/core, src/bindings)"),
+    ("python", "Python (package)"),
+    ("tests", "Tests"),
+    ("docs", "Docs + changelog"),
+    ("other", "Build / other"),
+]
+
+DEFAULT_BASE = "origin/dev_1.0.1"
+
+
+def bucket_of(path):
+    """Which row of the table a changed file belongs to.
+
+    Tests come first on purpose: a test file is a test whatever its language, so
+    ``src/tests/*.cpp`` must not fall into the C++ bucket.
+    """
+    if fnmatch.fnmatch(path, "src/tests/*") or fnmatch.fnmatch(path, "lightsim2grid/tests/*"):
+        return "tests"
+    if path.startswith("docs/") or path.endswith((".rst", ".md")):
+        return "docs"
+    if path.startswith(("src/core/", "src/bindings/")) and path.endswith((".cpp", ".hpp", ".tpp", ".h")):
+        return "cpp"
+    if path.startswith("lightsim2grid/") and path.endswith(".py"):
+        return "python"
+    return "other"
+
+
+def diff_stats(base):
+    """{bucket: [added, removed]} for `git diff base...HEAD`."""
+    merge_base = subprocess.run(["git", "merge-base", base, "HEAD"],
+                                capture_output=True, text=True, check=True).stdout.strip()
+    numstat = subprocess.run(["git", "diff", "--numstat", merge_base + "...HEAD"],
+                             capture_output=True, text=True, check=True).stdout
+    totals = {}
+    for line in numstat.strip().splitlines():
+        added, removed, path = line.split("\t")
+        if added == "-":
+            continue  # binary file: git reports no line counts
+        entry = totals.setdefault(bucket_of(path), [0, 0])
+        entry[0] += int(added)
+        entry[1] += int(removed)
+    return totals
+
+
+def as_markdown(totals):
+    lines = ["| | added | removed |", "|---|---|---|"]
+    for key, label in BUCKETS:
+        if key in totals:  # an empty bucket gets no row
+            lines.append(f"| **{label}** | +{totals[key][0]} | -{totals[key][1]} |")
+    added = sum(v[0] for v in totals.values())
+    removed = sum(v[1] for v in totals.values())
+    lines.append(f"| total | +{added} | -{removed} |")
+    return "\n".join(lines)
+
+
+def main():
+    base = sys.argv[1] if len(sys.argv) > 1 else DEFAULT_BASE
+    try:
+        print(as_markdown(diff_stats(base)))
+    except subprocess.CalledProcessError as exc:
+        print(f"could not diff against '{base}': {exc.stderr.strip() or exc}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
| | added | removed |
|---|---|---|
| **C++ (src/core, src/bindings)** | +979 | -0 |
| **Python (package)** | +384 | -0 |
| **Tests** | +922 | -0 |
| **Docs + changelog** | +187 | -0 |
| **Build / other** | +98 | -0 |
| total | +2570 | -0 |

Traces the PV curve from the grid's own injections towards a target state and stops at the voltage-collapse nose, with per-element steering vectors deciding which loads and generators move along the way.

```python
from lightsim2grid import run_cpf

res = run_cpf(grid, loading_factor=3.0)
print(f"collapse at {res.lam_max:.3f} of the requested increase")

# only the loads of one area grow, at their own rates
steering = np.zeros(len(grid.get_loads()))
steering[my_area_load_ids] = 1.0
res = run_cpf(grid, loading_factor=3.0, load_steering=steering)
```

## A batch algorithm, and why a sibling rather than a fifth instantiation

`ContinuationSweep` derives from `BaseBatchSolverSynch`, which is where the batch layer's real guarantee lives: `_finish_preprocessing` solves the base case with `tell_all_changed()` — building the Jacobian sparsity and paying the one symbolic factorization — and leaves the control in `tell_none_changed()`, so every corrector after it refactorizes numerically only. **A curve of several hundred points costs one `analyze`**, and both test suites assert it. It also means the `tell_none_changed()` discipline is never applied by hand here.

It is deliberately *not* a fifth `BaseBatchSweep` instantiation. What distinguishes a continuation is not which of (Ybus, Sbus) varies — in that taxonomy it is exactly `TimeSeries`' cell — but **who decides the next row**:

| | `BaseBatchSweep` | continuation |
|---|---|---|
| row count | known up front | unknown (adaptive step, nose) |
| a diverged solve | a failed row | a retry signal: halve the step, same point |
| threading | supported | impossible, strictly sequential |
| Ybus axis | a whole policy | unused |

Making it an instantiation would have meant a policy axis the other four ignore plus loosening the fixed-row-count invariant `ScenarioSweep`'s cross-axis lock relies on.

## What the algorithm gains

Two primitives, not an algorithm: `cpf_tangent` (one triangular solve reusing the standing factorization) and `cpf_predict`. Their right-hand side is built from the `NRLedger`, so it is correct for the augmented Jacobian with no offset arithmetic, and its sign is *derived* from the residual convention in `_residual_into` rather than assumed.

That claim is tested where it costs something, on the **exotic-elements fixture** (IEEE14 + a voltage-regulating SVC + three HVDC lines with angle droop enabled on one + a phase-shifting transformer + storage), in two steps:

1. **the curve is correct there** — every traced point matches an ordinary `ac_pf`, and the test first asserts the grid really does augment J so it cannot pass vacuously;
2. **the exotic elements are actually read** — moving one has to move the margin. An HVDC converter station's voltage setpoint shifts the nose 1.648670 → 1.641051; the transfer of the non-droop HVDC line shifts it to 1.644316 (and moves the droop-controlled line with it, via the angles it responds to). The nose is reproducible to ~1e-9, so the 1e-4 threshold is far outside anything numerical. Each mutated run is itself re-checked against powerflows on its own mutated grid, so a margin that moved has moved to another *correct* answer rather than because the run broke.

Step 1 alone would pass on a continuation that ignored the HVDC entirely — the corrector would ignore it just as consistently as the predictor. Step 2 is what closes that.

## Steering

The steering vectors needed no new element→bus mapping: the direction is built with `SbusPolicy::Vary`'s own scatter helpers applied to target-minus-base deltas, so per-bus load aggregation, disconnected elements and the `sn_mva` division all come from the code `TimeSeries` already exercises.

A coefficient in `[0, 1]` per element; 0 holds it at its base value, 1 moves it fully. **`gen_steering` defaults to all ones — slack machines included**, which is where this deliberately parts from MATPOWER.

MATPOWER requires a target case to be "same as base case w.r.t. Qg and slack Pg" because a slack bus has no active-power equation: its `Pg` is an *output*, so specifying a change there asks for something the solver ignores. In lightsim2grid the slack is by design a *generator*, and that premise only half transfers:

- **single slack** — it holds. Scaling the machine's `target_p` 219 → 438 MW leaves the solution bit-identical and its output at 232.39 MW. Excluding it is a no-op, not a correction.
- **distributed slack** — it fails. The same scaling moves V by 0.12 and the output 227.54 → 308.50 MW. Excluding participants is an arbitrary dispatch choice, and on a grid whose slack spans many machines it silently freezes most of the generation.

So one rule for every generator. On a single-slack grid the curve is unchanged either way (case14, k=4: `lam_max` 1.020084), which is the point. Note the slack's *output* follows the load regardless — with every other machine scaled by k it produces roughly k× its base power; holding its setpoint would never have held its production.

`gen_steering=0` holds generation fixed and lets the slack supply the whole increase — a legitimate but **different curve with a different nose**, so the two margins are not comparable.

## Two degenerate directions

- **Zero direction** (target == base) throws: nothing was asked.
- **A direction the slack absorbs entirely** — steering only the machine at a single slack bus — is *not* refused; it is a legal request that simply has nowhere to go. But it stops at the base case with `success=False` and an explanatory message, because before that it marched λ to 20.8 over a thousand points on which |V| changed by 3e-15 and reported success.

## MATPOWER alignment

Option names and defaults follow `cpf.*` (`step` 0.05, `step_min` 1e-4, `step_max` 0.2, `adapt_step` off using the error-based scheme with `adapt_step_damping` 0.7 / `adapt_step_tol` 1e-3, `nose_tol` 1e-5, base→target formulation with λ=0/1).

The one thing that cannot follow MATPOWER is the parameterisation: this is the natural one (`cpf.parameterization = 1`), so **the curve stops at the nose rather than rounding it**. Pseudo arc length — MATPOWER's default — needs a λ column and a parameterisation row inside the Jacobian, i.e. an `NRSystem` extension, and is left for a follow-up. Docs and docstring say so, and that the default will flip when it lands.

## Verification

Correctness oracles are independent of the continuation itself:

- **every traced point re-solved with a plain `ac_pf`** at the same injections, on a plain grid and on the exotic one — the tolerance is keyed on `tangent_lam`, which *is* the conditioning of the point, rather than excluding points by index;
- **nose vs. brute-force bisection** on the loading factor (case14): 1.020084 both ways, 2.3e-9 relative;
- **`nb_analyze == 1`** for a 278-point curve, extensions and all.

Three failure modes have their own tests because each would otherwise produce a plausible-looking curve rather than an error: an inverted load direction (loads are stamped into Sbus with a minus, so loading must *lower* the voltages), a direction that moves nothing, and an exotic element the continuation does not read.

32 Python tests and 14 Catch2 tests; the full C++ suite is 266/266 at both C++14 and C++26, no regressions. `test_jacobian`, `test_dist_slack_jacobian`, `test_multi_slack` and `test_pf_input_robustness` are clean. `test_ACPF` could not run in the dev container (no grid2op installed, so `LightSimBackend` is unimportable) — unrelated to this change, and covered by CI.

## Files

- `src/core/batch_algorithm/ContinuationSweep.{hpp,cpp}` — the algorithm
- `src/core/powerflow_algorithm/{BaseAlgo,NRAlgo,NRSystem}.{hpp,tpp}` — the three NR primitives (purely additive)
- `src/core/AlgorithmSelector.hpp` — forwarding, guarded like `get_J`
- `src/bindings/python/binding_batch.cpp` — `ContinuationSweepCPP`
- `lightsim2grid/continuationPowerflow.py` — the wrapper, `plot_pv_curve`
- `docs/continuation_powerflow.rst`, `CHANGELOG.rst`, tests
- `utils/pr_diff_stats.py` + `CLAUDE.md` — the table at the top of this body, and the note asking future PRs to lead with it

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P1QabyFxUXhXSyBgmUAteW