### PR TITLE
differentiable: a batch of powerflows as a pytorch operation

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -156,6 +156,9 @@ TODO: a "combine mode" axis for ``ScenarioSweepCPP`` choosing between the curren
 
 [1.0.1] 2026-xx-yy
 --------------------
+- [ADDED] ``lightsim2grid.differentiable.BatchCPUPowerFlow``: a batch of powerflows as a
+  pytorch operation, differentiable with respect to the injections through the adjoint of
+  :func:`solve_JT`. ``pip install lightsim2grid[torch]``; torch stays optional.
 - [ADDED] ``keep_jacobian`` and ``solve_JT`` on the batch algorithms: the adjoint of a whole
   sweep, one transposed solve per row, which is what reverse-mode differentiation (a pytorch
   backward) needs. See ``BatchAdjoint``.

--- a/docs/differentiable.rst
+++ b/docs/differentiable.rst
@@ -1,0 +1,95 @@
+Differentiable powerflow (pytorch)
+===================================
+
+.. _differentiable:
+
+A batch of powerflows, differentiable with respect to its injections, as a
+pytorch operation: a loss computed on the results of thousands of AC powerflows
+can be back-propagated to the loads and generators that produced them.
+
+.. code-block:: python
+
+    import torch
+    from lightsim2grid.network import init_from_pandapower
+    from lightsim2grid.differentiable import BatchCPUPowerFlow
+
+    grid = init_from_pandapower(some_pandapower_net)
+    pf = BatchCPUPowerFlow.init_from_grid(grid, nb_thread=8)
+
+    load_p = torch.tensor(..., requires_grad=True)    # (n_scenarios, n_load), MW
+    V = pf(load_p=load_p)                             # complex (n_scenarios, n_bus)
+
+    loss = pf.compute_flows(V).i_or_a.relu().sum()    # eg an overload penalty
+    loss.backward()
+    load_p.grad                                       # (n_scenarios, n_load)
+
+``pytorch`` is **not** a dependency of lightsim2grid: this subpackage is the only
+thing that needs it, and it is never imported by ``import lightsim2grid``.
+Install it with ``pip install lightsim2grid[torch]``, or just ``pip install torch``.
+
+What is differentiable
+----------------------
+
+Inputs are ``(n_scenarios, n_elements)`` tensors; ``None`` means "the grid's own
+value, in every row". Row *i* is one independent scenario, with its own
+injections and its own set of disconnected elements.
+
+================== ===================================== ==================
+input              meaning                               gradient
+================== ===================================== ==================
+``load_p``         active load, MW                       yes
+``load_q``         reactive load, MVAr                   yes
+``gen_p``          generator active setpoint, MW         yes
+``sgen_p``         static generator active power, MW     yes
+``gen_v``          generator voltage setpoint, pu        not yet [#genv]_
+``line_status``    True = connected                      no (discrete)
+``trafo_status``   True = connected                      no (discrete)
+``gen_status``     True = connected                      no (discrete)
+================== ===================================== ==================
+
+.. [#genv] ``gen_v`` can be used as a fixed setpoint; a tensor that requires a
+   gradient is rejected rather than silently given none. Its gradient needs a
+   term the Jacobian does not store for a voltage-fixed bus.
+
+The statuses follow grid2op's convention (**True means connected**), and a row
+that trips a generator gets the whole treatment the C++ already implements: the
+lost MW go to the slack, the distributed slack is re-weighted without the
+machine, and a bus whose last voltage-regulating generator is gone becomes PQ
+for that row.
+
+Why it is not expensive
+-----------------------
+
+The gradient comes from the adjoint method (the implicit function theorem), not
+from differentiating the Newton-Raphson iterations. Each row costs **one
+transposed solve** on top of the forward -- and that cost does not depend on how
+many inputs are being differentiated, nor on how wide ``V`` is.
+
+Two things make it cheap here, both of them properties the batch algorithms
+already had:
+
+* every row of a batch shares one Jacobian **sparsity pattern**, so the whole
+  batch keeps one symbolic factorization;
+* KLU answers the transposed system out of the factorization of :math:`J`
+  itself (``klu_tsolve``), so no transposed matrix is ever built.
+
+The price is memory: the converged Jacobian of every row is kept, which is
+``n_scenarios * nnz(J)`` floats. On a large grid with a large batch that is
+gigabytes -- :func:`BatchCPUPowerFlow.adjoint_memory_bytes` reports it, and it
+is worth reading before scaling a batch up.
+
+Rows that fail
+--------------
+
+A row that did not converge, or that a contingency islanded, comes back as
+``NaN`` rather than as zeros -- zeros are a plausible-looking voltage, ``NaN`` is
+not -- and its gradient is zero. :func:`BatchCPUPowerFlow.converged` says which
+rows those are, so a loss can mask them out.
+
+Detailed documentation
+----------------------
+
+.. automodule:: lightsim2grid.differentiable
+    :members:
+    :autosummary:
+

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -63,6 +63,7 @@ This is a work in progress at the moment
    security_analysis
    scenario_sweep
    continuation_powerflow
+   differentiable
    cpp_library
    solver_plugin
    binary_serialization

--- a/lightsim2grid/differentiable/__init__.py
+++ b/lightsim2grid/differentiable/__init__.py
@@ -1,0 +1,20 @@
+# Copyright (c) 2020-2026, RTE (https://www.rte-france.com)
+# See AUTHORS.txt
+# This Source Code Form is subject to the terms of the Mozilla Public License, version 2.0.
+# If a copy of the Mozilla Public License, version 2.0 was not distributed with this file,
+# you can obtain one at http://mozilla.org/MPL/2.0/.
+# SPDX-License-Identifier: MPL-2.0
+# This file is part of LightSim2grid, LightSim2grid implements a c++ backend targeting the Grid2Op platform.
+
+"""Reverse-mode differentiation of a batch of powerflows, for pytorch.
+
+Not imported by ``lightsim2grid`` itself: torch is an optional dependency, so this
+subpackage is reached explicitly.
+
+    from lightsim2grid.differentiable import BatchCPUPowerFlow
+"""
+
+__all__ = ["BatchCPUPowerFlow", "BranchFlows", "compute_branch_flows"]
+
+from ._flows import BranchFlows, compute_branch_flows
+from ._batch_cpu_power_flow import BatchCPUPowerFlow

--- a/lightsim2grid/differentiable/_batch_cpu_power_flow.py
+++ b/lightsim2grid/differentiable/_batch_cpu_power_flow.py
@@ -1,0 +1,448 @@
+# Copyright (c) 2020-2026, RTE (https://www.rte-france.com)
+# See AUTHORS.txt
+# This Source Code Form is subject to the terms of the Mozilla Public License, version 2.0.
+# If a copy of the Mozilla Public License, version 2.0 was not distributed with this file,
+# you can obtain one at http://mozilla.org/MPL/2.0/.
+# SPDX-License-Identifier: MPL-2.0
+# This file is part of LightSim2grid, LightSim2grid implements a c++ backend targeting the Grid2Op platform.
+
+"""
+BatchCPUPowerFlow -- a batch of AC powerflows as a differentiable pytorch operation.
+
+    pf = BatchCPUPowerFlow.init_from_grid(grid)
+    V = pf(load_p=load_p, load_q=load_q, gen_p=gen_p)   # complex (n_scenarios, n_bus)
+    loss = pf.compute_flows(V).i_or_a.relu().sum()
+    loss.backward()                                     # load_p.grad, load_q.grad, ...
+
+Every input is a ``(n_scenarios, n_elements)`` tensor, or ``None`` for "the grid's
+own value in every row". Row ``i`` is one independent scenario: its own injections
+and its own set of disconnected elements. The whole batch is one
+:class:`ScenarioSweepCPP` call, so it pays one symbolic factorization and
+refactorizes per row.
+
+Differentiable: ``load_p``, ``load_q``, ``gen_p``, ``sgen_p``. Discrete and
+carrying no gradient: ``line_status``, ``trafo_status``, ``gen_status`` (booleans,
+True = connected, grid2op's convention). ``gen_v`` is accepted but is not
+differentiable yet -- passing one that requires a gradient raises rather than
+silently returning none for it.
+
+How the gradient is obtained
+----------------------------
+Each row solves ``G(x_i ; u_i) = 0`` and returns ``V_i``. The implicit function
+theorem gives the gradient of a scalar loss with respect to every injection from
+ONE transposed solve per row (see ``BatchAdjoint`` on the C++ side):
+
+    x̄_i     = the loss's cotangent on V, projected onto the row's unknowns
+    λ_i     = J_iᵀ⁻¹ x̄_i                      (keep_jacobian + solve_JT)
+    ∂L/∂Sbus_i = λ_i, read at each bus's P and Q equation
+
+and from the per-unit bus injection to an element is an affine map this class
+applies directly: a load subtracts from its bus, a generator adds to it, both
+scaled by ``sn_mva``. The element inputs are therefore the autograd leaves, and
+nothing about the assembly (a generator contingency re-weighting the distributed
+slack, a bus released from PV to PQ) has to be mirrored in python -- it stays in
+the C++ that the forward already runs.
+
+A row that did not converge -- it diverged, or a contingency islanded it -- comes
+back as NaN and gets a zero gradient; see :func:`converged`.
+"""
+
+import numpy as np
+
+from lightsim2grid.lightsim2grid_cpp import ScenarioSweepCPP
+from lightsim2grid.algorithm import AlgorithmType
+
+from ._flows import compute_branch_flows, BranchFlows
+
+__all__ = ["BatchCPUPowerFlow"]
+
+
+def _torch():
+    """Import torch on first use, with an error that says what to do.
+
+    Deliberately not imported at module scope: torch is an optional dependency of
+    lightsim2grid, and `import lightsim2grid` must not drag it in.
+    """
+    try:
+        import torch
+    except ImportError as exc:  # pragma: no cover - depends on the environment
+        raise ImportError(
+            "BatchCPUPowerFlow needs pytorch, which lightsim2grid does not require: "
+            "install it with `pip install torch`, or `pip install lightsim2grid[torch]`."
+        ) from exc
+    return torch
+
+
+class BatchCPUPowerFlow:
+    """A batch of AC powerflows, differentiable with respect to its injections.
+
+    Build it with :func:`init_from_grid`, then call it like a function (or use
+    :func:`forward`). See the module docstring.
+    """
+
+    def __init__(self, sweep, grid, *, handle_disconnected_grid=False,
+                 max_iter=10, tol=1e-8, v_init=None):
+        torch = _torch()
+        self._sweep = sweep
+        self._grid = grid
+        self._handle_disconnected_grid = bool(handle_disconnected_grid)
+        self.max_iter = int(max_iter)
+        self.tol = float(tol)
+
+        self.sn_mva = float(grid.get_sn_mva())
+        self.n_bus = int(grid.total_bus())
+        self._v_init = (np.ones(self.n_bus, dtype=complex) if v_init is None
+                        else np.asarray(v_init, dtype=complex).copy())
+        if self._v_init.shape != (self.n_bus,):
+            raise ValueError(f"`v_init` must have one entry per grid bus ({self.n_bus}), "
+                             f"got {self._v_init.shape}.")
+
+        # --- element -> bus, once. -1 marks an element the grid has disconnected;
+        # it contributes to no bus, so it can never carry a gradient.
+        self._load_bus = np.asarray(grid.get_loads().get_bus_id(), dtype=np.int64)
+        self._gen_bus = np.asarray(grid.get_generators().get_bus_id(), dtype=np.int64)
+        self._sgen_bus = np.asarray(grid.get_static_generators().get_bus_id(), dtype=np.int64)
+        self.n_load = self._load_bus.shape[0]
+        self.n_gen = self._gen_bus.shape[0]
+        self.n_sgen = self._sgen_bus.shape[0]
+
+        lines, trafos = grid.get_lines(), grid.get_trafos()
+        self.n_line = np.asarray(lines.get_bus_id_side_1()).shape[0]
+        self.n_trafo = np.asarray(trafos.get_bus_id_side_1()).shape[0]
+        self.n_branch = self.n_line + self.n_trafo
+
+        # --- branch data for compute_flows(), powerlines then transformers
+        def _cat(attr):
+            return np.concatenate([np.asarray(getattr(lines, attr)()),
+                                   np.asarray(getattr(trafos, attr)())])
+
+        branch_or = _cat("get_bus_id_side_1").astype(np.int64)
+        branch_ex = _cat("get_bus_id_side_2").astype(np.int64)
+        # a branch the grid itself has disconnected has no bus at one end: clamp the
+        # index so the gather is in range, and remember never to report a flow for it
+        self._branch_alive = (branch_or >= 0) & (branch_ex >= 0)
+        self._branch_or = torch.as_tensor(np.clip(branch_or, 0, None))
+        self._branch_ex = torch.as_tensor(np.clip(branch_ex, 0, None))
+        self._y_11 = torch.as_tensor(_cat("get_yac_eff_11"), dtype=torch.complex128)
+        self._y_12 = torch.as_tensor(_cat("get_yac_eff_12"), dtype=torch.complex128)
+        self._y_21 = torch.as_tensor(_cat("get_yac_eff_21"), dtype=torch.complex128)
+        self._y_22 = torch.as_tensor(_cat("get_yac_eff_22"), dtype=torch.complex128)
+        self._bus_vn_kv = torch.as_tensor(np.asarray(grid.get_bus_vn_kv()), dtype=torch.float64)
+
+        # --- call-to-call state (see _apply_status)
+        self._n_scen = None
+        self._line_off = None
+        self._trafo_off = None
+        self._gen_off = None
+        self._gen_v_set = False
+        self._last_connected = None      # (n_scen, n_branch) bool, for compute_flows
+        self._converged = None
+
+    # ------------------------------------------------------------------- build
+    @classmethod
+    def init_from_grid(cls, grid, *, nb_thread=1, handle_disconnected_grid=False,
+                       algorithm=None, max_iter=10, tol=1e-8, v_init=None,
+                       init_from_n_powerflow=False):
+        """Build from an :class:`LSGrid`.
+
+        The grid does not have to be solved first: every batch begins with its own
+        "n" warm-up powerflow. ``algorithm`` defaults to the fastest Newton-Raphson
+        the build has (KLU when it was compiled in); it must be one of the AC NR
+        family, since the adjoint is a solve against that Jacobian.
+        """
+        sweep = ScenarioSweepCPP(grid)
+        if algorithm is None:
+            available = sweep.available_default_algorithms()
+            algorithm = (AlgorithmType.NR_KLU if AlgorithmType.NR_KLU in available
+                         else AlgorithmType.NR_SparseLU)
+        sweep.change_algorithm(algorithm)
+        sweep.nb_thread = int(nb_thread)
+        sweep.init_from_n_powerflow = bool(init_from_n_powerflow)
+        if handle_disconnected_grid:
+            sweep.handle_disconnected_grid = True
+        sweep.keep_jacobian = True
+        return cls(sweep, grid, handle_disconnected_grid=handle_disconnected_grid,
+                   max_iter=max_iter, tol=tol, v_init=v_init)
+
+    # ----------------------------------------------------------------- forward
+    def __call__(self, *args, **kwargs):
+        return self.forward(*args, **kwargs)
+
+    def forward(self, load_p=None, load_q=None, gen_p=None, sgen_p=None, gen_v=None,
+                line_status=None, trafo_status=None, gen_status=None):
+        """Solve one scenario per row; returns complex ``V`` of shape
+        ``(n_scenarios, n_bus)`` in per unit, in grid bus numbering (the same
+        numbering the grid's own accessors use).
+
+        load_p, load_q : (n_scen, n_load) MW / MVAr        differentiable
+        gen_p          : (n_scen, n_gen)  MW               differentiable
+        sgen_p         : (n_scen, n_sgen) MW               differentiable
+        gen_v          : (n_scen, n_gen)  vm_pu            NOT differentiable yet
+        line_status    : (n_scen, n_line)  bool, True = connected
+        trafo_status   : (n_scen, n_trafo) bool, True = connected
+        gen_status     : (n_scen, n_gen)   bool, True = connected
+
+        ``None`` means "whatever the grid itself says", in every row. At least one
+        input must be given: it is what fixes the number of scenarios.
+        """
+        n_scen = self._infer_n_scen(load_p=load_p, load_q=load_q, gen_p=gen_p, sgen_p=sgen_p,
+                                    gen_v=gen_v, line_status=line_status,
+                                    trafo_status=trafo_status, gen_status=gen_status)
+
+        # The row count is locked by the first setter of a batch, so a different one
+        # means starting the batch over. So does dropping gen_v: unlike the three
+        # contingency masks, it has no "nothing set" value to send, so the only way to
+        # stop applying the previous call's set-points is to start again. clear() also
+        # drops settings the constructor made, hence _reconfigure.
+        if n_scen != self._n_scen or (gen_v is None and self._gen_v_set):
+            self._sweep.clear()
+            self._reconfigure()
+            self._line_off = self._trafo_off = self._gen_off = None
+            self._gen_v_set = False
+            self._n_scen = n_scen
+
+        load_p = self._as_input(load_p, self.n_load, n_scen, "load_p")
+        load_q = self._as_input(load_q, self.n_load, n_scen, "load_q")
+        gen_p = self._as_input(gen_p, self.n_gen, n_scen, "gen_p")
+        sgen_p = self._as_input(sgen_p, self.n_sgen, n_scen, "sgen_p")
+
+        if gen_v is not None:
+            gen_v = self._as_input(gen_v, self.n_gen, n_scen, "gen_v")
+            if gen_v.requires_grad:
+                raise NotImplementedError(
+                    "`gen_v` is not differentiable yet: its gradient needs the dS/dVm "
+                    "column the Jacobian does not store for a voltage-fixed bus. Pass "
+                    "`gen_v.detach()` to use it as a (fixed) set-point in the meantime.")
+
+        self._apply_status(line_status, trafo_status, gen_status, n_scen)
+        if gen_v is not None:
+            self._sweep.modify_gen_v(np.ascontiguousarray(gen_v.detach().numpy()))
+            self._gen_v_set = True
+
+        return _BatchCPUPowerFlowOp.apply(load_p, load_q, gen_p, sgen_p, self)
+
+    # ----------------------------------------------------------------- results
+    def converged(self):
+        """(n_scenarios,) bool: whether each row's powerflow converged. A row that
+        did not is NaN in ``V`` and gets a zero gradient."""
+        if self._converged is None:
+            raise RuntimeError("nothing has been computed yet: call this instance first.")
+        return self._converged.copy()
+
+    def compute_flows(self, V, connected=None):
+        """Branch flows from ``V``, differentiable -- powerlines then transformers.
+
+        Returns a :class:`BranchFlows`. By default a branch is taken as connected
+        where the last :func:`forward` had it connected; pass ``connected``
+        ``(n_scen, n_branch)`` to say otherwise.
+        """
+        torch = _torch()
+        if connected is None:
+            connected = self._last_connected
+            if connected is None:
+                connected = torch.ones((V.shape[0], self.n_branch), dtype=torch.bool)
+        connected = connected & torch.as_tensor(self._branch_alive).unsqueeze(0)
+        return compute_branch_flows(V, self._y_11, self._y_12, self._y_21, self._y_22,
+                                    self._branch_or, self._branch_ex, self._bus_vn_kv,
+                                    self.sn_mva, connected)
+
+    @property
+    def sweep(self):
+        """The underlying :class:`ScenarioSweepCPP` (escape hatch: timers, limit
+        violations, the adjoint's own linear-solver counters)."""
+        return self._sweep
+
+    def adjoint_memory_bytes(self):
+        """Bytes the kept Jacobians of the last call occupy. Grows as
+        ``n_scenarios * nnz(J)``: worth watching before scaling a batch up."""
+        return self._sweep.adjoint_memory_bytes()
+
+    # ----------------------------------------------------------------- helpers
+    def _reconfigure(self):
+        """Re-apply what ``clear()`` drops. ``keep_jacobian`` and ``nb_thread``
+        survive it; ``handle_disconnected_grid`` does not."""
+        if self._handle_disconnected_grid:
+            self._sweep.handle_disconnected_grid = True
+        self._sweep.keep_jacobian = True
+
+    @staticmethod
+    def _infer_n_scen(**inputs):
+        n = None
+        for name, value in inputs.items():
+            if value is None:
+                continue
+            shape = tuple(np.shape(value))
+            if len(shape) != 2:
+                raise ValueError(f"every input must be 2-D (n_scenarios, n_elements); "
+                                 f"'{name}' has shape {shape}.")
+            if n is None:
+                n = int(shape[0])
+            elif int(shape[0]) != n:
+                raise ValueError(f"all inputs must have the same number of scenarios; "
+                                 f"got {n} and {shape[0]} (for '{name}').")
+        if n is None:
+            raise ValueError(
+                "BatchCPUPowerFlow needs at least one input (load_p, load_q, gen_p, "
+                "sgen_p, gen_v, line_status, trafo_status or gen_status): it is what "
+                "fixes the number of scenarios.")
+        if n <= 0:
+            raise ValueError("the number of scenarios must be > 0.")
+        return n
+
+    def _as_input(self, x, n_cols, n_scen, name):
+        """Bring an input to a CPU float64 tensor of the expected shape, or leave it
+        None (which means "do not set this axis at all", so the C++ keeps the grid's
+        own value for every row)."""
+        torch = _torch()
+        if x is None:
+            return None
+        if not isinstance(x, torch.Tensor):
+            x = torch.as_tensor(np.asarray(x, dtype=np.float64))
+        if x.device.type != "cpu":
+            raise ValueError(f"'{name}' is on device '{x.device}': BatchCPUPowerFlow "
+                             "solves on the CPU, and moving a tensor here silently would "
+                             "hide that. Use gpusim2grid for a GPU batch, or pass "
+                             f"`{name}.cpu()`.")
+        x = x.to(dtype=torch.float64)
+        if tuple(x.shape) != (n_scen, n_cols):
+            raise ValueError(f"'{name}' must have shape ({n_scen}, {n_cols}), "
+                             f"got {tuple(x.shape)}.")
+        return x
+
+    def _as_status(self, x, n_cols, n_scen, name):
+        torch = _torch()
+        if x is None:
+            return None
+        if not isinstance(x, torch.Tensor):
+            x = torch.as_tensor(np.asarray(x, dtype=bool))
+        x = x.to(dtype=torch.bool, device="cpu")
+        if tuple(x.shape) != (n_scen, n_cols):
+            raise ValueError(f"'{name}' must have shape ({n_scen}, {n_cols}), "
+                             f"got {tuple(x.shape)}.")
+        return x
+
+    def _apply_status(self, line_status, trafo_status, gen_status, n_scen):
+        """Hand the three contingency masks to the sweep, and remember them.
+
+        A call that drops a mask the previous one had must say so explicitly -- an
+        all-False mask -- or the sweep would keep applying the old one. That is what
+        makes a call's result depend only on its own arguments.
+        """
+        torch = _torch()
+        line_status = self._as_status(line_status, self.n_line, n_scen, "line_status")
+        trafo_status = self._as_status(trafo_status, self.n_trafo, n_scen, "trafo_status")
+        gen_status = self._as_status(gen_status, self.n_gen, n_scen, "gen_status")
+
+        for name, status, n_cols, attr, setter in (
+                ("line", line_status, self.n_line, "_line_off", self._sweep.set_contingency_lines),
+                ("trafo", trafo_status, self.n_trafo, "_trafo_off", self._sweep.set_contingency_trafos),
+                ("gen", gen_status, self.n_gen, "_gen_off", self._sweep.set_contingency_gens)):
+            if status is not None:
+                off = np.ascontiguousarray(~status.numpy())
+            elif getattr(self, attr) is not None:
+                off = np.zeros((n_scen, n_cols), dtype=bool)   # explicitly: nothing tripped
+            else:
+                off = None                                      # never set, nothing to undo
+            if off is not None:
+                setter(off)
+            setattr(self, attr, off)
+
+        # what compute_flows() takes as "this branch carries something"
+        off_branch = []
+        for off, n_cols in ((self._line_off, self.n_line), (self._trafo_off, self.n_trafo)):
+            off_branch.append(np.zeros((n_scen, n_cols), dtype=bool) if off is None else off)
+        self._last_connected = ~torch.as_tensor(np.concatenate(off_branch, axis=1))
+
+
+class _BatchCPUPowerFlowOp:
+    """Built lazily: torch.autograd.Function must be subclassed, and torch may not
+    be importable at import time. See :func:`apply`."""
+
+    _impl = None
+
+    @classmethod
+    def apply(cls, load_p, load_q, gen_p, sgen_p, pf):
+        if cls._impl is None:
+            cls._impl = _make_op(_torch())
+        return cls._impl.apply(load_p, load_q, gen_p, sgen_p, pf)
+
+
+def _make_op(torch):
+    class _Op(torch.autograd.Function):
+        @staticmethod
+        def forward(ctx, load_p, load_q, gen_p, sgen_p, pf):
+            sweep = pf._sweep
+            for tensor, setter in ((load_p, sweep.modify_load_p),
+                                   (load_q, sweep.modify_load_q),
+                                   (gen_p, sweep.modify_gen_p),
+                                   (sgen_p, sweep.modify_sgen_p)):
+                if tensor is not None:
+                    setter(np.ascontiguousarray(tensor.detach().numpy()))
+
+            sweep.compute(pf._v_init, pf.max_iter, pf.tol)
+
+            converged = np.asarray(sweep.converged_mask(), dtype=bool)
+            pf._converged = converged
+            V = torch.as_tensor(np.array(sweep.get_voltages()))
+            # a row that was never solved holds zeros, which is indistinguishable from
+            # a genuine result: NaN says "there is nothing here" out loud, and
+            # propagates into any loss that forgets to mask it
+            V[~torch.as_tensor(converged)] = float("nan")
+
+            ctx.pf = pf
+            ctx.needs = tuple(t is not None for t in (load_p, load_q, gen_p, sgen_p))
+            ctx.save_for_backward(V)
+            return V
+
+        @staticmethod
+        def backward(ctx, grad_V):
+            pf = ctx.pf
+            sweep = pf._sweep
+            V, = ctx.saved_tensors
+            n_scen, n_bus = V.shape
+            dim_J = sweep.dim_J()
+
+            theta_col = np.asarray(sweep.get_theta_col_of_bus())
+            vm_col = np.asarray(sweep.get_vm_col_of_bus())
+            p_row = np.asarray(sweep.get_p_row_of_bus())
+            q_row = np.asarray(sweep.get_q_row_of_bus())
+
+            # NaN rows (never solved) carry no cotangent, and must not put a NaN into
+            # the system either
+            finite = torch.isfinite(V.real) & torch.isfinite(V.imag)
+            gV = torch.where(finite, grad_V, torch.zeros_like(grad_V))
+            Vs = torch.where(finite, V, torch.ones_like(V))
+
+            # project the loss's sensitivity to V onto the Newton-Raphson unknowns:
+            # an angle unknown takes Im(conj(V) . gV), a magnitude one
+            # Re(conj(V/|V|) . gV) -- the two halves of dL/dV in polar coordinates
+            xbar = torch.zeros(n_scen, dim_J, dtype=torch.float64)
+            th_bus = np.flatnonzero(theta_col >= 0)
+            vm_bus = np.flatnonzero(vm_col >= 0)
+            if th_bus.size:
+                xbar[:, torch.as_tensor(theta_col[th_bus])] = \
+                    (torch.conj(Vs[:, th_bus]) * gV[:, th_bus]).imag
+            if vm_bus.size:
+                v_hat = Vs[:, vm_bus] / Vs[:, vm_bus].abs()
+                xbar[:, torch.as_tensor(vm_col[vm_bus])] = (torch.conj(v_hat) * gV[:, vm_bus]).real
+
+            lam = torch.as_tensor(sweep.solve_JT(np.ascontiguousarray(xbar.numpy())))
+
+            # lambda is the gradient with respect to the per-unit bus injection; an
+            # element's own is that, times how it enters its bus
+            def element_grad(bus_of_element, row_of_bus, sign):
+                grad = torch.zeros(n_scen, bus_of_element.shape[0], dtype=torch.float64)
+                rows = np.where(bus_of_element >= 0, row_of_bus[np.clip(bus_of_element, 0, None)], -1)
+                sel = np.flatnonzero(rows >= 0)   # an element off the grid, or on a bus
+                if sel.size:                      # with no such equation, keeps its zero
+                    grad[:, torch.as_tensor(sel)] = sign * lam[:, torch.as_tensor(rows[sel])] / pf.sn_mva
+                return grad
+
+            wants_lp, wants_lq, wants_gp, wants_sp = ctx.needs
+            grad_load_p = element_grad(pf._load_bus, p_row, -1.) if wants_lp else None
+            grad_load_q = element_grad(pf._load_bus, q_row, -1.) if wants_lq else None
+            grad_gen_p = element_grad(pf._gen_bus, p_row, +1.) if wants_gp else None
+            grad_sgen_p = element_grad(pf._sgen_bus, p_row, +1.) if wants_sp else None
+            return grad_load_p, grad_load_q, grad_gen_p, grad_sgen_p, None
+
+    return _Op

--- a/lightsim2grid/differentiable/_flows.py
+++ b/lightsim2grid/differentiable/_flows.py
@@ -1,0 +1,80 @@
+# Copyright (c) 2020-2026, RTE (https://www.rte-france.com)
+# See AUTHORS.txt
+# This Source Code Form is subject to the terms of the Mozilla Public License, version 2.0.
+# If a copy of the Mozilla Public License, version 2.0 was not distributed with this file,
+# you can obtain one at http://mozilla.org/MPL/2.0/.
+# SPDX-License-Identifier: MPL-2.0
+# This file is part of LightSim2grid, LightSim2grid implements a c++ backend targeting the Grid2Op platform.
+
+"""Branch flows from the bus voltages, in pure torch.
+
+The batch algorithms already compute flows in C++ (``compute_flows`` /
+``compute_power_flows``), but those read the voltages the solver stored and
+return numbers: nothing differentiates through them. The functions here are the
+same formulas written as torch operations, so a loss on a current -- an overload
+penalty, the usual reason to differentiate a powerflow at all -- reaches the
+injections through :class:`BatchCPUPowerFlow`'s backward.
+
+They are kept deliberately equal, coefficient for coefficient, to what
+``BaseBatchSolverSynch::_flows_of_row`` does, and a test pins that agreement
+against the C++ on the same voltages.
+"""
+
+from collections import namedtuple
+
+__all__ = ["BranchFlows", "compute_branch_flows"]
+
+
+#: what :func:`compute_branch_flows` returns, all of shape ``(n_scenarios, n_branch)``
+#: with the powerlines first and the transformers after, in grid order. "or" / "ex"
+#: are grid2op's names for the two ends: the origin side (side 1, the high voltage
+#: side of a transformer) and the extremity side.
+BranchFlows = namedtuple("BranchFlows",
+                         ["p_or_mw", "q_or_mvar", "p_ex_mw", "q_ex_mvar", "i_or_a", "i_ex_a"])
+
+
+def _one_side(v_here, v_there, y_here, y_there, vn_kv_here, sn_mva, connected):
+    """Flows measured at one end of a branch: ``S = V . conj(y_here V + y_there V')``.
+
+    ``connected`` is the boolean "this branch carries something in this scenario";
+    where it is False the end reads exactly zero, which is what the C++ does by
+    zeroing the voltage of an open side rather than by masking afterwards.
+    """
+    import torch
+
+    current = y_here * v_here + y_there * v_there           # per unit
+    s = v_here * torch.conj(current)                        # per unit
+    zero = torch.zeros((), dtype=s.real.dtype)
+    p_mw = torch.where(connected, s.real * sn_mva, zero)
+    q_mvar = torch.where(connected, s.imag * sn_mva, zero)
+
+    # |S| / (sqrt(3) . |V| . vn_kv) in kA, then A. The magnitude of the voltage at
+    # the measuring end is the base; a disconnected end would put 0 there, hence the
+    # guard -- the numerator is zero there anyway, and this only avoids the 0/0.
+    v_kv = v_here.abs() * vn_kv_here
+    v_kv = torch.where(connected & (v_kv > 0.), v_kv, torch.ones((), dtype=v_kv.dtype))
+    i_a = torch.where(connected, 1000. * s.abs() * sn_mva / ((3. ** 0.5) * v_kv), zero)
+    return p_mw, q_mvar, i_a
+
+
+def compute_branch_flows(V, y_11, y_12, y_21, y_22, bus_or, bus_ex,
+                         bus_vn_kv, sn_mva, connected=None):
+    """Flows at both ends of every branch, differentiable with respect to ``V``.
+
+    V : complex ``(n_scenarios, n_bus)``, per unit, in GRID bus numbering
+    y_* : complex ``(n_branch,)``, the branch's Kron-reduced admittances
+    bus_or / bus_ex : int ``(n_branch,)``, the grid bus at each end
+    bus_vn_kv : real ``(n_bus,)``, nominal voltage of each bus
+    connected : bool ``(n_scenarios, n_branch)`` or None (everything connected)
+    """
+    import torch
+
+    v_or = V[:, bus_or]
+    v_ex = V[:, bus_ex]
+    if connected is None:
+        connected = torch.ones(v_or.shape, dtype=torch.bool)
+
+    p_or, q_or, i_or = _one_side(v_or, v_ex, y_11, y_12, bus_vn_kv[bus_or], sn_mva, connected)
+    p_ex, q_ex, i_ex = _one_side(v_ex, v_or, y_22, y_21, bus_vn_kv[bus_ex], sn_mva, connected)
+    return BranchFlows(p_or_mw=p_or, q_or_mvar=q_or, p_ex_mw=p_ex, q_ex_mvar=q_ex,
+                       i_or_a=i_or, i_ex_a=i_ex)

--- a/lightsim2grid/tests/test_BatchCPUPowerFlow.py
+++ b/lightsim2grid/tests/test_BatchCPUPowerFlow.py
@@ -1,0 +1,273 @@
+# Copyright (c) 2020-2026, RTE (https://www.rte-france.com)
+# See AUTHORS.txt
+# This Source Code Form is subject to the terms of the Mozilla Public License, version 2.0.
+# If a copy of the Mozilla Public License, version 2.0 was not distributed with this file,
+# you can obtain one at http://mozilla.org/MPL/2.0/.
+# SPDX-License-Identifier: MPL-2.0
+# This file is part of LightSim2grid, LightSim2grid implements a c++ backend targeting the Grid2Op platform.
+
+"""BatchCPUPowerFlow: the batch adjoint, as pytorch sees it.
+
+The reference for a gradient here is always a central finite difference of the
+same quantity, computed by re-running the batch -- something that knows nothing
+about Jacobians, ledgers or adjoint signs. Where the gradient flows through
+compute_flows(), the flows themselves are checked against the C++ ones on the
+same voltages first, so a failure can be told apart from a failure of the
+formulas they go through.
+"""
+
+import subprocess
+import sys
+import unittest
+import warnings
+
+import numpy as np
+
+try:
+    import torch
+    TORCH_AVAILABLE = True
+except ImportError:
+    TORCH_AVAILABLE = False
+
+try:
+    import pandapower.networks as pn
+    from lightsim2grid.network import init_from_pandapower
+    PP_AVAILABLE = True
+except ImportError:
+    PP_AVAILABLE = False
+
+
+@unittest.skipUnless(TORCH_AVAILABLE and PP_AVAILABLE, "needs pytorch and pandapower")
+class TestBatchCPUPowerFlow(unittest.TestCase):
+    N_SCEN = 4
+    TOL = 1e-12
+
+    def setUp(self):
+        from lightsim2grid.differentiable import BatchCPUPowerFlow
+        self._cls = BatchCPUPowerFlow
+        warnings.filterwarnings("ignore")
+        self.pf = self._make()
+        rng = np.random.default_rng(0)
+        base_lp = np.asarray(self.pf._grid.get_load_target_p())
+        base_gp = np.asarray(self.pf._grid.get_gen_target_p())
+        self.load_p = base_lp[None, :] * (1. + 0.15 * rng.standard_normal((self.N_SCEN, self.pf.n_load)))
+        self.load_q = 0.2 * self.load_p
+        self.gen_p = base_gp[None, :] * (1. + 0.05 * rng.standard_normal((self.N_SCEN, self.pf.n_gen)))
+
+    def _make(self, **kwargs):
+        grid = init_from_pandapower(pn.case14())
+        return self._cls.init_from_grid(grid, tol=self.TOL, **kwargs)
+
+    # the loss every gradient below is taken of: linear in Re/Im so that BOTH the
+    # angle and the magnitude of every bus carry a cotangent (|V|^2 would leave the
+    # angle half of the ledger untested), and bounded away from any kink
+    @staticmethod
+    def _loss(V):
+        n_bus = V.shape[1]
+        wr = torch.as_tensor(1. + 0.5 * np.arange(n_bus))
+        wi = torch.as_tensor(-0.75 + 0.25 * np.arange(n_bus))
+        return (wr * V.real + wi * V.imag).sum()
+
+    def _run(self, pf=None, **inputs):
+        pf = pf if pf is not None else self._make()
+        tensors = {k: torch.tensor(v) if v is not None else None for k, v in inputs.items()}
+        return pf, tensors, pf(**tensors)
+
+    def _fd(self, name, idx, delta=1e-4, loss=None, **inputs):
+        """Central finite difference of the loss with respect to one input entry,
+        each evaluation on its own batch."""
+        loss = loss if loss is not None else (lambda pf, V: self._loss(V))
+        out = []
+        for sign in (+1., -1.):
+            perturbed = {k: (v.copy() if v is not None else None) for k, v in inputs.items()}
+            perturbed[name][idx] += sign * delta
+            pf, _, V = self._run(**perturbed)
+            out.append(float(loss(pf, V)))
+        return (out[0] - out[1]) / (2. * delta)
+
+    # ------------------------------------------------------------------ gradient
+    def test_gradient_of_every_differentiable_input(self):
+        inputs = dict(load_p=self.load_p, load_q=self.load_q, gen_p=self.gen_p)
+        pf, tensors, V = self._run(pf=self.pf, **inputs)
+        for t in tensors.values():
+            t.requires_grad_(True)
+        V = pf(**tensors)
+        self.assertTrue(pf.converged().all())
+        self._loss(V).backward()
+
+        for name in ("load_p", "load_q", "gen_p"):
+            grad = tensors[name].grad
+            self.assertIsNotNone(grad, name)
+            for idx in ((0, 0), (2, 1), (self.N_SCEN - 1, grad.shape[1] - 1)):
+                fd = self._fd(name, idx, **inputs)
+                self.assertAlmostEqual(
+                    grad[idx].item(), fd, places=6,
+                    msg=f"{name}{idx}: adjoint {grad[idx].item()} vs finite difference {fd}")
+
+    def test_gradcheck(self):
+        load_p = torch.tensor(self.load_p[:2], requires_grad=True)
+        pf = self._make()
+        self.assertTrue(torch.autograd.gradcheck(
+            lambda lp: self._loss(pf(load_p=lp)), (load_p,), eps=1e-6, atol=1e-5))
+
+    def test_gradient_flows_through_the_currents(self):
+        load_p = torch.tensor(self.load_p, requires_grad=True)
+        pf = self._make()
+        loss = pf.compute_flows(pf(load_p=load_p)).i_or_a.sum()
+        loss.backward()
+        fd = self._fd("load_p", (1, 2), load_p=self.load_p,
+                      loss=lambda pf_, V: pf_.compute_flows(V).i_or_a.sum())
+        self.assertAlmostEqual(load_p.grad[1, 2].item(), fd, places=4)
+
+    # ------------------------------------------------------------------ the flows
+    def test_flows_agree_with_the_cpp_ones(self):
+        pf, _, V = self._run(load_p=self.load_p, load_q=self.load_q)
+        flows = pf.compute_flows(V)
+        np.testing.assert_allclose(flows.p_or_mw.detach().numpy(),
+                                   pf.sweep.compute_power_flows(), rtol=1e-9, atol=1e-9)
+        np.testing.assert_allclose(flows.i_or_a.detach().numpy(),
+                                   1000. * np.asarray(pf.sweep.compute_flows()),
+                                   rtol=1e-9, atol=1e-9)
+
+    # --------------------------------------------------------------- contingencies
+    def test_gradient_with_a_line_contingency(self):
+        line_status = np.ones((self.N_SCEN, self.pf.n_line), dtype=bool)
+        line_status[:, 3] = False
+        line_status[1, 5] = False
+        inputs = dict(load_p=self.load_p, line_status=line_status)
+
+        load_p = torch.tensor(self.load_p, requires_grad=True)
+        pf = self._make()
+        V = pf(load_p=load_p, line_status=torch.as_tensor(line_status))
+        self.assertTrue(pf.converged().all())
+        self._loss(V).backward()
+        for idx in ((0, 0), (1, 4)):
+            fd = self._fd("load_p", idx, **inputs)
+            self.assertAlmostEqual(load_p.grad[idx].item(), fd, places=6)
+
+    def test_gradient_with_a_generator_contingency(self):
+        gen_status = np.ones((self.N_SCEN, self.pf.n_gen), dtype=bool)
+        gen_status[2, 3] = False
+        inputs = dict(load_p=self.load_p, gen_status=gen_status)
+
+        load_p = torch.tensor(self.load_p, requires_grad=True)
+        pf = self._make()
+        V = pf(load_p=load_p, gen_status=torch.as_tensor(gen_status))
+        self.assertTrue(pf.converged().all())
+        self._loss(V).backward()
+        for idx in ((2, 0), (0, 1)):
+            fd = self._fd("load_p", idx, **inputs)
+            self.assertAlmostEqual(load_p.grad[idx].item(), fd, places=6)
+
+    def test_a_call_does_not_depend_on_the_previous_one(self):
+        """A mask set by one call must not leak into the next: the same arguments
+        always give the same answer, whatever ran before."""
+        line_status = np.ones((self.N_SCEN, self.pf.n_line), dtype=bool)
+        line_status[:, 3] = False
+
+        pf = self._make()
+        pf(load_p=torch.tensor(self.load_p), line_status=torch.as_tensor(line_status))
+        after_mask = pf(load_p=torch.tensor(self.load_p))          # no mask this time
+
+        _, _, fresh = self._run(load_p=self.load_p)
+        np.testing.assert_allclose(after_mask.detach().numpy(), fresh.detach().numpy(),
+                                   rtol=1e-10, atol=1e-10)
+
+        # ... and the other way round: a masked call after an unmasked one
+        pf2 = self._make()
+        pf2(load_p=torch.tensor(self.load_p))
+        after_plain = pf2(load_p=torch.tensor(self.load_p), line_status=torch.as_tensor(line_status))
+        _, _, fresh_masked = self._run(load_p=self.load_p, line_status=line_status)
+        np.testing.assert_allclose(after_plain.detach().numpy(), fresh_masked.detach().numpy(),
+                                   rtol=1e-10, atol=1e-10)
+
+    def test_the_number_of_scenarios_can_change(self):
+        pf = self._make()
+        pf(load_p=torch.tensor(self.load_p))
+        V2 = pf(load_p=torch.tensor(self.load_p[:2]))
+        self.assertEqual(V2.shape[0], 2)
+        _, _, fresh = self._run(load_p=self.load_p[:2])
+        np.testing.assert_allclose(V2.detach().numpy(), fresh.detach().numpy(),
+                                   rtol=1e-10, atol=1e-10)
+
+    # -------------------------------------------------------------- failing rows
+    def test_a_row_that_does_not_converge_is_nan_and_has_no_gradient(self):
+        load_p = self.load_p.copy()
+        load_p[1, :] = 1e6      # far outside anything solvable
+        tensor = torch.tensor(load_p, requires_grad=True)
+        pf = self._make()
+        V = pf(load_p=tensor)
+
+        converged = pf.converged()
+        self.assertFalse(converged[1])
+        self.assertTrue(torch.isnan(V[1]).all())
+        self.assertFalse(torch.isnan(V[converged]).any())
+
+        self._loss(torch.where(torch.isnan(V), torch.zeros_like(V), V)).backward()
+        np.testing.assert_array_equal(tensor.grad[1].numpy(), np.zeros(pf.n_load))
+        self.assertGreater(np.abs(tensor.grad[0].numpy()).max(), 0.)
+
+    # ------------------------------------------------------------------ threading
+    def test_threads_do_not_change_the_answer(self):
+        big_p = np.repeat(self.load_p, 5, axis=0)
+        _, _, v1 = self._run(pf=self._make(nb_thread=1), load_p=big_p)
+        pf4 = self._make(nb_thread=4)
+        lp = torch.tensor(big_p, requires_grad=True)
+        v4 = pf4(load_p=lp)
+        np.testing.assert_allclose(v4.detach().numpy(), v1.detach().numpy(), rtol=1e-12, atol=1e-12)
+
+        lp1 = torch.tensor(big_p, requires_grad=True)
+        self._loss(self._make(nb_thread=1)(load_p=lp1)).backward()
+        self._loss(v4).backward()
+        np.testing.assert_allclose(lp.grad.numpy(), lp1.grad.numpy(), rtol=1e-10, atol=1e-10)
+
+    # --------------------------------------------------------------------- errors
+    def test_rejects_inputs_that_do_not_line_up(self):
+        pf = self._make()
+        with self.assertRaises(ValueError):
+            pf()                                             # nothing to size the batch by
+        with self.assertRaises(ValueError):
+            pf(load_p=torch.zeros(self.N_SCEN))              # not 2-D
+        with self.assertRaises(ValueError):
+            pf(load_p=torch.zeros(self.N_SCEN, self.pf.n_load + 1))
+        with self.assertRaises(ValueError):
+            pf(load_p=torch.zeros(3, self.pf.n_load), load_q=torch.zeros(4, self.pf.n_load))
+
+    def test_a_gen_v_does_not_leak_into_the_next_call(self):
+        """gen_v has no "nothing set" value to send back, so dropping it has to start
+        the batch over -- otherwise the previous call's set-points stay applied."""
+        pf = self._make()
+        gen_v = np.full((self.N_SCEN, self.pf.n_gen), 1.06)
+        pf(load_p=torch.tensor(self.load_p), gen_v=torch.tensor(gen_v))
+        after = pf(load_p=torch.tensor(self.load_p))
+
+        _, _, fresh = self._run(load_p=self.load_p)
+        np.testing.assert_allclose(after.detach().numpy(), fresh.detach().numpy(),
+                                   rtol=1e-10, atol=1e-10)
+
+    def test_gen_v_is_usable_but_not_yet_differentiable(self):
+        pf = self._make()
+        gen_v = np.full((self.N_SCEN, self.pf.n_gen), 1.02)
+        V = pf(load_p=torch.tensor(self.load_p), gen_v=torch.tensor(gen_v))
+        self.assertTrue(pf.converged().all())
+        with self.assertRaises(NotImplementedError):
+            pf(load_p=torch.tensor(self.load_p),
+               gen_v=torch.tensor(gen_v, requires_grad=True))
+
+
+class TestTorchStaysOptional(unittest.TestCase):
+    """torch is an optional dependency, and the only thing that may break if it is
+    missing is actually building a BatchCPUPowerFlow -- not importing lightsim2grid,
+    and not importing the subpackage either."""
+
+    def test_importing_lightsim2grid_does_not_import_torch(self):
+        script = ("import sys, lightsim2grid, lightsim2grid.differentiable;"
+                  "sys.exit(1 if 'torch' in sys.modules else 0)")
+        completed = subprocess.run([sys.executable, "-c", script], capture_output=True)
+        self.assertEqual(completed.returncode, 0,
+                         "importing lightsim2grid (or its differentiable subpackage) pulled "
+                         "torch in; it must stay lazy, see _batch_cpu_power_flow._torch")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,9 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
+torch = [
+    "torch",
+]
 matpower = [
     "scipy",
     "matpowercaseframes",


### PR DESCRIPTION
| | added | removed |
|---|---|---|
| **Python (package)** | +548 | -0 |
| **Tests** | +273 | -0 |
| **Docs + changelog** | +99 | -0 |
| **Build / other** | +3 | -0 |
| total | +923 | -0 |

Third of the series, on top of #199 (`solve_transpose`) and #200 (`BatchAdjoint`). This one is the layer an ML user actually touches; no C++ changes at all.

```python
pf = BatchCPUPowerFlow.init_from_grid(grid, nb_thread=8)
V = pf(load_p=load_p, line_status=status)          # complex (n_scenarios, n_bus)
pf.compute_flows(V).i_or_a.relu().sum().backward() # -> load_p.grad
```

`load_p`, `load_q`, `gen_p`, `sgen_p` carry gradients. `line_status` / `trafo_status` / `gen_status` are discrete (True = connected, grid2op's convention). `gen_v` is accepted as a fixed set-point.

## The one design choice worth reviewing

The injections reach the solver through the sweep's **own `modify_*` setters**, not as an assembled Sbus, and the element tensors are the autograd leaves. That is what keeps this layer thin: everything that makes the assembly subtle — a generator contingency re-weighting the distributed slack, a bus released from PV to PQ when its last regulating machine goes — stays in the C++ the forward already runs. Backward only undoes the last, affine step from a per-unit bus injection back to the elements on it (a load subtracts, a generator adds, both over `sn_mva`).

## Three things this layer owes the caller beyond calling C++

- **A row that did not converge is NaN, not zeros.** Zeros are a plausible-looking voltage and would quietly poison a loss; `converged()` says which rows they are.
- **A call's result depends only on its own arguments.** The sweep keeps whatever masks it was last given, so a call that drops one says so explicitly (an all-false mask), and dropping `gen_v` — which has no "nothing set" value to send — restarts the batch instead. Both directions are tested.
- **`gen_v` is rejected if it requires a gradient** rather than silently getting none: that term needs the dS/dVm column the Jacobian does not store for a voltage-fixed bus. It is the next PR.

`compute_flows` is `BaseBatchSolverSynch::_flows_of_row`'s formulas written in torch, so a loss on a current — an overload penalty, the usual reason to want any of this — reaches the injections.

torch stays **optional**: imported on first use, never at module scope, and a test pins that importing lightsim2grid (or this subpackage) does not pull it in.

## Tests

14, all against references that owe nothing to the thing under test.

- Every gradient is checked against a **central finite difference of the same loss**, re-running the batch: the plain case, one through the currents, one with lines tripped, one with a generator tripped, plus `gradcheck`.
- The torch flows are pinned against the **C++ flows on the same voltages**, so a wrong flow cannot masquerade as a wrong gradient.
- Plus: diverging rows (NaN, zero gradient), threads not changing the answer, the scenario count changing between calls, both call-to-call independence cases, and the input-validation errors.

The loss is linear in Re/Im rather than `|V|²`, whose angle cotangent is identically zero and would leave half the ledger untested.

**Mutation-checked**: flipping the `load_p` gradient sign fails 5 tests; removing the stale-mask reset fails exactly the independence test; removing the `gen_v` restart fails exactly its own test.

## Verification

- The 14 new tests pass, against torch 2.14 and grid2op installed from source.
- `test_ScenarioSweep` (21) and `test_InjectionSweep` (15) still pass — this PR is purely additive.

One caveat: the new tests use pandapower's case14 as their fixture and skip without pandapower. CI has it, but any job that doesn't will silently skip the whole file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013aKUfd8Vy1xkpvrvV3waod

---
_Generated by [Claude Code](https://claude.ai/code/session_013aKUfd8Vy1xkpvrvV3waod)_