### PR TITLE
batch: keep each row's Jacobian, and solve the adjoint system of the whole sweep

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -156,6 +156,11 @@ TODO: a "combine mode" axis for ``ScenarioSweepCPP`` choosing between the curren
 
 [1.0.1] 2026-xx-yy
 --------------------
+- [ADDED] ``keep_jacobian`` and ``solve_JT`` on the batch algorithms: the adjoint of a whole
+  sweep, one transposed solve per row, which is what reverse-mode differentiation (a pytorch
+  backward) needs. See ``BatchAdjoint``.
+- [FIXED] the KLU / NICSLU / CKTSO headers closed their namespace outside their include guard,
+  so including one twice in a translation unit failed to compile.
 - [ADDED] ``solve_transpose`` on the linear solvers: :math:`J^T x = b` out of the
   factorization of :math:`J`, no transposed copy and no second factorization
   (``klu_tsolve`` for KLU, the transpose view for Eigen's SparseLU). ``CAN_SOLVE_TRANSPOSE``

--- a/src/bindings/python/binding_batch.cpp
+++ b/src/bindings/python/binding_batch.cpp
@@ -84,6 +84,66 @@ void bind_batch_sweep_common(py::class_<T> & cls)
              },
              DocTimeSeries::converged_mask.c_str())
 
+        // reverse-mode differentiation (see BatchAdjoint.hpp)
+        .def_property("keep_jacobian",
+                      [](const T & self){ return self.get_keep_jacobian(); },
+                      [](T & self, bool val){ self.set_keep_jacobian(val); },
+                      "Whether each row's converged Jacobian is kept during compute(), so that "
+                      "solve_JT() can run afterwards. Defaults to ``False``; must be set BEFORE "
+                      "compute().\n\n"
+                      "This is what makes a batch differentiable: with the Jacobians kept, one "
+                      "transposed solve per row turns a loss's sensitivity to the voltages into "
+                      "its gradient with respect to every injection of every row (the adjoint "
+                      "method / the implicit function theorem).\n\n"
+                      "It costs `nb_rows * nnz(J)` floats -- see adjoint_memory_bytes(), and mind "
+                      "that on a large grid with many rows this is gigabytes -- plus one extra "
+                      "Jacobian evaluation per row (the Newton-Raphson loop stops on the Jacobian "
+                      "of its previous iterate, which is not quite the one at the solution). Only "
+                      "the AC Newton-Raphson algorithms build a Jacobian at all; compute() raises "
+                      "with any other.")
+        .def("adjoint_memory_bytes", &T::adjoint_memory_bytes,
+             "Bytes the kept Jacobians occupy after a compute() (0 when none were kept). "
+             "Grows as nb_rows * nnz(J): worth reading before scaling a batch up.")
+        .def("dim_J", &T::dim_J,
+             "Dimension of the augmented Newton-Raphson system -- the length of one "
+             "cotangent handed to solve_JT, and of one row of its result. 0 until a "
+             "compute() that kept the Jacobians.")
+        .def("get_theta_col_of_bus", &T::get_theta_col_of_bus,
+             "For each grid bus (same numbering as the columns of get_voltages()), the column "
+             "of the Jacobian holding its voltage-ANGLE unknown, or -1 where it has none (a "
+             "reference slack, a bus outside the solver). Where the angle part of that bus's "
+             "cotangent goes in solve_JT's input.")
+        .def("get_vm_col_of_bus", &T::get_vm_col_of_bus,
+             "Same as get_theta_col_of_bus for the voltage-MAGNITUDE unknown: -1 at a bus whose "
+             "magnitude is held fixed (a PV bus, unless a generator contingency may release it).")
+        .def("get_p_row_of_bus", &T::get_p_row_of_bus,
+             "For each grid bus, the row of the Jacobian holding its ACTIVE power mismatch "
+             "equation, or -1 where it has none. Where that bus's active injection gradient is "
+             "read out of solve_JT's result.")
+        .def("get_q_row_of_bus", &T::get_q_row_of_bus,
+             "Same as get_p_row_of_bus for the REACTIVE power mismatch equation.")
+        .def("solve_JT", &T::solve_JT, py::arg("xbar"),
+             "Solve the adjoint system `J_i^T . lambda_i = xbar_i` of every row, and return "
+             "lambda. Requires `keep_jacobian` to have been True during compute().\n\n"
+             "`xbar` has shape (nb_rows, k * dim_J): one row per simulation, holding k "
+             "cotangents of dim_J coefficients laid end to end. Differentiating a scalar loss "
+             "uses k = 1; several directions are only needed for a full Jacobian, and cost one "
+             "triangular solve each rather than one factorization each.\n\n"
+             "lambda is the gradient with respect to the per-unit bus injection: its real part "
+             "sits at get_p_row_of_bus()[bus], its imaginary part at get_q_row_of_bus()[bus]. "
+             "Rows that did not converge come back as zeros -- see adjoint_row_ok().")
+        .def("adjoint_row_ok", [](const T & self){
+                 const std::vector<char> & c = self.adjoint_row_ok();
+                 return std::vector<bool>(c.begin(), c.end());
+             },
+             "Per row: True where the last solve_JT() actually solved that row's adjoint "
+             "system. False for a row the batch never solved (it diverged, or a contingency "
+             "islanded it), whose lambda is zero.")
+        .def("adjoint_solver_stats", &T::adjoint_solver_stats,
+             "Linear-solver counters and timings of the last solve_JT(), summed over its "
+             "worker threads: how much of the backward pass went into refactorizing each "
+             "row's Jacobian versus into the transposed solves themselves.")
+
         // status
         // `<>`: see the comment above modify_gen_p -- Clang (used for the macOS/arm64
         // wheels) rejects `&T::get_status` outright for a member function template

