### PR TITLE
linear solvers: solve J^T x = b out of the factorization of J

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -156,6 +156,10 @@ TODO: a "combine mode" axis for ``ScenarioSweepCPP`` choosing between the curren
 
 [1.0.1] 2026-xx-yy
 --------------------
+- [ADDED] ``solve_transpose`` on the linear solvers: :math:`J^T x = b` out of the
+  factorization of :math:`J`, no transposed copy and no second factorization
+  (``klu_tsolve`` for KLU, the transpose view for Eigen's SparseLU). ``CAN_SOLVE_TRANSPOSE``
+  says which solvers have it; it is what the adjoint of a batch needs.
 - [IMPROVED] ``ContingencyAnalysis`` / ``ScenarioSweep`` no longer run a connectivity search
   per contingency: one DFS of the base graph (``BusGraph``: bridges, subtree ranges) settles
   every N-1 up front, the search only remains for an N-k it cannot decide. Same answers;

--- a/src/bindings/python/binding_enums.cpp
+++ b/src/bindings/python/binding_enums.cpp
@@ -90,5 +90,6 @@ void bind_enums(py::module_& m) {
         .value("SolverSolve", ErrorType::SolverSolve, "The linear solve failed to solve the linear system J.X = b (*eg* `solve` for Eigen, `klu_solve` for KLU or `Solve` for NICSLU")
         .value("NotInitError", ErrorType::NotInitError, "Attempt to perform some powerflow computation when the linear solver is not initiliazed")
         .value("LicenseError", ErrorType::LicenseError, "Impossible to use the linear solver as the license cannot be found (*eg* unable to locate the `nicslu.lic` file")
+        .value("NotImplemented", ErrorType::NotImplemented, "The linear solver does not implement the operation that was asked of it (*eg* `solve_transpose` on a solver whose `CAN_SOLVE_TRANSPOSE` is False)")
         .export_values();
 }

--- a/src/core/Utils.cpp
+++ b/src/core/Utils.cpp
@@ -64,6 +64,9 @@ std::ostream& operator<<(std::ostream& out, const ErrorType & error_type){
     case ErrorType::LicenseError:
         out << "LicenseError";
         break;
+    case ErrorType::NotImplemented:
+        out << "NotImplemented";
+        break;
     default:
         out << "unknown error (check utils.cpp)";
         break;

--- a/src/core/Utils.hpp
+++ b/src/core/Utils.hpp
@@ -60,7 +60,8 @@ enum class ErrorType {NoError,
                       SolverReFactor,
                       SolverSolve,
                       NotInitError,
-                      LicenseError};
+                      LicenseError,
+                      NotImplemented};
 std::ostream& operator<<(std::ostream& out, const ErrorType & error_type);
 
 // Escape (and truncate to 64 chars) a string of untrusted origin -- read from a

--- a/src/core/linear_solvers/CKTSOSolver.cpp
+++ b/src/core/linear_solvers/CKTSOSolver.cpp
@@ -14,12 +14,6 @@
 
 namespace ls2g {
 
-const bool CKTSOLinearSolver::CAN_SOLVE_MAT = false;
-// Same as NICSLU (see NICSLUSolver.cpp): CKTSO ships separately from this repository
-// and is not built in CI, so its transposed solve -- if it has one -- is unverified
-// here and the capability is not claimed rather than claimed and wrong.
-const bool CKTSOLinearSolver::CAN_SOLVE_TRANSPOSE = false;
-
 
 ErrorType CKTSOLinearSolver::reset(){
     // free everything

--- a/src/core/linear_solvers/CKTSOSolver.cpp
+++ b/src/core/linear_solvers/CKTSOSolver.cpp
@@ -15,6 +15,10 @@
 namespace ls2g {
 
 const bool CKTSOLinearSolver::CAN_SOLVE_MAT = false;
+// Same as NICSLU (see NICSLUSolver.cpp): CKTSO ships separately from this repository
+// and is not built in CI, so its transposed solve -- if it has one -- is unverified
+// here and the capability is not claimed rather than claimed and wrong.
+const bool CKTSOLinearSolver::CAN_SOLVE_TRANSPOSE = false;
 
 
 ErrorType CKTSOLinearSolver::reset(){
@@ -105,6 +109,13 @@ ErrorType CKTSOLinearSolver::solve(Eigen::Ref<RealVect> b){
     }
     b = x;
     return ErrorType::NoError;
+}
+
+ErrorType CKTSOLinearSolver::solve_transpose(Eigen::Ref<RealVect> /*b*/){
+    // Deliberately not solving anything: see CAN_SOLVE_TRANSPOSE above. Returning an
+    // error rather than solving J x = b keeps a caller that ignored the flag from
+    // getting a plausible-looking answer to the wrong system.
+    return ErrorType::NotImplemented;
 }
 
 } // namespace ls2g

--- a/src/core/linear_solvers/CKTSOSolver.hpp
+++ b/src/core/linear_solvers/CKTSOSolver.hpp
@@ -87,9 +87,14 @@ class LS2G_API CKTSOLinearSolver final
         ErrorType factorize(const EigenRefConstRealSpMat & J); // numeric factorization (requires values)
         ErrorType refactorize(const EigenRefConstRealSpMat & J);  // re-numeric factorization, reuses symbolic
         ErrorType solve(Eigen::Ref<RealVect> b);
+        // Not implemented: see the .cpp. Callers must honour CAN_SOLVE_TRANSPOSE.
+        ErrorType solve_transpose(Eigen::Ref<RealVect> b);
 
         // can this linear solver solve problem where RHS is a matrix
         static const bool CAN_SOLVE_MAT;
+
+        // can this linear solver solve J^T x = b out of the factorization of J
+        static const bool CAN_SOLVE_TRANSPOSE;
         
         // prevent copy and assignment
         CKTSOLinearSolver(const CKTSOLinearSolver&) = delete;
@@ -144,9 +149,13 @@ class LS2G_API CKTSOLinearSolver final
         ErrorType factorize(const EigenRefConstRealSpMat & /*J*/) { return ErrorType::NoError; }
         ErrorType refactorize(const EigenRefConstRealSpMat & /*J*/) { return ErrorType::NoError; }
         ErrorType solve(Eigen::Ref<RealVect> /*b*/) { return ErrorType::NoError; }
+        ErrorType solve_transpose(Eigen::Ref<RealVect> /*b*/) { return ErrorType::NotImplemented; }
 
         // can this linear solver solve problem where RHS is a matrix
         static constexpr bool CAN_SOLVE_MAT = false;
+
+        // can this linear solver solve J^T x = b out of the factorization of J
+        static constexpr bool CAN_SOLVE_TRANSPOSE = false;
 
         // prevent copy and assignment (matches the real CKTSOLinearSolver)
         CKTSOLinearSolver(const CKTSOLinearSolver&) = delete;

--- a/src/core/linear_solvers/CKTSOSolver.hpp
+++ b/src/core/linear_solvers/CKTSOSolver.hpp
@@ -91,10 +91,13 @@ class LS2G_API CKTSOLinearSolver final
         ErrorType solve_transpose(Eigen::Ref<RealVect> b);
 
         // can this linear solver solve problem where RHS is a matrix
-        static const bool CAN_SOLVE_MAT;
+        static constexpr bool CAN_SOLVE_MAT = false;
 
-        // can this linear solver solve J^T x = b out of the factorization of J
-        static const bool CAN_SOLVE_TRANSPOSE;
+        // Same as NICSLU (see NICSLUSolver.hpp): CKTSO ships separately from this
+        // repository and is not built in CI, so its transposed solve -- if it has one --
+        // is unverified here and the capability is not claimed rather than claimed and
+        // wrong.
+        static constexpr bool CAN_SOLVE_TRANSPOSE = false;
         
         // prevent copy and assignment
         CKTSOLinearSolver(const CKTSOLinearSolver&) = delete;

--- a/src/core/linear_solvers/KLUSolver.cpp
+++ b/src/core/linear_solvers/KLUSolver.cpp
@@ -12,9 +12,6 @@
 
 namespace ls2g {
 
-const bool KLULinearSolver::CAN_SOLVE_MAT = false;
-const bool KLULinearSolver::CAN_SOLVE_TRANSPOSE = true;
-
 ErrorType KLULinearSolver::reset(){
     // release both handles (their deleters use common_) before resetting common_
     numeric_.reset();

--- a/src/core/linear_solvers/KLUSolver.cpp
+++ b/src/core/linear_solvers/KLUSolver.cpp
@@ -13,6 +13,7 @@
 namespace ls2g {
 
 const bool KLULinearSolver::CAN_SOLVE_MAT = false;
+const bool KLULinearSolver::CAN_SOLVE_TRANSPOSE = true;
 
 ErrorType KLULinearSolver::reset(){
     // release both handles (their deleters use common_) before resetting common_
@@ -70,6 +71,20 @@ ErrorType KLULinearSolver::solve(Eigen::Ref<RealVect> b){
     int ok = klu_solve(symbolic_.get(), numeric_.get(), n, 1, &b(0), &common_);
     if(ok != 1){
         // std::cout << "\t KLU: klu_solve error" << std::endl;
+        return ErrorType::SolverSolve;
+    }
+    return ErrorType::NoError;
+}
+
+ErrorType KLULinearSolver::solve_transpose(Eigen::Ref<RealVect> b){
+    // klu_tsolve walks the very same L / U factors as klu_solve, backwards: J^T is
+    // never formed, and neither the symbolic analysis nor the numeric factorization
+    // is repeated. That is what makes an adjoint (a vector-Jacobian product, as
+    // reverse-mode differentiation of a powerflow needs) cost one triangular solve.
+    const int n = static_cast<int>(b.size());
+    int ok = klu_tsolve(symbolic_.get(), numeric_.get(), n, 1, &b(0), &common_);
+    if(ok != 1){
+        // std::cout << "\t KLU: klu_tsolve error" << std::endl;
         return ErrorType::SolverSolve;
     }
     return ErrorType::NoError;

--- a/src/core/linear_solvers/KLUSolver.hpp
+++ b/src/core/linear_solvers/KLUSolver.hpp
@@ -58,10 +58,10 @@ class LS2G_API KLULinearSolver final
         ErrorType solve_transpose(Eigen::Ref<RealVect> b);  // J^T x = b, out of the factorization of J
 
         // can this linear solver solve problem where RHS is a matrix
-        static const bool CAN_SOLVE_MAT;
+        static constexpr bool CAN_SOLVE_MAT = false;
 
         // can this linear solver solve J^T x = b out of the factorization of J
-        static const bool CAN_SOLVE_TRANSPOSE;
+        static constexpr bool CAN_SOLVE_TRANSPOSE = true;  // klu_tsolve
 
     private:
         // KLU frees its symbolic / numeric handles through a pair of functions that

--- a/src/core/linear_solvers/KLUSolver.hpp
+++ b/src/core/linear_solvers/KLUSolver.hpp
@@ -55,9 +55,13 @@ class LS2G_API KLULinearSolver final
         ErrorType factorize(const EigenRefConstRealSpMat & J); // numeric factorization (requires values)
         ErrorType refactorize(const EigenRefConstRealSpMat & J);  // re-numeric factorization, reuses symbolic
         ErrorType solve(Eigen::Ref<RealVect> b);
+        ErrorType solve_transpose(Eigen::Ref<RealVect> b);  // J^T x = b, out of the factorization of J
 
         // can this linear solver solve problem where RHS is a matrix
         static const bool CAN_SOLVE_MAT;
+
+        // can this linear solver solve J^T x = b out of the factorization of J
+        static const bool CAN_SOLVE_TRANSPOSE;
 
     private:
         // KLU frees its symbolic / numeric handles through a pair of functions that
@@ -132,9 +136,13 @@ class LS2G_API KLULinearSolver final
         ErrorType factorize(const EigenRefConstRealSpMat & /*J*/) { return ErrorType::NoError; }
         ErrorType refactorize(const EigenRefConstRealSpMat & /*J*/) { return ErrorType::NoError; }
         ErrorType solve(Eigen::Ref<RealVect> /*b*/) { return ErrorType::NoError; }
+        ErrorType solve_transpose(Eigen::Ref<RealVect> /*b*/) { return ErrorType::NoError; }
 
         // can this linear solver solve problem where RHS is a matrix
         static constexpr bool CAN_SOLVE_MAT = false;
+
+        // can this linear solver solve J^T x = b out of the factorization of J
+        static constexpr bool CAN_SOLVE_TRANSPOSE = true;
 
     private:
         // no copy allowed (matches the real KLULinearSolver)

--- a/src/core/linear_solvers/LinearSolverPolicy.hpp
+++ b/src/core/linear_solvers/LinearSolverPolicy.hpp
@@ -39,6 +39,10 @@ class LinearSolverPolicy
         // can this linear solver solve problem where RHS is a matrix
         static const bool CAN_SOLVE_MAT;
 
+        // can this linear solver solve J^T x = b using the factorization of J itself,
+        // without ever forming J^T (see solve_transpose)
+        static const bool CAN_SOLVE_TRANSPOSE;
+
         ErrorType reset() {
             ++stats_.nb_reset;
             return inner_.reset();
@@ -105,6 +109,20 @@ class LinearSolverPolicy
             return res;
         }
 
+        // Solves J^T x = b reusing the factorization of J that factorize() /
+        // refactorize() produced -- no transposed copy of J, no second analyze, no
+        // second numeric factorization. Only meaningful where CAN_SOLVE_TRANSPOSE is
+        // true; the solvers where it is false return ErrorType::NotImplemented rather
+        // than silently solving the wrong system, so a caller that cannot check the
+        // flag at compile time can check the return value instead.
+        ErrorType solve_transpose(Eigen::Ref<RealVect> b) {
+            ++stats_.nb_solve_transpose;
+            auto timer = CustTimer();
+            ErrorType res = inner_.solve_transpose(b);
+            stats_.timer_solve_transpose_ += timer.duration();
+            return res;
+        }
+
         const LinearSolverStats & get_linear_solver_stats() const noexcept { return stats_; }
 
         // Called from the owning algorithm's reset_timer() (itself invoked at the start
@@ -116,6 +134,7 @@ class LinearSolverPolicy
             stats_.timer_factor_     = 0.;
             stats_.timer_refactor_   = 0.;
             stats_.timer_solve_      = 0.;
+            stats_.timer_solve_transpose_ = 0.;
         }
 
     protected:
@@ -133,6 +152,9 @@ class LinearSolverPolicy
 
 template<class LinearSolver>
 const bool LinearSolverPolicy<LinearSolver>::CAN_SOLVE_MAT = LinearSolver::CAN_SOLVE_MAT;
+
+template<class LinearSolver>
+const bool LinearSolverPolicy<LinearSolver>::CAN_SOLVE_TRANSPOSE = LinearSolver::CAN_SOLVE_TRANSPOSE;
 
 } // namespace ls2g
 

--- a/src/core/linear_solvers/LinearSolverPolicy.hpp
+++ b/src/core/linear_solvers/LinearSolverPolicy.hpp
@@ -37,11 +37,11 @@ class LinearSolverPolicy
         ~LinearSolverPolicy() noexcept = default;
 
         // can this linear solver solve problem where RHS is a matrix
-        static const bool CAN_SOLVE_MAT;
+        static constexpr bool CAN_SOLVE_MAT = LinearSolver::CAN_SOLVE_MAT;
 
         // can this linear solver solve J^T x = b using the factorization of J itself,
         // without ever forming J^T (see solve_transpose)
-        static const bool CAN_SOLVE_TRANSPOSE;
+        static constexpr bool CAN_SOLVE_TRANSPOSE = LinearSolver::CAN_SOLVE_TRANSPOSE;
 
         ErrorType reset() {
             ++stats_.nb_reset;
@@ -149,12 +149,6 @@ class LinearSolverPolicy
         LinearSolverPolicy & operator=(LinearSolverPolicy&&) = delete;
         LinearSolverPolicy & operator=(const LinearSolverPolicy&) = delete;
 };
-
-template<class LinearSolver>
-const bool LinearSolverPolicy<LinearSolver>::CAN_SOLVE_MAT = LinearSolver::CAN_SOLVE_MAT;
-
-template<class LinearSolver>
-const bool LinearSolverPolicy<LinearSolver>::CAN_SOLVE_TRANSPOSE = LinearSolver::CAN_SOLVE_TRANSPOSE;
 
 } // namespace ls2g
 

--- a/src/core/linear_solvers/LinearSolverStats.hpp
+++ b/src/core/linear_solvers/LinearSolverStats.hpp
@@ -33,11 +33,13 @@ struct LinearSolverStats {
     std::size_t nb_fallback_factorize_failed = 0;  // of those, how many also failed
 
     std::size_t nb_solve = 0;
+    std::size_t nb_solve_transpose = 0;            // solve_transpose() calls (the adjoint / VJP path)
 
     double timer_initialize_ = 0.;  // time spent in analyze()
     double timer_factor_     = 0.;  // time spent in factorize() (incl. fallback factors)
     double timer_refactor_   = 0.;  // time spent in refactorize() itself (not the fallback factor)
     double timer_solve_      = 0.;  // time spent in solve()
+    double timer_solve_transpose_ = 0.;  // time spent in solve_transpose()
 };
 
 namespace detail {

--- a/src/core/linear_solvers/NICSLUSolver.cpp
+++ b/src/core/linear_solvers/NICSLUSolver.cpp
@@ -13,6 +13,13 @@
 namespace ls2g {
 
 const bool NICSLULinearSolver::CAN_SOLVE_MAT = false;
+// NICSLU's own solve entry point is wrapped here as `Solve(b, x)` only. Whether the
+// library can walk its factors transposed was not established against its headers (it
+// ships separately from this repository and is not built in CI), so lightsim2grid does
+// not claim the capability: a caller needing J^T x = b with NICSLU has to form the
+// transpose itself and factorize it. Implementing this is a contained follow-up for
+// anyone with the NICSLU documentation at hand.
+const bool NICSLULinearSolver::CAN_SOLVE_TRANSPOSE = false;
 
 ErrorType NICSLULinearSolver::reset(){
     // free everything
@@ -93,6 +100,13 @@ ErrorType NICSLULinearSolver::solve(Eigen::Ref<RealVect> b){
     }
     b = x;
     return ErrorType::NoError;
+}
+
+ErrorType NICSLULinearSolver::solve_transpose(Eigen::Ref<RealVect> /*b*/){
+    // Deliberately not solving anything: see CAN_SOLVE_TRANSPOSE above. Returning an
+    // error rather than solving J x = b keeps a caller that ignored the flag from
+    // getting a plausible-looking answer to the wrong system.
+    return ErrorType::NotImplemented;
 }
 
 } // namespace ls2g

--- a/src/core/linear_solvers/NICSLUSolver.cpp
+++ b/src/core/linear_solvers/NICSLUSolver.cpp
@@ -12,15 +12,6 @@
 
 namespace ls2g {
 
-const bool NICSLULinearSolver::CAN_SOLVE_MAT = false;
-// NICSLU's own solve entry point is wrapped here as `Solve(b, x)` only. Whether the
-// library can walk its factors transposed was not established against its headers (it
-// ships separately from this repository and is not built in CI), so lightsim2grid does
-// not claim the capability: a caller needing J^T x = b with NICSLU has to form the
-// transpose itself and factorize it. Implementing this is a contained follow-up for
-// anyone with the NICSLU documentation at hand.
-const bool NICSLULinearSolver::CAN_SOLVE_TRANSPOSE = false;
-
 ErrorType NICSLULinearSolver::reset(){
     // free everything
     solver_.Free();

--- a/src/core/linear_solvers/NICSLUSolver.hpp
+++ b/src/core/linear_solvers/NICSLUSolver.hpp
@@ -74,9 +74,14 @@ class LS2G_API NICSLULinearSolver final
         ErrorType factorize(const EigenRefConstRealSpMat & J); // numeric factorization (requires values)
         ErrorType refactorize(const EigenRefConstRealSpMat & J);  // re-numeric factorization, reuses symbolic
         ErrorType solve(Eigen::Ref<RealVect> b);
+        // Not implemented: see the .cpp. Callers must honour CAN_SOLVE_TRANSPOSE.
+        ErrorType solve_transpose(Eigen::Ref<RealVect> b);
 
         // can this linear solver solve problem where RHS is a matrix
         static const bool CAN_SOLVE_MAT;
+
+        // can this linear solver solve J^T x = b out of the factorization of J
+        static const bool CAN_SOLVE_TRANSPOSE;
 
         // prevent copy and assignment
         NICSLULinearSolver(const NICSLULinearSolver&) = delete;
@@ -130,9 +135,13 @@ class LS2G_API NICSLULinearSolver final
         ErrorType factorize(const EigenRefConstRealSpMat & /*J*/) { return ErrorType::NoError; }
         ErrorType refactorize(const EigenRefConstRealSpMat & /*J*/) { return ErrorType::NoError; }
         ErrorType solve(Eigen::Ref<RealVect> /*b*/) { return ErrorType::NoError; }
+        ErrorType solve_transpose(Eigen::Ref<RealVect> /*b*/) { return ErrorType::NotImplemented; }
 
         // can this linear solver solve problem where RHS is a matrix
         static constexpr bool CAN_SOLVE_MAT = false;
+
+        // can this linear solver solve J^T x = b out of the factorization of J
+        static constexpr bool CAN_SOLVE_TRANSPOSE = false;
 
         // prevent copy and assignment (matches the real NICSLULinearSolver)
         NICSLULinearSolver(const NICSLULinearSolver&) = delete;

--- a/src/core/linear_solvers/NICSLUSolver.hpp
+++ b/src/core/linear_solvers/NICSLUSolver.hpp
@@ -78,10 +78,15 @@ class LS2G_API NICSLULinearSolver final
         ErrorType solve_transpose(Eigen::Ref<RealVect> b);
 
         // can this linear solver solve problem where RHS is a matrix
-        static const bool CAN_SOLVE_MAT;
+        static constexpr bool CAN_SOLVE_MAT = false;
 
-        // can this linear solver solve J^T x = b out of the factorization of J
-        static const bool CAN_SOLVE_TRANSPOSE;
+        // NICSLU's own solve entry point is wrapped here as `Solve(b, x)` only. Whether
+        // the library can walk its factors transposed was not established against its
+        // headers (it ships separately from this repository and is not built in CI), so
+        // lightsim2grid does not claim the capability: a caller needing J^T x = b with
+        // NICSLU has to form the transpose itself and factorize it. Implementing this is
+        // a contained follow-up for anyone with the NICSLU documentation at hand.
+        static constexpr bool CAN_SOLVE_TRANSPOSE = false;
 
         // prevent copy and assignment
         NICSLULinearSolver(const NICSLULinearSolver&) = delete;

--- a/src/core/linear_solvers/SparseLUSolver.cpp
+++ b/src/core/linear_solvers/SparseLUSolver.cpp
@@ -12,9 +12,6 @@
 
 namespace ls2g {
 
-const bool SparseLULinearSolver::CAN_SOLVE_MAT = true;
-const bool SparseLULinearSolver::CAN_SOLVE_TRANSPOSE = true;
-
 ErrorType SparseLULinearSolver::analyze(const EigenRefConstRealSpMat & J){
     solver_.analyzePattern(J);
     // analyzePattern does not set solver_.info() to Success, so no check here

--- a/src/core/linear_solvers/SparseLUSolver.cpp
+++ b/src/core/linear_solvers/SparseLUSolver.cpp
@@ -13,6 +13,7 @@
 namespace ls2g {
 
 const bool SparseLULinearSolver::CAN_SOLVE_MAT = true;
+const bool SparseLULinearSolver::CAN_SOLVE_TRANSPOSE = true;
 
 ErrorType SparseLULinearSolver::analyze(const EigenRefConstRealSpMat & J){
     solver_.analyzePattern(J);
@@ -30,6 +31,17 @@ ErrorType SparseLULinearSolver::refactorize(const EigenRefConstRealSpMat & J){
     solver_.factorize(J);
     if(solver_.info() != Eigen::Success) return ErrorType::SolverFactor;
     return ErrorType::NoError;
+}
+
+ErrorType SparseLULinearSolver::solve_transpose(Eigen::Ref<RealVect> b){
+    ErrorType err = ErrorType::NoError;
+    // Eigen reuses the L / U factors of J and walks them the other way round
+    // (transpose(), not adjoint(): both agree here since real_type is real, but
+    // adjoint() would conjugate if this were ever instantiated on a complex type).
+    RealVect Va = solver_.transpose().solve(b);
+    if(solver_.info() != Eigen::Success) err = ErrorType::SolverSolve;
+    b = Va;
+    return err;
 }
 
 ErrorType SparseLULinearSolver::solve(Eigen::Ref<RealVect> b) const{

--- a/src/core/linear_solvers/SparseLUSolver.hpp
+++ b/src/core/linear_solvers/SparseLUSolver.hpp
@@ -50,10 +50,10 @@ class LS2G_API SparseLULinearSolver final
         }
 
         // can this linear solver solve problem where RHS is a matrix
-        static const bool CAN_SOLVE_MAT;
+        static constexpr bool CAN_SOLVE_MAT = true;
 
         // can this linear solver solve J^T x = b out of the factorization of J
-        static const bool CAN_SOLVE_TRANSPOSE;
+        static constexpr bool CAN_SOLVE_TRANSPOSE = true;
     private:
         // solver initialization
         Eigen::SparseLU<Eigen::SparseMatrix<real_type>, Eigen::COLAMDOrdering<int> >  solver_;

--- a/src/core/linear_solvers/SparseLUSolver.hpp
+++ b/src/core/linear_solvers/SparseLUSolver.hpp
@@ -42,12 +42,18 @@ class LS2G_API SparseLULinearSolver final
         ErrorType factorize(const EigenRefConstRealSpMat & J); // numeric factorization (requires values)
         ErrorType refactorize(const EigenRefConstRealSpMat & J);  // re-numeric factorization, reuses symbolic
         ErrorType solve(Eigen::Ref<RealVect> b) const;
+        // NB not const, unlike solve(): Eigen's SparseLU::transpose() is a non-const
+        // member (it hands the view a pointer to the solver it must reuse).
+        ErrorType solve_transpose(Eigen::Ref<RealVect> b);
         ErrorType reset(){
             return ErrorType::NoError;
         }
 
         // can this linear solver solve problem where RHS is a matrix
         static const bool CAN_SOLVE_MAT;
+
+        // can this linear solver solve J^T x = b out of the factorization of J
+        static const bool CAN_SOLVE_TRANSPOSE;
     private:
         // solver initialization
         Eigen::SparseLU<Eigen::SparseMatrix<real_type>, Eigen::COLAMDOrdering<int> >  solver_;

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -84,6 +84,7 @@ add_executable(lightsim2grid_unit_tests
     test_scenario_sweep_violations.cpp
     test_bus_element_count.cpp
     test_kcl_from_results.cpp
+    test_solve_transpose.cpp
 )
 target_link_libraries(lightsim2grid_unit_tests PRIVATE lightsim2grid_core Catch2::Catch2WithMain)
 

--- a/src/tests/test_solve_transpose.cpp
+++ b/src/tests/test_solve_transpose.cpp
@@ -1,0 +1,219 @@
+// Copyright (c) 2026, RTE (https://www.rte-france.com)
+// See AUTHORS.txt
+// This Source Code Form is subject to the terms of the Mozilla Public License, version 2.0.
+// If a copy of the Mozilla Public License, version 2.0 was not distributed with this file,
+// you can obtain one at http://mozilla.org/MPL/2.0/.
+// SPDX-License-Identifier: MPL-2.0
+// This file is part of LightSim2grid, LightSim2grid implements a c++ backend targeting the Grid2Op platform.
+
+// solve_transpose() answers J^T x = b out of the factorization of J itself -- no
+// transposed copy, no second analyze, no second numeric factorization. The reference
+// here is a dense LU of the explicitly transposed matrix, and every matrix below is
+// deliberately asymmetric in BOTH its pattern and its values: a solve_transpose that
+// quietly solved J x = b instead would return a different vector and fail.
+
+#include <vector>
+
+#include <catch2/catch_approx.hpp>
+#include <catch2/catch_test_macros.hpp>
+
+#include "Eigen/Dense"
+
+#include "Utils.hpp"
+#include "linear_solvers/LinearSolverPolicy.hpp"
+#include "linear_solvers/SparseLUSolver.hpp"
+#ifdef KLU_SOLVER_AVAILABLE
+#include "linear_solvers/KLUSolver.hpp"
+#endif
+
+using Catch::Approx;
+using ls2g::ErrorType;
+using ls2g::RealVect;
+using ls2g::real_type;
+
+namespace {
+
+using SpMat = Eigen::SparseMatrix<real_type>;
+
+// A deterministic, strongly asymmetric, diagonally dominant matrix: an entry (i, j)
+// exists without (j, i) existing, so J^T does not even share J's pattern. `shift`
+// perturbs the values without touching the pattern -- that is the batch-adjoint case
+// (one analyze, then refactorize per row).
+SpMat make_asym_matrix(int n, real_type shift = 0.)
+{
+    std::vector<Eigen::Triplet<real_type> > coeffs;
+    for(int i = 0; i < n; ++i){
+        coeffs.push_back(Eigen::Triplet<real_type>(i, i, 10. + i + shift));
+        // one sub-diagonal, two super-diagonals: no (j, i) mirror for most of them
+        if(i + 1 < n) coeffs.push_back(Eigen::Triplet<real_type>(i, i + 1, -1. - 0.25 * i + shift));
+        if(i + 3 < n) coeffs.push_back(Eigen::Triplet<real_type>(i, i + 3, 0.5 + 0.125 * i));
+        if(i - 2 >= 0) coeffs.push_back(Eigen::Triplet<real_type>(i, i - 2, 2. + 0.5 * i - shift));
+    }
+    // a couple of far-off entries, on one side only, to break any residual symmetry
+    coeffs.push_back(Eigen::Triplet<real_type>(0, n - 1, 3.5));
+    coeffs.push_back(Eigen::Triplet<real_type>(n - 2, 1, -2.25));
+
+    SpMat res(n, n);
+    res.setFromTriplets(coeffs.begin(), coeffs.end());
+    res.makeCompressed();
+    return res;
+}
+
+RealVect make_rhs(int n)
+{
+    RealVect b(n);
+    for(int i = 0; i < n; ++i) b(i) = 1. + 0.75 * i - (i % 3);
+    return b;
+}
+
+// x such that J^T x = b, by a dense LU of the explicitly transposed matrix
+RealVect dense_transposed_solve(const SpMat & J, const RealVect & b)
+{
+    const Eigen::Matrix<real_type, Eigen::Dynamic, Eigen::Dynamic> dense = Eigen::Matrix<real_type, Eigen::Dynamic, Eigen::Dynamic>(J).transpose();
+    return dense.fullPivLu().solve(b);
+}
+
+void check_close(const RealVect & got, const RealVect & expected, real_type tol = 1e-10)
+{
+    REQUIRE(got.size() == expected.size());
+    for(Eigen::Index i = 0; i < got.size(); ++i){
+        REQUIRE(got(i) == Approx(expected(i)).margin(tol));
+    }
+}
+
+}  // namespace
+
+
+TEST_CASE("SparseLU solves the transposed system out of the factorization of J")
+{
+    const int n = 12;
+    const SpMat J = make_asym_matrix(n);
+    const RealVect b = make_rhs(n);
+
+    ls2g::SparseLULinearSolver solver;
+    REQUIRE(solver.analyze(J) == ErrorType::NoError);
+    REQUIRE(solver.factorize(J) == ErrorType::NoError);
+
+    RealVect x = b;
+    REQUIRE(solver.solve_transpose(x) == ErrorType::NoError);
+    check_close(x, dense_transposed_solve(J, b));
+
+    // ... and the residual of the transposed system is what it claims to be
+    const RealVect residual = SpMat(J.transpose()) * x - b;
+    REQUIRE(residual.lpNorm<Eigen::Infinity>() == Approx(0.).margin(1e-10));
+
+    // the untransposed solve still solves J x = b, and gives a DIFFERENT vector --
+    // without this the test above would pass on a solve_transpose that ignores the
+    // transposition entirely
+    RealVect y = b;
+    REQUIRE(solver.solve(y) == ErrorType::NoError);
+    REQUIRE((y - x).lpNorm<Eigen::Infinity>() > 1e-3);
+    REQUIRE((J * y - b).lpNorm<Eigen::Infinity>() == Approx(0.).margin(1e-10));
+}
+
+
+TEST_CASE("a transposed solve after a refactorize uses the new values")
+{
+    const int n = 12;
+    const SpMat J = make_asym_matrix(n);
+    const SpMat J2 = make_asym_matrix(n, 0.75);   // same pattern, different values
+    REQUIRE(J.nonZeros() == J2.nonZeros());
+    const RealVect b = make_rhs(n);
+
+    ls2g::SparseLULinearSolver solver;
+    REQUIRE(solver.analyze(J) == ErrorType::NoError);
+    REQUIRE(solver.factorize(J) == ErrorType::NoError);
+    REQUIRE(solver.refactorize(J2) == ErrorType::NoError);
+
+    RealVect x = b;
+    REQUIRE(solver.solve_transpose(x) == ErrorType::NoError);
+    check_close(x, dense_transposed_solve(J2, b));
+}
+
+
+TEST_CASE("LinearSolverPolicy times and counts the transposed solves separately")
+{
+    const int n = 12;
+    const SpMat J = make_asym_matrix(n);
+    const RealVect b = make_rhs(n);
+
+    ls2g::LinearSolverPolicy<ls2g::SparseLULinearSolver> solver;
+    REQUIRE(ls2g::LinearSolverPolicy<ls2g::SparseLULinearSolver>::CAN_SOLVE_TRANSPOSE ==
+            ls2g::SparseLULinearSolver::CAN_SOLVE_TRANSPOSE);
+
+    REQUIRE(solver.analyze(J) == ErrorType::NoError);
+    REQUIRE(solver.factorize(J) == ErrorType::NoError);
+
+    RealVect x = b;
+    REQUIRE(solver.solve_transpose(x) == ErrorType::NoError);
+    check_close(x, dense_transposed_solve(J, b));
+
+    RealVect y = b;
+    REQUIRE(solver.solve(y) == ErrorType::NoError);
+
+    const ls2g::LinearSolverStats & stats = solver.get_linear_solver_stats();
+    REQUIRE(stats.nb_solve_transpose == 1);
+    REQUIRE(stats.nb_solve == 1);   // a transposed solve is not counted as a plain one
+
+    solver.reset_stats_timers();
+    REQUIRE(stats.timer_solve_transpose_ == 0.);
+}
+
+
+#ifdef KLU_SOLVER_AVAILABLE
+TEST_CASE("KLU solves the transposed system out of the factorization of J")
+{
+    const int n = 12;
+    const SpMat J = make_asym_matrix(n);
+    const RealVect b = make_rhs(n);
+
+    REQUIRE(ls2g::KLULinearSolver::CAN_SOLVE_TRANSPOSE);
+
+    ls2g::KLULinearSolver solver;
+    REQUIRE(solver.analyze(J) == ErrorType::NoError);
+    REQUIRE(solver.factorize(J) == ErrorType::NoError);
+
+    RealVect x = b;
+    REQUIRE(solver.solve_transpose(x) == ErrorType::NoError);
+    check_close(x, dense_transposed_solve(J, b));
+
+    RealVect y = b;
+    REQUIRE(solver.solve(y) == ErrorType::NoError);
+    REQUIRE((y - x).lpNorm<Eigen::Infinity>() > 1e-3);
+}
+
+
+TEST_CASE("KLU and SparseLU agree on the transposed solve, before and after a refactorize")
+{
+    const int n = 20;
+    const RealVect b = make_rhs(n);
+
+    ls2g::KLULinearSolver klu;
+    ls2g::SparseLULinearSolver splu;
+
+    const SpMat J = make_asym_matrix(n);
+    REQUIRE(klu.analyze(J) == ErrorType::NoError);
+    REQUIRE(klu.factorize(J) == ErrorType::NoError);
+    REQUIRE(splu.analyze(J) == ErrorType::NoError);
+    REQUIRE(splu.factorize(J) == ErrorType::NoError);
+
+    RealVect x_klu = b;
+    RealVect x_splu = b;
+    REQUIRE(klu.solve_transpose(x_klu) == ErrorType::NoError);
+    REQUIRE(splu.solve_transpose(x_splu) == ErrorType::NoError);
+    check_close(x_klu, x_splu);
+
+    // the adjoint of a batch does exactly this: one analyze, then per row new values
+    // into the same pattern, refactorize, transposed solve
+    const SpMat J2 = make_asym_matrix(n, -1.5);
+    REQUIRE(klu.refactorize(J2) == ErrorType::NoError);
+    REQUIRE(splu.refactorize(J2) == ErrorType::NoError);
+
+    x_klu = b;
+    x_splu = b;
+    REQUIRE(klu.solve_transpose(x_klu) == ErrorType::NoError);
+    REQUIRE(splu.solve_transpose(x_splu) == ErrorType::NoError);
+    check_close(x_klu, x_splu);
+    check_close(x_klu, dense_transposed_solve(J2, b));
+}
+#endif  // KLU_SOLVER_AVAILABLE

--- a/src/tests/test_solve_transpose.cpp
+++ b/src/tests/test_solve_transpose.cpp
@@ -138,8 +138,13 @@ TEST_CASE("LinearSolverPolicy times and counts the transposed solves separately"
     const RealVect b = make_rhs(n);
 
     ls2g::LinearSolverPolicy<ls2g::SparseLULinearSolver> solver;
-    REQUIRE(ls2g::LinearSolverPolicy<ls2g::SparseLULinearSolver>::CAN_SOLVE_TRANSPOSE ==
-            ls2g::SparseLULinearSolver::CAN_SOLVE_TRANSPOSE);
+    // the flags are constexpr: asserted at compile time, and deliberately NOT through
+    // REQUIRE, whose expression decomposition binds a reference to its operands -- that
+    // would odr-use a constexpr static member the headers no longer define out of line
+    // (needed before C++17, and this project still builds at C++14).
+    static_assert(ls2g::LinearSolverPolicy<ls2g::SparseLULinearSolver>::CAN_SOLVE_TRANSPOSE ==
+                  ls2g::SparseLULinearSolver::CAN_SOLVE_TRANSPOSE,
+                  "the policy must mirror the capability of the solver it wraps");
 
     REQUIRE(solver.analyze(J) == ErrorType::NoError);
     REQUIRE(solver.factorize(J) == ErrorType::NoError);
@@ -167,7 +172,7 @@ TEST_CASE("KLU solves the transposed system out of the factorization of J")
     const SpMat J = make_asym_matrix(n);
     const RealVect b = make_rhs(n);
 
-    REQUIRE(ls2g::KLULinearSolver::CAN_SOLVE_TRANSPOSE);
+    static_assert(ls2g::KLULinearSolver::CAN_SOLVE_TRANSPOSE, "KLU has klu_tsolve");
 
     ls2g::KLULinearSolver solver;
     REQUIRE(solver.analyze(J) == ErrorType::NoError);


### PR DESCRIPTION
| | added | removed |
|---|---|---|
| **C++ (src/core, src/bindings)** | +114 | -1 |
| **Tests** | +220 | -0 |
| **Docs + changelog** | +4 | -0 |
| total | +338 | -1 |

First of four PRs towards `BatchCPUPowerFlow`, a batched differentiable AC powerflow for PyTorch over `ScenarioSweep`. This one adds only the linear-solver capability the adjoint needs; nothing here depends on the rest, and nothing else in the tree calls it yet.

## Why

Reverse-mode differentiation of a powerflow needs the adjoint system `J^T λ = x̄` at the converged point. Forming `J^T` and factorizing it costs a second symbolic analysis and a second numeric factorization per solve — which is what a GPU library has to do, its direct solver only going one way.

KLU does not: `klu_tsolve` walks the very `L` and `U` that `klu_factor` / `klu_refactor` already produced, backwards. Eigen's `SparseLU` has the same through its transpose view. So the adjoint of an already-factorized system costs one triangular solve, and the whole "build the transposed pattern, map J's values into it, analyze, factorize" machinery is unnecessary on CPU.

## What

- `solve_transpose(b)` on the four linear solvers, with `CAN_SOLVE_TRANSPOSE` saying which of them have it.
  - KLU → `klu_tsolve`, same `Symbolic` / `Numeric` as `klu_solve`.
  - SparseLU → `solver_.transpose().solve(b)`. Non-`const`, unlike `solve()`: Eigen's `SparseLU::transpose()` is a non-const member.
- NICSLU and CKTSO report the capability as **absent**. Both ship outside this repository and are not built in CI, so whether they can walk their factors transposed is unverified here — rather than claim it and be wrong, they return the new `ErrorType::NotImplemented` instead of silently answering `J x = b`. A plausible-looking solution to the wrong system is the one outcome worth ruling out. The comments say this is a not-implemented-here, not a library limitation, so whoever has the vendor docs can fill it in. A caller branches on the constant at compile time or on the error at runtime.
- `ErrorType::NotImplemented` is appended at the **end** of the enum, so no existing value renumbers; bound to Python alongside the others.
- `LinearSolverPolicy` counts and times transposed solves apart from plain ones (`nb_solve_transpose`, `timer_solve_transpose_`), so an adjoint's cost can be attributed rather than guessed. That measurement is what a later decision about keeping per-row factorizations will rest on.

Out-of-tree linear solvers plugged into `LinearSolverPolicy` are unaffected: both the new method and the new static member are instantiated only if used.

## Tests

New `src/tests/test_solve_transpose.cpp`, on matrices asymmetric in **both** pattern and values:

- `solve_transpose` against a dense LU of the explicitly transposed matrix, and the residual of the transposed system;
- the untransposed `solve` gives a *different* vector — without that assertion the test would pass on an implementation that dropped the transposition;
- the sequence the batch adjoint will use: one `analyze`, then new values into the same pattern, `refactorize`, transposed solve;
- KLU and SparseLU agreeing with each other and with the dense reference, before and after a refactorize;
- `LinearSolverPolicy` counting a transposed solve separately from a plain one.

## Verification

- Full C++ suite **277/277**, at the default C++26 and at a pinned C++14 build (`-std=c++14` confirmed in the generated flags). KLU built from the SuiteSparse submodule (v2.3.6), so the KLU paths really run.
- **Mutation check**: swapping `klu_tsolve` → `klu_solve` makes both KLU tests fail, so the test bites rather than passing by symmetry. Reverted and re-verified.
- `binding_enums.cpp` syntax-checked at C++14 against pybind11 and the vendored SuiteSparse headers.

No Python test touched: nothing in the Python API changes beyond the new enum value.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013aKUfd8Vy1xkpvrvV3waod

---
_Generated by [Claude Code](https://claude.ai/code/session_013aKUfd8Vy1xkpvrvV3waod)_