--- a/src/bindings/python/binding_solvers.cpp
+++ b/src/bindings/python/binding_solvers.cpp
@@ -151,10 +151,17 @@ void bind_solvers(py::module_& m) {
         .def_readonly("nb_fallback_factorize",          &LinearSolverStats::nb_fallback_factorize, DocSolver::nb_fallback_factorize.c_str())
         .def_readonly("nb_fallback_factorize_failed",   &LinearSolverStats::nb_fallback_factorize_failed, DocSolver::nb_fallback_factorize_failed.c_str())
         .def_readonly("nb_solve",                       &LinearSolverStats::nb_solve, DocSolver::nb_solve.c_str())
+        .def_readonly("nb_solve_transpose",             &LinearSolverStats::nb_solve_transpose,
+                      "Number of transposed solves (`J^T x = b`, out of the factorization of J). "
+                      "Raised by the adjoint of a differentiable batch, never by an ordinary "
+                      "powerflow.")
         .def_readonly("timer_initialize",               &LinearSolverStats::timer_initialize_, DocSolver::timer_initialize.c_str())
         .def_readonly("timer_factor",                   &LinearSolverStats::timer_factor_, DocSolver::timer_factor.c_str())
         .def_readonly("timer_refactor",                 &LinearSolverStats::timer_refactor_, DocSolver::timer_refactor.c_str())
         .def_readonly("timer_solve",                    &LinearSolverStats::timer_solve_, DocSolver::timer_solve.c_str())
+        .def_readonly("timer_solve_transpose",          &LinearSolverStats::timer_solve_transpose_,
+                      "Time spent in the transposed solves, apart from the plain ones (see "
+                      "nb_solve_transpose).")
         .def("__repr__", [](const LinearSolverStats& s) {
             return "LinearSolverStats(nb_factorize=" + std::to_string(s.nb_factorize) +
                    ", nb_refactorize=" + std::to_string(s.nb_refactorize) +

--- a/src/core/AlgorithmSelector.hpp
+++ b/src/core/AlgorithmSelector.hpp
@@ -264,6 +264,12 @@ class LS2G_API AlgorithmSelector final
         bool supports_bus_masking() const {
             return get_prt_solver("supports_bus_masking", false)->supports_bus_masking();
         }
+        bool supports_jacobian() const {
+            return get_prt_solver("supports_jacobian", false)->supports_jacobian();
+        }
+        void refresh_J_at_solution() {
+            get_prt_solver("refresh_J_at_solution", false)->refresh_J_at_solution();
+        }
         void set_masked_buses(const std::vector<int>& solver_bus_ids) {
             get_prt_solver("set_masked_buses", false)->set_masked_buses(solver_bus_ids);
         }

--- a/src/core/batch_algorithm/BaseBatchSweep.cpp
+++ b/src/core/batch_algorithm/BaseBatchSweep.cpp
@@ -54,6 +54,8 @@ void BaseBatchSweep<YbusPolicy, SbusPolicy, INIT>::_run_one_step(
                                          active_layout().slack_bus_id_solver.as_eigen(), active_layout().slack_weights,
                                          active_layout().bus_pv.as_eigen(), active_layout().bus_pq.as_eigen(),
                                          max_iter, tol_solver);
+            // while this row's Ybus edits are still in place -- see _maybe_store_jacobian
+            if(conv) _maybe_store_jacobian(i, algo);
         } else {
             // generator contingencies: this row's buses that keep a live local voltage
             // controller stay pinned (their Q row is the identity, so |V| holds at the
@@ -72,6 +74,9 @@ void BaseBatchSweep<YbusPolicy, SbusPolicy, INIT>::_run_one_step(
                                          active_layout().slack_bus_id_solver.as_eigen(), sw,
                                          active_layout().bus_pv.as_eigen(), active_layout().bus_pq.as_eigen(),
                                          max_iter, tol_solver);
+            // before the pinning is restored, and before the Ybus is put back: the
+            // refreshed Jacobian has to describe the system THIS row solved
+            if(conv) _maybe_store_jacobian(i, algo);
             if(flips) algo.set_pv_pinned_buses(_switchable_buses_);
         }
     } else {
@@ -526,6 +531,27 @@ void BaseBatchSweep<YbusPolicy, SbusPolicy, INIT>::compute(
     // pre-contingency ("n") case violations (ContingencyAnalysis only; no-op
     // elsewhere)
     _record_n_case_violations(_algo.get_V());
+
+    // Reverse-mode differentiation: size the Jacobian store ONCE, here. Everything it
+    // needs is known by now and none of it changes afterwards -- the number of rows is
+    // locked, and the "n" solve above has built the ledger, so the Jacobian's dimension
+    // and nonzero count are final (every row shares that pattern, which is the premise
+    // of the whole batch). The row loop below then only ever memcpy's into rows of a
+    // buffer that is never resized, from whichever thread owns them.
+    _adjoint_.clear();
+    _adjoint_row_ok_.clear();
+    if(_keep_jacobian_){
+        if(!ac_solver_used || !_algo.supports_jacobian()){
+            std::ostringstream exc_;
+            exc_ << algo_name() << "::compute: `keep_jacobian` needs an AC Newton-Raphson "
+                    "algorithm -- it is the Jacobian of the augmented Newton-Raphson system "
+                    "that the adjoint solves against, and no other algorithm builds one. "
+                    "Pick one of the NR_* algorithms (change_algorithm), or turn "
+                    "`keep_jacobian` off.";
+            throw std::runtime_error(exc_.str());
+        }
+        _adjoint_.allocate(static_cast<Eigen::Index>(nb_steps), _algo.get_J());
+    }
 
     // compute the powerflows, possibly split across several threads
     _compute_threaded(nb_steps, Vinit_solver, ac_solver_used, max_iter, tol, sn_mva, _timer_thread_init);

--- a/src/core/batch_algorithm/BaseBatchSweep.hpp
+++ b/src/core/batch_algorithm/BaseBatchSweep.hpp
@@ -14,6 +14,7 @@
 #include "SbusPolicy.hpp"
 #include "LimitViolation.hpp"
 #include "BusGraph.hpp"
+#include "BatchAdjoint.hpp"
 
 #include <set>
 #include <map>
@@ -331,6 +332,8 @@ class LS2G_API BaseBatchSweep: public BaseBatchSolverSynch
 
         void clear() override {
             _results_present_ = false;
+            _adjoint_.clear();
+            _adjoint_row_ok_.clear();
             _gen_contingency_active_ = false;
             _switchable_buses_.clear();
             _row_pv_to_pq_.clear();
@@ -371,6 +374,8 @@ class LS2G_API BaseBatchSweep: public BaseBatchSolverSynch
             // public connectivity entry points), lowered here and by clear().
             if(!_results_present_) return;
             _results_present_ = false;
+            _adjoint_.clear();
+            _adjoint_row_ok_.clear();
             BaseBatchSolverSynch::clear();
             _li_masked.clear();
             _cont_connected_.clear();
@@ -729,6 +734,68 @@ class LS2G_API BaseBatchSweep: public BaseBatchSolverSynch
         template<class S = SbusPolicy, typename std::enable_if<S::supports_vary, int>::type = 0>
         int get_status() const { return _status; }
 
+        // ================= reverse-mode differentiation ============================
+        // See BatchAdjoint for the maths and the cost. In short: with this on, every
+        // row's converged Jacobian is kept, and solve_JT() then answers
+        // `J_i^T lambda_i = xbar_i` for the whole batch at one transposed solve per
+        // row -- which is the gradient of a scalar loss with respect to every
+        // injection of every row.
+
+        // Keep each row's converged Jacobian during compute(), so solve_JT() can run
+        // afterwards. Off by default: it costs nb_rows * nnz_J reals (see
+        // adjoint_memory_bytes(), answerable before compute() through
+        // BatchAdjoint::memory_bytes) plus one Jacobian fill per row, and a caller
+        // who only wants flows should pay neither. Only the Newton-Raphson family of
+        // AC algorithms has a Jacobian to keep; compute() raises if this is on with
+        // any other.
+        void set_keep_jacobian(bool val) {
+            if(val == _keep_jacobian_) return;
+            _keep_jacobian_ = val;
+            _adjoint_.clear();
+        }
+        bool get_keep_jacobian() const { return _keep_jacobian_; }
+
+        // Bytes the kept Jacobians occupy after a compute() (0 when none were kept).
+        std::size_t adjoint_memory_bytes() const { return _adjoint_.memory_bytes(); }
+
+        // Dimension of the augmented Newton-Raphson system: the length of one
+        // cotangent, and of one lambda. 0 before a compute() that kept the Jacobians.
+        int dim_J() const { return static_cast<int>(_adjoint_.dim_J()); }
+
+        // Where each GRID bus sits in the Jacobian, -1 where it owns no such
+        // row / column. Keyed by grid bus id -- the same numbering as the columns of
+        // get_voltages() -- rather than by the solver's own, which is an internal
+        // labelling a caller has no business reconstructing:
+        //   *_col_of_bus: the unknown (a voltage angle / magnitude) -> where a
+        //                 cotangent of that bus goes in xbar;
+        //   *_row_of_bus: the equation (an active / reactive mismatch) -> where that
+        //                 bus's injection gradient is read out of lambda.
+        IntVect get_theta_col_of_bus() const { return _bus_map_to_grid(_algo.get_theta_to_J_col_python()); }
+        IntVect get_vm_col_of_bus() const { return _bus_map_to_grid(_algo.get_vm_to_J_col_python()); }
+        IntVect get_p_row_of_bus() const { return _bus_map_to_grid(_algo.get_p_to_J_row_python()); }
+        IntVect get_q_row_of_bus() const { return _bus_map_to_grid(_algo.get_q_to_J_row_python()); }
+
+        // Solve the adjoint system of every row. `xbar` is (nb_rows, k * dim_J): one
+        // row per batch row, holding k cotangents of dim_J coefficients laid end to
+        // end (k = 1 for the gradient of a scalar loss). Returns lambda, same shape.
+        // Rows that did not converge come back zero -- see adjoint_row_ok().
+        BatchAdjoint::RealMatRM solve_JT(const Eigen::Ref<const BatchAdjoint::RealMatRM> & xbar) {
+            if(!_adjoint_.is_allocated()){
+                std::ostringstream exc_;
+                exc_ << algo_name() << "::solve_JT: no Jacobian was kept for this batch. Set "
+                        "`keep_jacobian` to True BEFORE calling compute().";
+                throw std::runtime_error(exc_.str());
+            }
+            return _adjoint_.solve_JT(xbar, _adjoint_identity_rows(), _nb_thread, _adjoint_row_ok_);
+        }
+
+        // Per row: 1 where solve_JT() actually solved that row's adjoint system.
+        const std::vector<char> & adjoint_row_ok() const { return _adjoint_row_ok_; }
+
+        // Linear-solver counters and timings of the last solve_JT: how much of the
+        // backward went into refactorizing versus into the transposed solves.
+        const LinearSolverStats & adjoint_solver_stats() const { return _adjoint_.get_linear_solver_stats(); }
+
         // ================= unified compute() ======================================
         void compute(const Eigen::Ref<const CplxVect> & Vinit, int max_iter, real_type tol);
 
@@ -757,6 +824,73 @@ class LS2G_API BaseBatchSweep: public BaseBatchSolverSynch
         double solve_time() const {return _timer_solver;}
 
     protected:
+        // ----- reverse-mode differentiation helpers -------------------------------
+
+        // Re-key a solver-bus-keyed map onto grid bus ids (see get_p_row_of_bus).
+        IntVect _bus_map_to_grid(const IntVect & solver_keyed) const {
+            const auto me_to_solver = active_layout().id_me_to_solver.as_eigen();
+            IntVect res = IntVect::Constant(me_to_solver.size(), -1);
+            for(Eigen::Index bus_me = 0; bus_me < me_to_solver.size(); ++bus_me){
+                const int bus_solver = me_to_solver[bus_me];
+                if(bus_solver < 0) continue;   // bus not in the solver (deactivated, isolated)
+                if(bus_solver >= solver_keyed.size()) continue;
+                res[bus_me] = solver_keyed[bus_solver];
+            }
+            return res;
+        }
+
+        // Keep this row's converged Jacobian for the adjoint. MUST be called while the
+        // row's own state is still installed on the algorithm -- its Ybus edits, its
+        // masked buses, its PV pinning -- because refresh_J_at_solution() re-fills J
+        // from exactly that, and a J refreshed after the loop restored its resting
+        // state would describe a system this row never solved.
+        void _maybe_store_jacobian(size_t i, AlgorithmSelector & algo) {
+            if(!_adjoint_.is_allocated()) return;
+            algo.refresh_J_at_solution();
+            _adjoint_.store_row(static_cast<Eigen::Index>(i), algo.get_J());
+        }
+
+        // Which equations each row froze to the identity, as Jacobian row indices --
+        // what solve_JT drops from lambda (see BatchAdjoint::solve_JT). Two sources,
+        // and a row can have both:
+        //   - a bus a contingency stranded: masked, so BOTH its P and its Q equation;
+        //   - a bus still PV in this row (a reserved switchable bus whose generator
+        //     is still on): pinned, so its Q equation only.
+        // Empty when the batch does neither, which is the common case.
+        std::vector<std::vector<int> > _adjoint_identity_rows() const {
+            const Eigen::Index nb_rows = _adjoint_.nb_rows();
+            // _li_masked is filled whenever connectivity was analysed, but only the
+            // masked mode ever hands it to the algorithm: without it a contingency
+            // that strands a bus makes the row skipped entirely, not masked
+            const bool has_masking = _handle_disconnected_grid && !_li_masked.empty();
+            const bool has_pinning = _has_pv_switching();
+            if(nb_rows <= 0 || (!has_masking && !has_pinning)) return std::vector<std::vector<int> >();
+
+            const IntVect p_row = _algo.get_p_to_J_row_python();
+            const IntVect q_row = _algo.get_q_to_J_row_python();
+            auto push = [](const IntVect & map, int bus, std::vector<int> & out){
+                if(bus >= 0 && bus < map.size() && map[bus] >= 0) out.push_back(map[bus]);
+            };
+
+            std::vector<std::vector<int> > res(static_cast<size_t>(nb_rows));
+            for(Eigen::Index i = 0; i < nb_rows; ++i){
+                std::vector<int> & row = res[static_cast<size_t>(i)];
+                if(has_masking && static_cast<size_t>(i) < _li_masked.size()){
+                    for(int bus : _li_masked[static_cast<size_t>(i)]){
+                        push(p_row, bus, row);
+                        push(q_row, bus, row);
+                    }
+                }
+                if(has_pinning){
+                    // _row_pv_pinned falls back to the whole switchable set for a row
+                    // that flips nothing -- which is right: such a row leaves every
+                    // reserved bus pinned, exactly as the loop's resting state has it.
+                    for(int bus : _row_pv_pinned(static_cast<size_t>(i))) push(q_row, bus, row);
+                }
+            }
+            return res;
+        }
+
         // ----- bookkeeping shared by every instantiation (plain, always compiled) -
         void _check_ok_el(Eigen::Index el){
             if(el < 0 || el >= static_cast<Eigen::Index>(n_total_)){
@@ -1510,6 +1644,9 @@ class LS2G_API BaseBatchSweep: public BaseBatchSolverSynch
                                                      active_layout().slack_bus_id_solver.as_eigen(), sw,
                                                      active_layout().bus_pv.as_eigen(), active_layout().bus_pq.as_eigen(), max_iter, tol / sn_mva);
                         if(needs_solver_init){ control.tell_none_changed(); needs_solver_init = false; }
+                        // before the two restores below, and before the Ybus is put
+                        // back: see _maybe_store_jacobian
+                        if(conv) _maybe_store_jacobian(cont_id, algo);
                         if(!masked.empty()) algo.set_masked_buses(std::vector<int>());
                         if(flips) algo.set_pv_pinned_buses(_switchable_buses_);
 
@@ -1731,6 +1868,11 @@ class LS2G_API BaseBatchSweep: public BaseBatchSolverSynch
         std::vector<std::vector<int> > _li_defaults_vect_cache_;
 
         double _timer_modif_Ybus = 0.;
+
+        // reverse-mode differentiation (see the public block above and BatchAdjoint)
+        bool _keep_jacobian_ = false;
+        BatchAdjoint _adjoint_;
+        std::vector<char> _adjoint_row_ok_;
 };
 
 /**

--- a/src/core/batch_algorithm/BatchAdjoint.cpp
+++ b/src/core/batch_algorithm/BatchAdjoint.cpp
@@ -1,0 +1,243 @@
+// Copyright (c) 2026, RTE (https://www.rte-france.com)
+// See AUTHORS.txt
+// This Source Code Form is subject to the terms of the Mozilla Public License, version 2.0.
+// If a copy of the Mozilla Public License, version 2.0 was not distributed with this file,
+// you can obtain one at http://mozilla.org/MPL/2.0/.
+// SPDX-License-Identifier: MPL-2.0
+// This file is part of LightSim2grid, LightSim2grid implements a c++ backend targeting the Grid2Op platform.
+
+#include "BatchAdjoint.hpp"
+
+#include <algorithm>
+#include <sstream>
+#include <stdexcept>
+#include <thread>
+
+namespace ls2g {
+
+std::unique_ptr<IAdjointLinearSolver> make_adjoint_linear_solver()
+{
+    #ifdef KLU_SOLVER_AVAILABLE
+    return std::unique_ptr<IAdjointLinearSolver>(new AdjointLinearSolver<KLULinearSolver>());
+    #else
+    return std::unique_ptr<IAdjointLinearSolver>(new AdjointLinearSolver<SparseLULinearSolver>());
+    #endif
+}
+
+void BatchAdjoint::allocate(Eigen::Index nb_rows, const Eigen::Ref<const Eigen::SparseMatrix<real_type> > & J)
+{
+    if(nb_rows <= 0){
+        clear();
+        return;
+    }
+    if(J.rows() != J.cols()){
+        std::ostringstream exc_;
+        exc_ << "BatchAdjoint::allocate: the Jacobian must be square, got " << J.rows()
+             << " x " << J.cols() << ".";
+        throw std::runtime_error(exc_.str());
+    }
+    // the pattern, values zeroed: a worker copies this to get a working matrix whose
+    // index arrays it never has to rebuild
+    pattern_ = J;
+    real_type * val = pattern_.valuePtr();
+    std::fill(val, val + pattern_.nonZeros(), static_cast<real_type>(0.));
+
+    J_values_ = RealMatRM::Zero(nb_rows, pattern_.nonZeros());
+    row_has_J_.assign(static_cast<size_t>(nb_rows), 0);
+    stats_ = LinearSolverStats();
+}
+
+void BatchAdjoint::clear()
+{
+    pattern_ = Eigen::SparseMatrix<real_type>();
+    J_values_ = RealMatRM();
+    row_has_J_.clear();
+    stats_ = LinearSolverStats();
+}
+
+void BatchAdjoint::store_row(Eigen::Index row, const Eigen::Ref<const Eigen::SparseMatrix<real_type> > & J)
+{
+    if(row < 0 || row >= J_values_.rows()){
+        std::ostringstream exc_;
+        exc_ << "BatchAdjoint::store_row: row " << row << " is out of the [0, "
+             << J_values_.rows() << "[ range this adjoint was allocated for.";
+        throw std::runtime_error(exc_.str());
+    }
+    // The whole premise of a batch is that this never fires (see the class comment).
+    // It is checked anyway, on every row: a pattern that drifted would not throw, it
+    // would quietly return a gradient computed from somebody else's matrix -- and the
+    // comparison costs a pass over arrays the memcpy below walks regardless.
+    const bool same_shape = (J.rows() == pattern_.rows()) && (J.cols() == pattern_.cols()) &&
+                            (J.nonZeros() == pattern_.nonZeros());
+    const bool same_pattern = same_shape &&
+        std::memcmp(J.outerIndexPtr(), pattern_.outerIndexPtr(),
+                    static_cast<size_t>(pattern_.outerSize() + 1) * sizeof(Eigen::SparseMatrix<real_type>::StorageIndex)) == 0 &&
+        std::memcmp(J.innerIndexPtr(), pattern_.innerIndexPtr(),
+                    static_cast<size_t>(pattern_.nonZeros()) * sizeof(Eigen::SparseMatrix<real_type>::StorageIndex)) == 0;
+    if(!same_pattern){
+        std::ostringstream exc_;
+        exc_ << "BatchAdjoint::store_row: row " << row << " has a Jacobian whose sparsity "
+                "pattern differs from the one the batch was allocated with (" << J.rows()
+             << " x " << J.cols() << ", " << J.nonZeros() << " nonzeros, against "
+             << pattern_.rows() << " x " << pattern_.cols() << ", " << pattern_.nonZeros()
+             << "). A batch algorithm must keep one pattern for every row -- a row that "
+                "changes a bus's role has to do it by rewriting values inside the pattern "
+                "reserved up front, never by re-deriving the pattern.";
+        throw std::runtime_error(exc_.str());
+    }
+    std::memcpy(J_values_.row(row).data(), J.valuePtr(),
+                static_cast<size_t>(pattern_.nonZeros()) * sizeof(real_type));
+    row_has_J_[static_cast<size_t>(row)] = 1;
+}
+
+void BatchAdjoint::_solve_range(Eigen::Index row_begin, Eigen::Index row_end,
+                                const Eigen::Ref<const RealMatRM> & xbar,
+                                const std::vector<std::vector<int> > & identity_rows,
+                                Eigen::Index nb_directions,
+                                RealMatRM & lambda, std::vector<char> & row_ok,
+                                LinearSolverStats & stats, std::exception_ptr & err) const
+{
+    try {
+        const Eigen::Index dim = dim_J();
+        std::unique_ptr<IAdjointLinearSolver> solver = make_adjoint_linear_solver();
+        // this worker's own copy of the shared pattern: from here on only its values
+        // are ever written, which is what lets every row after the first refactorize
+        Eigen::SparseMatrix<real_type> work = pattern_;
+        RealVect rhs(dim);
+        bool analyzed = false;
+
+        for(Eigen::Index i = row_begin; i < row_end; ++i){
+            if(!has_row(i)) continue;   // never solved in the forward: lambda stays 0
+
+            std::memcpy(work.valuePtr(), J_values_.row(i).data(),
+                        static_cast<size_t>(pattern_.nonZeros()) * sizeof(real_type));
+
+            ErrorType err_solver;
+            if(!analyzed){
+                // one symbolic analysis per worker, for the whole range it owns
+                err_solver = solver->analyze(work);
+                if(err_solver == ErrorType::NoError) err_solver = solver->factorize(work);
+                analyzed = (err_solver == ErrorType::NoError);
+            } else {
+                err_solver = solver->refactorize(work);
+            }
+            if(err_solver != ErrorType::NoError) continue;   // row_ok stays 0
+
+            bool all_ok = true;
+            for(Eigen::Index d = 0; d < nb_directions; ++d){
+                rhs = xbar.row(i).segment(d * dim, dim);
+                if(solver->solve_transpose(rhs) != ErrorType::NoError){
+                    all_ok = false;
+                    break;
+                }
+                lambda.row(i).segment(d * dim, dim) = rhs;
+            }
+            if(!all_ok) continue;
+
+            // Drop the multipliers of the equations this row froze to the identity.
+            // Such a row of J is a single 1: it feeds no other equation (every other
+            // entry of that row is zero), so the rest of lambda is exactly what it
+            // would have been without the frozen equation -- but the multiplier
+            // itself belongs to an equation the row does not really solve, and
+            // handing it back would put a gradient on an injection the solution does
+            // not depend on.
+            if(!identity_rows.empty()){
+                for(int eq : identity_rows[static_cast<size_t>(i)]){
+                    if(eq < 0 || eq >= dim) continue;
+                    for(Eigen::Index d = 0; d < nb_directions; ++d) lambda(i, d * dim + eq) = 0.;
+                }
+            }
+            row_ok[static_cast<size_t>(i)] = 1;
+        }
+        stats = solver->get_linear_solver_stats();
+    } catch(...) {
+        err = std::current_exception();
+    }
+}
+
+BatchAdjoint::RealMatRM BatchAdjoint::solve_JT(
+    const Eigen::Ref<const RealMatRM> & xbar,
+    const std::vector<std::vector<int> > & identity_rows,
+    int nb_thread,
+    std::vector<char> & row_ok) const
+{
+    if(!is_allocated()){
+        throw std::runtime_error("BatchAdjoint::solve_JT: no Jacobian was kept. Set "
+                                 "`keep_jacobian` to True before running the batch.");
+    }
+    const Eigen::Index rows = nb_rows();
+    const Eigen::Index dim = dim_J();
+    if(xbar.rows() != rows){
+        std::ostringstream exc_;
+        exc_ << "BatchAdjoint::solve_JT: xbar has " << xbar.rows() << " rows, but the batch "
+                "has " << rows << ".";
+        throw std::runtime_error(exc_.str());
+    }
+    if(xbar.cols() <= 0 || (xbar.cols() % dim) != 0){
+        std::ostringstream exc_;
+        exc_ << "BatchAdjoint::solve_JT: xbar has " << xbar.cols() << " columns, which is not "
+                "a positive multiple of the Jacobian's dimension (" << dim << "). Each row "
+                "holds one or more cotangents of " << dim << " coefficients, laid end to end.";
+        throw std::runtime_error(exc_.str());
+    }
+    if(!identity_rows.empty() && static_cast<Eigen::Index>(identity_rows.size()) != rows){
+        std::ostringstream exc_;
+        exc_ << "BatchAdjoint::solve_JT: identity_rows has " << identity_rows.size()
+             << " entries for a batch of " << rows << " rows (it must be empty, or have one "
+                "entry per row).";
+        throw std::runtime_error(exc_.str());
+    }
+    const Eigen::Index nb_directions = xbar.cols() / dim;
+
+    RealMatRM lambda = RealMatRM::Zero(rows, xbar.cols());
+    row_ok.assign(static_cast<size_t>(rows), 0);
+
+    const int nb_th = std::min(static_cast<int>(rows), std::max(1, nb_thread));
+    std::vector<LinearSolverStats> th_stats(nb_th);
+    std::vector<std::exception_ptr> th_err(nb_th);
+
+    if(nb_th <= 1){
+        _solve_range(0, rows, xbar, identity_rows, nb_directions, lambda, row_ok,
+                     th_stats[0], th_err[0]);
+    } else {
+        // contiguous ranges, exactly like the forward's row loop: disjoint rows of
+        // lambda / row_ok, one solver and one working matrix per worker
+        std::vector<std::thread> threads;
+        threads.reserve(static_cast<size_t>(nb_th));
+        const Eigen::Index per_thread = rows / nb_th;
+        const Eigen::Index remainder = rows % nb_th;
+        Eigen::Index begin = 0;
+        for(int t = 0; t < nb_th; ++t){
+            const Eigen::Index end = begin + per_thread + (t < remainder ? 1 : 0);
+            threads.emplace_back([this, begin, end, &xbar, &identity_rows, nb_directions,
+                                  &lambda, &row_ok, &th_stats, &th_err, t](){
+                this->_solve_range(begin, end, xbar, identity_rows, nb_directions,
+                                   lambda, row_ok, th_stats[t], th_err[t]);
+            });
+            begin = end;
+        }
+        for(auto & th : threads) th.join();
+    }
+
+    for(int t = 0; t < nb_th; ++t){
+        if(th_err[t]) std::rethrow_exception(th_err[t]);
+    }
+
+    stats_ = LinearSolverStats();
+    for(const auto & s : th_stats){
+        stats_.nb_analyze += s.nb_analyze;
+        stats_.nb_factorize += s.nb_factorize;
+        stats_.nb_refactorize += s.nb_refactorize;
+        stats_.nb_refactorize_failed += s.nb_refactorize_failed;
+        stats_.nb_fallback_factorize += s.nb_fallback_factorize;
+        stats_.nb_fallback_factorize_failed += s.nb_fallback_factorize_failed;
+        stats_.nb_solve_transpose += s.nb_solve_transpose;
+        stats_.timer_initialize_ += s.timer_initialize_;
+        stats_.timer_factor_ += s.timer_factor_;
+        stats_.timer_refactor_ += s.timer_refactor_;
+        stats_.timer_solve_transpose_ += s.timer_solve_transpose_;
+    }
+    return lambda;
+}
+
+} // namespace ls2g

--- a/src/core/batch_algorithm/BatchAdjoint.cpp
+++ b/src/core/batch_algorithm/BatchAdjoint.cpp
@@ -9,6 +9,7 @@
 #include "BatchAdjoint.hpp"
 
 #include <algorithm>
+#include <exception>
 #include <sstream>
 #include <stdexcept>
 #include <thread>

--- a/src/core/batch_algorithm/BatchAdjoint.cpp
+++ b/src/core/batch_algorithm/BatchAdjoint.cpp
@@ -18,10 +18,12 @@ namespace ls2g {
 
 std::unique_ptr<IAdjointLinearSolver> make_adjoint_linear_solver()
 {
+    // the derived unique_ptr converts to the base one on return (IAdjointLinearSolver
+    // has a virtual destructor), so no raw `new` has to be owned by hand here
     #ifdef KLU_SOLVER_AVAILABLE
-    return std::unique_ptr<IAdjointLinearSolver>(new AdjointLinearSolver<KLULinearSolver>());
+    return std::make_unique<AdjointLinearSolver<KLULinearSolver> >();
     #else
-    return std::unique_ptr<IAdjointLinearSolver>(new AdjointLinearSolver<SparseLULinearSolver>());
+    return std::make_unique<AdjointLinearSolver<SparseLULinearSolver> >();
     #endif
 }
 

--- a/src/core/batch_algorithm/BatchAdjoint.hpp
+++ b/src/core/batch_algorithm/BatchAdjoint.hpp
@@ -9,7 +9,9 @@
 #ifndef BATCH_ADJOINT_H
 #define BATCH_ADJOINT_H
 
+#include <cstddef>
 #include <cstring>
+#include <exception>   // std::exception_ptr: libc++ only forward-declares it in <vector>
 #include <memory>
 #include <vector>
 

--- a/src/core/batch_algorithm/BatchAdjoint.hpp
+++ b/src/core/batch_algorithm/BatchAdjoint.hpp
@@ -1,0 +1,216 @@
+// Copyright (c) 2026, RTE (https://www.rte-france.com)
+// See AUTHORS.txt
+// This Source Code Form is subject to the terms of the Mozilla Public License, version 2.0.
+// If a copy of the Mozilla Public License, version 2.0 was not distributed with this file,
+// you can obtain one at http://mozilla.org/MPL/2.0/.
+// SPDX-License-Identifier: MPL-2.0
+// This file is part of LightSim2grid, LightSim2grid implements a c++ backend targeting the Grid2Op platform.
+
+#ifndef BATCH_ADJOINT_H
+#define BATCH_ADJOINT_H
+
+#include <cstring>
+#include <memory>
+#include <vector>
+
+#include "Eigen/Core"
+#include "Eigen/SparseCore"
+
+#include "Utils.hpp"
+#include "linear_solvers/LinearSolverPolicy.hpp"
+#include "linear_solvers/RefactorRetryLinearSolver.hpp"
+#include "linear_solvers/SparseLUSolver.hpp"
+#include "linear_solvers/KLUSolver.hpp"
+
+namespace ls2g {
+
+/**
+Reverse-mode differentiation of a batch of powerflows: the adjoint system.
+
+Every row of a batch solves G(x_i ; u_i) = 0 by Newton-Raphson and ends on a
+Jacobian J_i. Differentiating a scalar loss L(V_1, ..., V_n) with respect to the
+per-row inputs needs, for each row, the solution of
+
+    J_i^T lambda_i = xbar_i
+
+(the implicit function theorem), and nothing else: lambda_i does not depend on
+which input is being differentiated, so ONE transposed solve per row yields the
+gradient with respect to every injection at once. See docs/ for the full
+derivation and for how lambda maps back onto the elements.
+
+Two properties of this repository's batch algorithms are what make that cheap,
+and they are why this class exists rather than a generic autodiff layer:
+
+- **the Jacobian's sparsity pattern is the same for every row of a batch** (see
+  BaseBatchSweep's class comment: a row may change a bus's role, but only by
+  rewriting values inside a pattern reserved up front). So one pattern is
+  snapshotted once and every row is just `nnz_J` reals;
+- **KLU solves the transposed system out of the factorization of J itself**
+  (`klu_tsolve`, see KLULinearSolver::solve_transpose). No transposed copy of J,
+  no second symbolic analysis.
+
+Memory is the price, and it is known before the batch runs: `nb_rows * nnz_J`
+reals, allocated ONCE by allocate() before the row loop starts (see
+memory_bytes(), which a caller can consult beforehand). Each worker thread then
+memcpy's into its own rows -- J_values_ is row-major precisely so that a row is
+one contiguous block and threads never share a cache line except at the two
+boundaries of their range.
+
+What is NOT stored is the numeric factorization: KLU's `klu_refactor` overwrites
+its klu_numeric in place, and there is no way to clone one, so keeping a
+factorization per row would mean a full `klu_factor` (more expensive than a
+refactor) per row in the forward. backward therefore pays one refactorize plus
+one transposed solve per row -- both timed separately in the returned stats, so
+the trade can be revisited on measurements rather than on belief.
+
+This class knows nothing about powerflows: it is a batch of "same pattern,
+different values" linear systems and their transposed solves. Which rows carry
+identity equations, and what lambda means once solved, are the caller's business
+(see BaseBatchSweep::solve_JT).
+**/
+class LS2G_API BatchAdjoint
+{
+    public:
+        // row-major: one row of J's values, or of xbar / lambda, is contiguous, so a
+        // worker writes a block instead of striding across the whole matrix (and so
+        // the numpy array a binding hands out is a view, not a transposing copy).
+        using RealMatRM = Eigen::Matrix<real_type, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor>;
+
+        BatchAdjoint() = default;
+
+        // --- filled during the forward -------------------------------------------
+
+        /** Snapshot `J`'s pattern and size the value buffer for `nb_rows` rows. Called
+        once, before the row loop, with the Jacobian of the batch's warm-up solve: by
+        then the ledger is built and dim_J / nnz_J are known. Drops whatever a previous
+        batch left. */
+        void allocate(Eigen::Index nb_rows, const Eigen::Ref<const Eigen::SparseMatrix<real_type> > & J);
+
+        /** Store row `row`'s converged Jacobian. Thread-safe with respect to other rows
+        (disjoint writes into a buffer that is never resized here). Throws if `J`'s
+        pattern is not the snapshotted one -- that would silently produce wrong
+        gradients, and the check costs a memcmp against a copy the row is about to
+        make anyway. */
+        void store_row(Eigen::Index row, const Eigen::Ref<const Eigen::SparseMatrix<real_type> > & J);
+
+        void clear();
+
+        // --- consumed by the backward --------------------------------------------
+
+        /** Solve `J_i^T lambda_i = xbar_i` for every row.
+
+        `xbar` is `(nb_rows, nb_directions * dim_J)`: one row per batch row, holding
+        `nb_directions` cotangents laid end to end (`dim_J` contiguous reals each --
+        the layout `klu_tsolve`'s `nrhs` wants). Reverse-mode differentiation of a
+        scalar loss uses one direction; several are only needed for a full Jacobian,
+        and cost one triangular solve each, not one factorization each.
+
+        `identity_rows[i]` lists the equations of row `i` that the batch pinned to the
+        identity (a bus stranded by a contingency, a bus still PV in this row). Their
+        multiplier is dropped from the result: it belongs to a frozen equation, and
+        reporting it would put a gradient on an injection that this row's solution does
+        not actually depend on. May be empty (no row pins anything), otherwise it must
+        have one entry per row.
+
+        Rows the forward never stored (they diverged, or were skipped) come back as
+        zero, with `row_ok` 0. */
+        RealMatRM solve_JT(const Eigen::Ref<const RealMatRM> & xbar,
+                           const std::vector<std::vector<int> > & identity_rows,
+                           int nb_thread,
+                           std::vector<char> & row_ok) const;
+
+        // --- introspection --------------------------------------------------------
+
+        bool is_allocated() const noexcept { return dim_J() > 0 && J_values_.rows() > 0; }
+        Eigen::Index nb_rows() const noexcept { return J_values_.rows(); }
+        Eigen::Index dim_J() const noexcept { return pattern_.rows(); }
+        Eigen::Index nnz_J() const noexcept { return pattern_.nonZeros(); }
+        bool has_row(Eigen::Index row) const {
+            return row >= 0 && row < static_cast<Eigen::Index>(row_has_J_.size()) && row_has_J_[static_cast<size_t>(row)] != 0;
+        }
+
+        /** Bytes the value buffer takes for `nb_rows` rows of this Jacobian. The only
+        cost of keeping every row's J, and knowable before compute() runs. */
+        static std::size_t memory_bytes(Eigen::Index nb_rows, Eigen::Index nnz) noexcept {
+            return static_cast<std::size_t>(nb_rows) * static_cast<std::size_t>(nnz) * sizeof(real_type);
+        }
+        std::size_t memory_bytes() const noexcept { return memory_bytes(nb_rows(), nnz_J()); }
+
+        /** Linear-solver counters and timings of the last solve_JT, summed over its
+        worker threads: how much of a backward went into refactorizing versus into the
+        transposed solves themselves. */
+        const LinearSolverStats & get_linear_solver_stats() const noexcept { return stats_; }
+
+    private:
+        // The pattern every row shares, values zeroed: a worker copies it once to get
+        // a working matrix it then only ever writes values into.
+        Eigen::SparseMatrix<real_type> pattern_;
+        RealMatRM J_values_;              // (nb_rows, nnz_J), row-major
+        std::vector<char> row_has_J_;     // char, not bool: written concurrently per row
+        mutable LinearSolverStats stats_;
+
+        void _solve_range(Eigen::Index row_begin, Eigen::Index row_end,
+                          const Eigen::Ref<const RealMatRM> & xbar,
+                          const std::vector<std::vector<int> > & identity_rows,
+                          Eigen::Index nb_directions,
+                          RealMatRM & lambda, std::vector<char> & row_ok,
+                          LinearSolverStats & stats, std::exception_ptr & err) const;
+
+        BatchAdjoint(const BatchAdjoint&) = delete;
+        BatchAdjoint & operator=(const BatchAdjoint&) = delete;
+};
+
+
+/**
+The linear solver a BatchAdjoint worker owns, behind a virtual interface.
+
+The algorithms pick their linear solver at compile time (LinearSolverPolicy is a
+template parameter, never a base pointer -- see its class comment). A batch's
+algorithm, though, is chosen at RUNTIME through AlgorithmSelector, so the adjoint
+cannot know its solver type statically. Three virtual calls per row against one
+refactorize and one triangular solve is not a measurable cost, and it keeps the
+adjoint out of the template explosion.
+
+Only solvers that answer the transposed system belong here -- hence the
+static_assert: the alternative, forming J^T and factorizing it per row, is a
+different (and much more expensive) algorithm, not a fallback to slip in
+silently.
+**/
+class IAdjointLinearSolver
+{
+    public:
+        virtual ~IAdjointLinearSolver() = default;
+        virtual ErrorType analyze(const Eigen::Ref<const Eigen::SparseMatrix<real_type> > & J) = 0;
+        virtual ErrorType factorize(const Eigen::Ref<const Eigen::SparseMatrix<real_type> > & J) = 0;
+        virtual ErrorType refactorize(const Eigen::Ref<const Eigen::SparseMatrix<real_type> > & J) = 0;
+        virtual ErrorType solve_transpose(Eigen::Ref<RealVect> b) = 0;
+        virtual const LinearSolverStats & get_linear_solver_stats() const = 0;
+};
+
+template<class LinearSolver>
+class AdjointLinearSolver final : public IAdjointLinearSolver
+{
+    static_assert(LinearSolver::CAN_SOLVE_TRANSPOSE,
+                  "a BatchAdjoint solver must answer J^T x = b out of the factorization of J");
+    public:
+        ErrorType analyze(const Eigen::Ref<const Eigen::SparseMatrix<real_type> > & J) override { return inner_.analyze(J); }
+        ErrorType factorize(const Eigen::Ref<const Eigen::SparseMatrix<real_type> > & J) override { return inner_.factorize(J); }
+        ErrorType refactorize(const Eigen::Ref<const Eigen::SparseMatrix<real_type> > & J) override { return inner_.refactorize(J); }
+        ErrorType solve_transpose(Eigen::Ref<RealVect> b) override { return inner_.solve_transpose(b); }
+        const LinearSolverStats & get_linear_solver_stats() const override { return inner_.get_linear_solver_stats(); }
+    private:
+        // RefactorRetry, not the plain policy: a masked or pinned row rewrites values
+        // where the base matrix had its pivot, which is exactly the case KLU's fixed
+        // pivot sequence finds at zero. The batch algorithms turn the same fallback on
+        // for their own solver for the same reason (BaseBatchSweep.cpp).
+        RefactorRetryLinearSolver<LinearSolver> inner_;
+};
+
+/** The best available transposed-solve capable linear solver: KLU where it was
+compiled in, Eigen's SparseLU otherwise (always available, same answers, slower).
+*/
+std::unique_ptr<IAdjointLinearSolver> LS2G_API make_adjoint_linear_solver();
+
+} // namespace ls2g
+
+#endif // BATCH_ADJOINT_H

--- a/src/core/batch_algorithm/CMakeLists.txt
+++ b/src/core/batch_algorithm/CMakeLists.txt
@@ -3,6 +3,7 @@ list(APPEND SOURCES
     "${CMAKE_CURRENT_SOURCE_DIR}/YbusPolicy.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/SbusPolicy.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/BaseBatchSweep.cpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/BatchAdjoint.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/ContinuationSweep.cpp"
 )
 set(SOURCES ${SOURCES} PARENT_SCOPE)

--- a/src/core/linear_solvers/CKTSOSolver.hpp
+++ b/src/core/linear_solvers/CKTSOSolver.hpp
@@ -118,9 +118,9 @@ class LS2G_API CKTSOLinearSolver final
 
 };
 
-#endif // CKTSOSOLVER_H
-
 } // namespace ls2g
+
+#endif // CKTSOSOLVER_H
 
 #elif defined(_READ_THE_DOCS)
 #ifndef CKTSOSOLVER_H

--- a/src/core/linear_solvers/KLUSolver.hpp
+++ b/src/core/linear_solvers/KLUSolver.hpp
@@ -101,9 +101,9 @@ class LS2G_API KLULinearSolver final
         KLULinearSolver & operator=(const KLULinearSolver&) = delete;
 };
 
-#endif // KLSOLVER_H
-
 } // namespace ls2g
+
+#endif // KLSOLVER_H
 
 #elif defined(_READ_THE_DOCS)
 #ifndef KLSOLVER_H

--- a/src/core/linear_solvers/NICSLUSolver.hpp
+++ b/src/core/linear_solvers/NICSLUSolver.hpp
@@ -105,9 +105,9 @@ class LS2G_API NICSLULinearSolver final
 
 };
 
-#endif // NICSLUSOLVER_H
-
 } // namespace ls2g
+
+#endif // NICSLUSOLVER_H
 
 #elif defined(_READ_THE_DOCS)
 #ifndef NICSLUSOLVER_H

--- a/src/core/powerflow_algorithm/BaseAlgo.hpp
+++ b/src/core/powerflow_algorithm/BaseAlgo.hpp
@@ -459,6 +459,28 @@ class LS2G_API BaseAlgo : public BaseConstants
         virtual bool supports_bus_masking() const { return false; }
         virtual void set_masked_buses(const std::vector<int> & /*solver_bus_ids*/) {}
 
+        // Whether get_J() / refresh_J_at_solution() mean anything for this algorithm,
+        // i.e. whether it is one of the Newton-Raphson family. Lets a caller that needs
+        // the Jacobian (the adjoint of a batch) say so before running rather than
+        // discover it through get_J()'s exception halfway through a sweep.
+        virtual bool supports_jacobian() const { return false; }
+
+        // Rebuild the Jacobian at the voltage the last compute_pf converged to.
+        //
+        // A Newton-Raphson loop tests the residual BEFORE deciding it needs a new
+        // Jacobian, so the J it rests on is the one it built at the previous iterate,
+        // not at the solution. For a solve that is the right economy -- the step it
+        // computed is what mattered. For an adjoint it is not: the gradient is exact
+        // only at the converged point, and the error is of the order of the last
+        // Newton step, which is the very thing the tolerance does NOT bound tightly.
+        //
+        // Costs one Jacobian fill and no factorization, so it is only worth paying
+        // where the Jacobian is about to be read (see BaseBatchSweep's keep_jacobian);
+        // nothing else in a solve depends on it. A no-op where there is no Jacobian to
+        // speak of (every non Newton-Raphson algorithm), which is safe: those cannot
+        // serve an adjoint at all (get_J already throws).
+        virtual void refresh_J_at_solution() {}
+
         // Tells the algorithm whether a stranded-controller Jacobian slot (see
         // VoltageControl::declare_feature_entries in NRSystem.hpp) is worth reserving
         // for THIS run: only ContingencyAnalysis/ScenarioSweep's handle_disconnected_grid

--- a/src/core/powerflow_algorithm/NRAlgo.hpp
+++ b/src/core/powerflow_algorithm/NRAlgo.hpp
@@ -166,6 +166,18 @@ public:
 
     // ----- bus masking ---------------------------------------------------------
     bool supports_bus_masking() const override { return true; }
+    bool supports_jacobian() const override { return true; }
+
+    // see BaseAlgo::refresh_J_at_solution. _system holds the converged V (apply_step
+    // wrote it, and the final mismatch_into read it back), so re-deriving the
+    // intermediate quantities and re-filling J evaluates it exactly there. The masked
+    // / pinned identity rows are re-applied by fill_J as usual, so the refreshed J
+    // still describes the system this row actually solved.
+    void refresh_J_at_solution() override {
+        _system.fill_internal_variables();
+        _system.fill_J();
+    }
+
     void set_masked_buses(const std::vector<int> & solver_bus_ids) override {
         _system.set_masked_buses(solver_bus_ids);
     }

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -85,6 +85,7 @@ add_executable(lightsim2grid_unit_tests
     test_bus_element_count.cpp
     test_kcl_from_results.cpp
     test_solve_transpose.cpp
+    test_batch_adjoint.cpp
 )
 target_link_libraries(lightsim2grid_unit_tests PRIVATE lightsim2grid_core Catch2::Catch2WithMain)
 

--- a/src/tests/test_batch_adjoint.cpp
+++ b/src/tests/test_batch_adjoint.cpp
@@ -1,0 +1,502 @@
+// Copyright (c) 2026, RTE (https://www.rte-france.com)
+// See AUTHORS.txt
+// This Source Code Form is subject to the terms of the Mozilla Public License, version 2.0.
+// If a copy of the Mozilla Public License, version 2.0 was not distributed with this file,
+// you can obtain one at http://mozilla.org/MPL/2.0/.
+// SPDX-License-Identifier: MPL-2.0
+// This file is part of LightSim2grid, LightSim2grid implements a c++ backend targeting the Grid2Op platform.
+
+// Two levels, because the adjoint can be wrong in two independent ways.
+//
+// BatchAdjoint on its own is a batch of "same pattern, different values" transposed
+// solves: the reference there is a dense LU of each row's explicitly transposed
+// matrix, which owes nothing to powerflows.
+//
+// Wired into a sweep, what matters is a different claim: that lambda really is the
+// gradient. The reference there is the sweep itself -- a central finite difference of
+// a scalar loss with respect to an injection, which knows nothing about Jacobians. If
+// the implicit-function sign were flipped, the ledger read backwards, or the Jacobian
+// captured one Newton iterate before the solution, this is what would say so.
+
+#include <vector>
+
+#include <catch2/catch_approx.hpp>
+#include <catch2/catch_test_macros.hpp>
+
+#include "Eigen/Dense"
+
+#include "LSGrid.hpp"
+#include "Solvers.hpp"
+#include "batch_algorithm/BatchAdjoint.hpp"
+#include "batch_algorithm/BaseBatchSweep.hpp"
+
+using Catch::Approx;
+using ls2g::AlgorithmType;
+using ls2g::BatchAdjoint;
+using ls2g::CplxVect;
+using ls2g::InjectionSweep;
+using ls2g::IntVect;
+using ls2g::LSGrid;
+using ls2g::RealVect;
+using ls2g::cplx_type;
+using ls2g::real_type;
+
+namespace {
+
+using RealMatRM = BatchAdjoint::RealMatRM;
+using SpMat = Eigen::SparseMatrix<real_type>;
+using DenseMat = Eigen::Matrix<real_type, Eigen::Dynamic, Eigen::Dynamic>;
+
+// ============================================================ part A: the solves
+
+// asymmetric in pattern AND values (so J^T is a genuinely different matrix), with a
+// `shift` that moves the values without touching the pattern -- one batch row each
+SpMat make_asym_matrix(int n, real_type shift)
+{
+    std::vector<Eigen::Triplet<real_type> > coeffs;
+    for(int i = 0; i < n; ++i){
+        coeffs.push_back(Eigen::Triplet<real_type>(i, i, 10. + i + shift));
+        if(i + 1 < n) coeffs.push_back(Eigen::Triplet<real_type>(i, i + 1, -1. - 0.25 * i + shift));
+        if(i + 3 < n) coeffs.push_back(Eigen::Triplet<real_type>(i, i + 3, 0.5 + 0.125 * i));
+        if(i - 2 >= 0) coeffs.push_back(Eigen::Triplet<real_type>(i, i - 2, 2. + 0.5 * i - shift));
+    }
+    coeffs.push_back(Eigen::Triplet<real_type>(0, n - 1, 3.5));
+    coeffs.push_back(Eigen::Triplet<real_type>(n - 2, 1, -2.25));
+    SpMat res(n, n);
+    res.setFromTriplets(coeffs.begin(), coeffs.end());
+    res.makeCompressed();
+    return res;
+}
+
+RealVect dense_transposed_solve(const SpMat & J, const RealVect & b)
+{
+    const DenseMat dense = DenseMat(J).transpose();
+    return dense.fullPivLu().solve(b);
+}
+
+real_type row_shift(int row) { return 0.1 * static_cast<real_type>((row * 7) % 13); }
+
+}  // namespace
+
+
+TEST_CASE("the batch adjoint solves every row against its own Jacobian")
+{
+    const int n = 14;
+    const int nb_rows = 9;
+
+    BatchAdjoint adj;
+    adj.allocate(nb_rows, make_asym_matrix(n, 0.));
+    REQUIRE(adj.dim_J() == n);
+    REQUIRE(adj.nb_rows() == nb_rows);
+    REQUIRE(adj.memory_bytes() == static_cast<std::size_t>(nb_rows) * static_cast<std::size_t>(adj.nnz_J()) * sizeof(real_type));
+
+    RealMatRM xbar(nb_rows, n);
+    for(int i = 0; i < nb_rows; ++i){
+        adj.store_row(i, make_asym_matrix(n, row_shift(i)));
+        for(int j = 0; j < n; ++j) xbar(i, j) = 1. + 0.5 * j - (i % 3);
+    }
+
+    std::vector<char> row_ok;
+    const RealMatRM lambda = adj.solve_JT(xbar, std::vector<std::vector<int> >(), 1, row_ok);
+
+    for(int i = 0; i < nb_rows; ++i){
+        REQUIRE(row_ok[static_cast<size_t>(i)] == 1);
+        const RealVect expected = dense_transposed_solve(make_asym_matrix(n, row_shift(i)), xbar.row(i).transpose());
+        for(int j = 0; j < n; ++j) REQUIRE(lambda(i, j) == Approx(expected(j)).margin(1e-9));
+    }
+
+    // ... and a row really is solved against ITS matrix, not against some other row's
+    const RealVect wrong = dense_transposed_solve(make_asym_matrix(n, row_shift(0)), xbar.row(3).transpose());
+    REQUIRE((lambda.row(3).transpose() - wrong).lpNorm<Eigen::Infinity>() > 1e-6);
+}
+
+
+TEST_CASE("the batch adjoint gives the same answer however many threads it uses")
+{
+    const int n = 14;
+    const int nb_rows = 23;   // deliberately not a multiple of the thread counts below
+
+    BatchAdjoint adj;
+    adj.allocate(nb_rows, make_asym_matrix(n, 0.));
+    RealMatRM xbar(nb_rows, n);
+    for(int i = 0; i < nb_rows; ++i){
+        adj.store_row(i, make_asym_matrix(n, row_shift(i)));
+        for(int j = 0; j < n; ++j) xbar(i, j) = 0.3 * j - 0.7 * i;
+    }
+
+    std::vector<char> ok1, ok4;
+    const RealMatRM l1 = adj.solve_JT(xbar, std::vector<std::vector<int> >(), 1, ok1);
+    const RealMatRM l4 = adj.solve_JT(xbar, std::vector<std::vector<int> >(), 4, ok4);
+    REQUIRE(ok1 == ok4);
+    for(int i = 0; i < nb_rows; ++i){
+        for(int j = 0; j < n; ++j) REQUIRE(l4(i, j) == Approx(l1(i, j)).margin(1e-10));
+    }
+}
+
+
+TEST_CASE("a row the batch never solved has no adjoint, and says so")
+{
+    const int n = 10;
+    const int nb_rows = 5;
+    BatchAdjoint adj;
+    adj.allocate(nb_rows, make_asym_matrix(n, 0.));
+    for(int i = 0; i < nb_rows; ++i){
+        if(i == 2) continue;   // as a diverging / skipped row leaves it
+        adj.store_row(i, make_asym_matrix(n, row_shift(i)));
+    }
+    REQUIRE_FALSE(adj.has_row(2));
+
+    const RealMatRM xbar = RealMatRM::Constant(nb_rows, n, 1.);
+    std::vector<char> row_ok;
+    const RealMatRM lambda = adj.solve_JT(xbar, std::vector<std::vector<int> >(), 1, row_ok);
+
+    REQUIRE(row_ok[2] == 0);
+    REQUIRE(lambda.row(2).lpNorm<Eigen::Infinity>() == Approx(0.).margin(0.));
+    for(int i = 0; i < nb_rows; ++i){
+        if(i == 2) continue;
+        REQUIRE(row_ok[static_cast<size_t>(i)] == 1);
+        REQUIRE(lambda.row(i).lpNorm<Eigen::Infinity>() > 0.);
+    }
+}
+
+
+TEST_CASE("the multiplier of an identity-pinned equation is dropped")
+{
+    const int n = 12;
+    const int nb_rows = 4;
+    BatchAdjoint adj;
+    adj.allocate(nb_rows, make_asym_matrix(n, 0.));
+    for(int i = 0; i < nb_rows; ++i) adj.store_row(i, make_asym_matrix(n, row_shift(i)));
+
+    const RealMatRM xbar = RealMatRM::Constant(nb_rows, n, 1.5);
+    std::vector<std::vector<int> > identity_rows(nb_rows);
+    identity_rows[1].push_back(4);
+    identity_rows[1].push_back(7);
+    identity_rows[3].push_back(0);
+
+    std::vector<char> ok_free, ok_pinned;
+    const RealMatRM free_ = adj.solve_JT(xbar, std::vector<std::vector<int> >(), 1, ok_free);
+    const RealMatRM pinned = adj.solve_JT(xbar, identity_rows, 1, ok_pinned);
+
+    for(int i = 0; i < nb_rows; ++i){
+        for(int j = 0; j < n; ++j){
+            const bool dropped = (i == 1 && (j == 4 || j == 7)) || (i == 3 && j == 0);
+            if(dropped) REQUIRE(pinned(i, j) == Approx(0.).margin(0.));
+            else REQUIRE(pinned(i, j) == Approx(free_(i, j)).margin(1e-12));
+        }
+    }
+}
+
+
+TEST_CASE("the batch adjoint refuses a Jacobian whose pattern is not the batch's")
+{
+    const int n = 10;
+    BatchAdjoint adj;
+    adj.allocate(3, make_asym_matrix(n, 0.));
+
+    SpMat other(n, n);                       // a different pattern entirely
+    std::vector<Eigen::Triplet<real_type> > coeffs;
+    for(int i = 0; i < n; ++i) coeffs.push_back(Eigen::Triplet<real_type>(i, i, 1.));
+    other.setFromTriplets(coeffs.begin(), coeffs.end());
+    other.makeCompressed();
+
+    REQUIRE_THROWS(adj.store_row(0, other));
+    REQUIRE_THROWS(adj.store_row(7, make_asym_matrix(n, 0.)));   // out of range
+}
+
+
+TEST_CASE("several cotangents per row cost solves, not factorizations")
+{
+    const int n = 11;
+    const int nb_rows = 6;
+    const int k = 3;
+    BatchAdjoint adj;
+    adj.allocate(nb_rows, make_asym_matrix(n, 0.));
+    for(int i = 0; i < nb_rows; ++i) adj.store_row(i, make_asym_matrix(n, row_shift(i)));
+
+    RealMatRM xbar(nb_rows, k * n);
+    for(int i = 0; i < nb_rows; ++i){
+        for(int d = 0; d < k; ++d){
+            for(int j = 0; j < n; ++j) xbar(i, d * n + j) = 1. + d - 0.3 * j + 0.1 * i;
+        }
+    }
+
+    std::vector<char> row_ok;
+    const RealMatRM lambda = adj.solve_JT(xbar, std::vector<std::vector<int> >(), 1, row_ok);
+    REQUIRE(lambda.cols() == k * n);
+
+    for(int i = 0; i < nb_rows; ++i){
+        const SpMat J = make_asym_matrix(n, row_shift(i));
+        for(int d = 0; d < k; ++d){
+            const RealVect expected = dense_transposed_solve(J, xbar.row(i).segment(d * n, n).transpose());
+            for(int j = 0; j < n; ++j) REQUIRE(lambda(i, d * n + j) == Approx(expected(j)).margin(1e-9));
+        }
+    }
+
+    // one analysis and one numeric factorization per row, k triangular solves per row
+    const ls2g::LinearSolverStats & stats = adj.get_linear_solver_stats();
+    REQUIRE(stats.nb_analyze == 1);
+    REQUIRE(stats.nb_solve_transpose == static_cast<std::size_t>(nb_rows * k));
+    REQUIRE(stats.nb_factorize + stats.nb_refactorize == static_cast<std::size_t>(nb_rows));
+}
+
+
+// ======================================================= part B: it is the gradient
+
+namespace {
+
+const int NB_BUS = 4;
+const int NB_GEN = 2;
+const int LOAD_BUS = NB_BUS - 1;
+const int GEN_BUS = 1;
+const real_type SN_MVA = 100.;
+
+// the 4-bus radial feeder of test_injection_sweep.cpp: slack generator at bus 0, PV
+// generator at bus 1, one load at bus 3
+LSGrid make_grid()
+{
+    LSGrid g;
+    g.set_sn_mva(SN_MVA);
+    g.set_init_vm_pu(1.0);
+    g.init_bus(static_cast<unsigned int>(NB_BUS), 1, RealVect::Constant(NB_BUS, 138.), 0, 0);
+
+    Eigen::VectorXi f(NB_BUS - 1), t(NB_BUS - 1);
+    for(int i = 0; i < NB_BUS - 1; ++i){ f(i) = i; t(i) = i + 1; }
+    g.init_powerlines(RealVect::Constant(NB_BUS - 1, 0.01), RealVect::Constant(NB_BUS - 1, 0.1),
+                      CplxVect::Zero(NB_BUS - 1), f, t);
+
+    RealVect lp(1), lq(1); lp << 50.; lq << 10.;
+    Eigen::VectorXi lb(1); lb << LOAD_BUS;
+    g.init_loads(lp, lq, lb);
+
+    RealVect p(NB_GEN), v(NB_GEN), q(NB_GEN), qmin(NB_GEN), qmax(NB_GEN);
+    Eigen::VectorXi b(NB_GEN);
+    p << 0., 20.;
+    v << 1.02, 1.01;
+    q << 0., 0.;
+    qmin << -1000., -1000.;
+    qmax << 1000., 1000.;
+    b << 0, GEN_BUS;
+    g.init_generators_full(p, v, q, std::vector<bool>{true, true}, qmin, qmax, b);
+    g.add_gen_slackbus(0, 1.);
+    return g;
+}
+
+const int NB_STEPS = 5;
+
+struct Inputs
+{
+    RealMatRM gen_p{NB_STEPS, NB_GEN};
+    RealMatRM sgen_p{NB_STEPS, 0};
+    RealMatRM load_p{NB_STEPS, 1};
+    RealMatRM load_q{NB_STEPS, 1};
+
+    Inputs()
+    {
+        for(int i = 0; i < NB_STEPS; ++i){
+            const real_type jitter = static_cast<real_type>((i * 37) % 11) / 10.;
+            gen_p(i, 0) = 0.;
+            gen_p(i, 1) = 10. + 15. * jitter;
+            load_p(i, 0) = 30. + 40. * jitter;
+            load_q(i, 0) = 5. + 10. * jitter;
+        }
+    }
+};
+
+// A loss with a genuine dependence on BOTH the angle and the magnitude of every bus
+// voltage: L = sum over rows and buses of (wr * Re V + wi * Im V). Deliberately not
+// |V|^2, whose angle cotangent is identically zero and would leave half of the ledger
+// untested. Its cotangent (torch's convention for a real loss of a complex tensor,
+// dL/dRe V + i dL/dIm V) is the constant wr + i wi.
+real_type loss_weight_re(int bus) { return 1. + 0.5 * bus; }
+real_type loss_weight_im(int bus) { return -0.75 + 0.25 * bus; }
+
+real_type loss_of(const Eigen::Ref<const Eigen::Matrix<cplx_type, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor> > & V)
+{
+    real_type res = 0.;
+    for(Eigen::Index i = 0; i < V.rows(); ++i){
+        for(Eigen::Index b = 0; b < V.cols(); ++b){
+            res += loss_weight_re(static_cast<int>(b)) * V(i, b).real() +
+                   loss_weight_im(static_cast<int>(b)) * V(i, b).imag();
+        }
+    }
+    return res;
+}
+
+real_type run_loss(const Inputs & in)
+{
+    LSGrid grid = make_grid();
+    InjectionSweep sweep(grid);
+    sweep.change_algorithm(AlgorithmType::NR_SparseLU);
+    const int status = sweep.compute_Vs(in.gen_p, in.sgen_p, in.load_p, in.load_q,
+                                        CplxVect::Constant(NB_BUS, cplx_type(1., 0.)), 30, 1e-11);
+    REQUIRE(status == 1);
+    return loss_of(sweep.get_voltages());
+}
+
+}  // namespace
+
+
+TEST_CASE("the adjoint of a sweep is the gradient a finite difference measures")
+{
+    LSGrid grid = make_grid();
+    InjectionSweep sweep(grid);
+    sweep.change_algorithm(AlgorithmType::NR_SparseLU);
+    sweep.set_keep_jacobian(true);
+    REQUIRE(sweep.get_keep_jacobian());
+
+    const Inputs in;
+    REQUIRE(sweep.compute_Vs(in.gen_p, in.sgen_p, in.load_p, in.load_q,
+                             CplxVect::Constant(NB_BUS, cplx_type(1., 0.)), 30, 1e-11) == 1);
+    REQUIRE(sweep.adjoint_memory_bytes() > 0);
+
+    const int dim_J = sweep.dim_J();
+    REQUIRE(dim_J > 0);
+    const IntVect theta_col = sweep.get_theta_col_of_bus();
+    const IntVect vm_col = sweep.get_vm_col_of_bus();
+    const IntVect p_row = sweep.get_p_row_of_bus();
+    const IntVect q_row = sweep.get_q_row_of_bus();
+    REQUIRE(theta_col.size() == NB_BUS);
+
+    // project the loss's cotangent onto the Newton-Raphson unknowns, bus by bus
+    const auto V = sweep.get_voltages();
+    RealMatRM xbar = RealMatRM::Zero(NB_STEPS, dim_J);
+    for(int i = 0; i < NB_STEPS; ++i){
+        for(int b = 0; b < NB_BUS; ++b){
+            const cplx_type gV(loss_weight_re(b), loss_weight_im(b));
+            const cplx_type v = V(i, b);
+            if(theta_col[b] >= 0) xbar(i, theta_col[b]) = (std::conj(v) * gV).imag();
+            if(vm_col[b] >= 0) xbar(i, vm_col[b]) = (std::conj(v / std::abs(v)) * gV).real();
+        }
+    }
+
+    const RealMatRM lambda = sweep.solve_JT(xbar);
+    REQUIRE(lambda.rows() == NB_STEPS);
+    REQUIRE(lambda.cols() == dim_J);
+    for(int i = 0; i < NB_STEPS; ++i) REQUIRE(sweep.adjoint_row_ok()[static_cast<size_t>(i)] == 1);
+
+    // lambda is the gradient with respect to the per-unit bus injection; an element's
+    // own gradient is that, times how it enters its bus (a load subtracts, a generator
+    // adds, both scaled by sn_mva)
+    REQUIRE(p_row[LOAD_BUS] >= 0);
+    REQUIRE(q_row[LOAD_BUS] >= 0);
+    REQUIRE(p_row[GEN_BUS] >= 0);
+
+    const real_type delta = 1e-4;   // MW / MVAr
+    for(int i = 0; i < NB_STEPS; ++i){
+        // ---- load P
+        {
+            Inputs plus = in, minus = in;
+            plus.load_p(i, 0) += delta;
+            minus.load_p(i, 0) -= delta;
+            const real_type fd = (run_loss(plus) - run_loss(minus)) / (2. * delta);
+            const real_type adjoint = -lambda(i, p_row[LOAD_BUS]) / SN_MVA;
+            REQUIRE(adjoint == Approx(fd).margin(1e-7));
+        }
+        // ---- load Q
+        {
+            Inputs plus = in, minus = in;
+            plus.load_q(i, 0) += delta;
+            minus.load_q(i, 0) -= delta;
+            const real_type fd = (run_loss(plus) - run_loss(minus)) / (2. * delta);
+            const real_type adjoint = -lambda(i, q_row[LOAD_BUS]) / SN_MVA;
+            REQUIRE(adjoint == Approx(fd).margin(1e-7));
+        }
+        // ---- generator P, at a PV bus (the other sign, and another corner of the ledger)
+        {
+            Inputs plus = in, minus = in;
+            plus.gen_p(i, 1) += delta;
+            minus.gen_p(i, 1) -= delta;
+            const real_type fd = (run_loss(plus) - run_loss(minus)) / (2. * delta);
+            const real_type adjoint = lambda(i, p_row[GEN_BUS]) / SN_MVA;
+            REQUIRE(adjoint == Approx(fd).margin(1e-7));
+        }
+    }
+}
+
+
+TEST_CASE("refreshing the Jacobian at the solution moves it off the last iterate")
+{
+    // Newton-Raphson tests its residual BEFORE deciding it needs a new Jacobian, so
+    // the J it stops on was built one iterate earlier. refresh_J_at_solution() is what
+    // re-evaluates it at the voltage actually returned -- the point the adjoint's
+    // gradient is exact at. The effect is of the order of the last Newton step, so a
+    // loose tolerance is what makes it visible: at the 1e-11 the gradient test above
+    // uses, the two Jacobians agree to well past its margin, which is precisely why
+    // that test cannot stand in for this one.
+    LSGrid grid = make_grid();
+    grid.change_algorithm(AlgorithmType::NR_SparseLU);
+    const CplxVect v_conv = grid.ac_pf(CplxVect::Constant(NB_BUS, cplx_type(1., 0.)), 30, 1e-8);
+    REQUIRE(v_conv.size() > 0);
+
+    ls2g::NR_SparseLU algo;
+    algo.set_lsgrid(&grid);
+    const Eigen::SparseMatrix<cplx_type> Ybus = grid.get_Ybus_solver();
+    const CplxVect Sbus = grid.get_Sbus_solver();
+    const IntVect pv = grid.get_pv_solver_numpy();
+    const IntVect pq = grid.get_pq_solver_numpy();
+    const IntVect slack_ids = grid.get_slack_ids_solver_numpy();
+    const RealVect slack_weights = grid.get_slack_weights_solver();
+
+    // a tolerance loose enough that the last step taken is not negligible
+    CplxVect V = CplxVect::Constant(Ybus.rows(), cplx_type(1., 0.));
+    REQUIRE(algo.compute_pf(Ybus, V, Sbus, slack_ids, slack_weights, pv, pq, 30, 1e-4));
+
+    const Eigen::SparseMatrix<real_type> J_last_iterate = algo.get_J();
+    algo.refresh_J_at_solution();
+    const Eigen::SparseMatrix<real_type> J_at_solution = algo.get_J();
+
+    // same pattern -- refreshing values is all it does, which is what lets the batch
+    // keep one symbolic factorization
+    REQUIRE(J_at_solution.rows() == J_last_iterate.rows());
+    REQUIRE(J_at_solution.nonZeros() == J_last_iterate.nonZeros());
+
+    real_type biggest_change = 0.;
+    for(Eigen::Index k = 0; k < J_last_iterate.nonZeros(); ++k){
+        biggest_change = std::max(biggest_change,
+                                  std::abs(J_at_solution.valuePtr()[k] - J_last_iterate.valuePtr()[k]));
+    }
+    REQUIRE(biggest_change > 1e-9);   // it really did re-evaluate
+
+    // ... and it is a function of the converged state alone: refreshing again changes
+    // nothing, so nothing here depends on how many times it is called
+    algo.refresh_J_at_solution();
+    const Eigen::SparseMatrix<real_type> J_again = algo.get_J();
+    for(Eigen::Index k = 0; k < J_again.nonZeros(); ++k){
+        REQUIRE(J_again.valuePtr()[k] == Approx(J_at_solution.valuePtr()[k]).margin(1e-14));
+    }
+}
+
+
+TEST_CASE("a sweep keeps no Jacobian unless it was asked to")
+{
+    LSGrid grid = make_grid();
+    InjectionSweep sweep(grid);
+    sweep.change_algorithm(AlgorithmType::NR_SparseLU);
+    const Inputs in;
+    REQUIRE(sweep.compute_Vs(in.gen_p, in.sgen_p, in.load_p, in.load_q,
+                             CplxVect::Constant(NB_BUS, cplx_type(1., 0.)), 30, 1e-11) == 1);
+
+    REQUIRE_FALSE(sweep.get_keep_jacobian());
+    REQUIRE(sweep.adjoint_memory_bytes() == 0);
+    REQUIRE_THROWS(sweep.solve_JT(RealMatRM::Zero(NB_STEPS, 1)));
+}
+
+
+TEST_CASE("a sweep refuses to keep a Jacobian no algorithm builds")
+{
+    LSGrid grid = make_grid();
+    InjectionSweep sweep(grid);
+    sweep.change_algorithm(AlgorithmType::DC_SparseLU);
+    sweep.set_keep_jacobian(true);
+
+    // through compute(), not the compute_Vs wrapper used everywhere else here: that
+    // one turns EVERY std::exception into its historical -1 return (see its body), so
+    // it would hide this error rather than report it
+    const Inputs in;
+    sweep.modify_gen_p(in.gen_p);
+    sweep.modify_sgen_p(in.sgen_p);
+    sweep.modify_load_p(in.load_p);
+    sweep.modify_load_q(in.load_q);
+    REQUIRE_THROWS(sweep.compute(CplxVect::Constant(NB_BUS, cplx_type(1., 0.)), 30, 1e-11));
+}

--- a/src/tests/test_batch_adjoint.cpp
+++ b/src/tests/test_batch_adjoint.cpp
@@ -18,6 +18,9 @@
 // the implicit-function sign were flipped, the ledger read backwards, or the Jacobian
 // captured one Newton iterate before the solution, this is what would say so.
 
+#include <algorithm>
+#include <cmath>
+#include <complex>
 #include <vector>
 
 #include <catch2/catch_approx.hpp>


### PR DESCRIPTION
| | added | removed |
|---|---|---|
| **C++ (src/core, src/bindings)** | +740 | -6 |
| **Tests** | +503 | -0 |
| **Docs + changelog** | +5 | -0 |
| **Build / other** | +1 | -0 |
| total | +1249 | -6 |

Second of four PRs towards `BatchCPUPowerFlow`, building on #199's `solve_transpose`. This one makes a batch differentiable in C++; the pytorch class and the flows come next, and the `gen_v` gradient after that. Nothing existing changes behaviour: `keep_jacobian` is off by default and the per-row hook is a no-op when it is.

## Why

For a scalar loss `L(V_1..V_n)`, the implicit function theorem gives the gradient with respect to **every** injection of **every** row from one transposed solve per row. λ does not depend on which input is being differentiated, so the cost is independent of how many inputs there are — and of how wide `V` is.

Two properties of this repository's batch algorithms are what make that cheap, and they are why this lives here rather than in a generic autodiff layer:

- **one sparsity pattern for the whole batch** — a row may change a bus's role, but only by rewriting values inside a pattern reserved up front. So one pattern is snapshotted and each row is just `nnz_J` reals.
- **KLU answers the transposed system out of the factorization of J itself** (#199). No transposed copy, no second symbolic analysis — the machinery a GPU library needs here collapses to a flag.

## What

**`BatchAdjoint`** (new, `src/core/batch_algorithm/`): one pattern, one `(nb_rows × nnz_J)` **row-major** value buffer sized **once** before the row loop — everything it needs is known by then, the row count is locked and the warm-up solve has built the ledger — and a threaded `solve_JT` giving each worker its own solver and working matrix. A row is one memcpy, one refactorize, one triangular solve. Row-major so a row is contiguous and workers never share a cache line except at their range boundaries. It knows nothing about powerflows: it is a batch of same-pattern linear systems.

`xbar` is `(nb_rows, k · dim_J)` — k cotangents laid end to end, the layout `klu_tsolve`'s `nrhs` wants. k = 1 for a scalar loss; more only for a full Jacobian, and they cost one triangular solve each rather than one factorization each.

**On the sweep**: `keep_jacobian`, `solve_JT(xbar)`, `adjoint_row_ok()`, `adjoint_memory_bytes()`, `dim_J()`, and the ledger maps **re-keyed onto grid bus ids** so callers never have to reconstruct the solver's internal labelling. All four instantiations get them.

**What is deliberately not stored** is the numeric factorization. `klu_refactor` overwrites its `klu_numeric` in place and there is no way to clone one, so keeping a factorization per row would mean a full `klu_factor` — more expensive than a refactor — per row in the *forward*. Backward therefore pays one refactorize + one transposed solve per row, and the two are timed apart in `adjoint_solver_stats()` so that trade can be revisited on measurements rather than on belief.

## Three things the maths needs that the sweep alone would get wrong

- **Newton-Raphson stops on the Jacobian of its previous iterate** (it tests the residual before deciding it needs a new one). The adjoint is exact only at the solution, and the error is of the order of the last Newton step — which is not what the tolerance bounds. `refresh_J_at_solution()` re-evaluates it where it belongs, for one Jacobian fill and no factorization.
- **A row's Jacobian is captured while that row's own state is still installed** — its Ybus edits, its masked buses, its PV pinning. Refreshing after the loop restored its resting state would describe a system the row never solved.
- **The multiplier of an identity-frozen equation is dropped** (a bus a contingency stranded, a bus still PV in this row). Such a row of J is a single 1, so it feeds no other equation and the rest of λ is unaffected — but reporting it would put a gradient on an injection the solution does not depend on.

## Drive-by fix

`KLUSolver.hpp`, `NICSLUSolver.hpp` and `CKTSOSolver.hpp` closed their namespace **outside** their include guard, so including one twice in a translation unit emitted a stray `}`. Latent until now because nothing included them after `Solvers.hpp` did; `BatchAdjoint.hpp` does.

## Tests

Two levels, because this can be wrong in two independent ways.

- **`BatchAdjoint` alone**, against a dense LU of each row's explicitly transposed matrix — which owes nothing to powerflows. Plus: same answer at 1 and 4 threads on a row count that divides neither; a row the batch never solved comes back zero and says so; identity-pinned multipliers dropped and nothing else touched; a foreign pattern refused; k = 3 cotangents costing 3 solves and 1 analysis.
- **End to end on a grid**, against a central finite difference of a scalar loss — which owes nothing to Jacobians. A flipped implicit-function sign, a ledger read backwards, or a Jacobian captured one iterate early would each show up here. Covers load P, load Q (a PQ bus) and generator P (a PV bus, the other sign). The loss is linear in Re/Im rather than `|V|²`, whose angle cotangent is identically zero and would leave half the ledger untested.
- **The refresh has its own test**, because the gradient test cannot stand in for it: at a loose tolerance the two Jacobians differ measurably (and refreshing twice changes nothing), while at the tolerance the gradient test uses they agree well past its margin — verified by making the hook a no-op, which fails this test and not that one.

## Verification

- C++ suite **287/287**, at the default standard and at a pinned C++14 build.
- Python batch suite, all four instantiations: `test_InjectionSweep` (15), `test_ScenarioSweep` (21), `test_ScenarioSweep_gen_contingency` (16), `test_TimeSerie` (2), `test_timeseries_sbus` (5), `test_SecurityAnlysis_cpp` (12), `test_ContingencyAnalysis_split` (14), `test_ContingencyAnalysis_limit_violations` (37) — **122 tests, all pass**, against grid2op installed from source.
- Extension built and exercised from Python end to end: the adjoint gradient matches a finite difference to 10 significant digits, with `nb_analyze = 1` and one refactorize per row after the first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013aKUfd8Vy1xkpvrvV3waod

---
_Generated by [Claude Code](https://claude.ai/code/session_013aKUfd8Vy1xkpvrvV3waod)_